### PR TITLE
[perf] preparse some internal GDEF fields

### DIFF
--- a/benches/Cargo.lock
+++ b/benches/Cargo.lock
@@ -91,10 +91,6 @@ dependencies = [
  "read-fonts",
  "smallvec",
  "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
 ]
 
 [[package]]
@@ -177,31 +173,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
-
-[[package]]
-name = "unicode-script"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"

--- a/src/hb/ot/gpos/mod.rs
+++ b/src/hb/ot/gpos/mod.rs
@@ -21,14 +21,7 @@ struct Value<'a> {
 
 impl Value<'_> {
     fn is_empty(&self) -> bool {
-        self.record.x_placement.is_none()
-            && self.record.y_placement.is_none()
-            && self.record.x_advance.is_none()
-            && self.record.y_advance.is_none()
-            && self.record.x_placement_device.get().is_null()
-            && self.record.y_placement_device.get().is_null()
-            && self.record.x_advance_device.get().is_null()
-            && self.record.y_advance_device.get().is_null()
+        self.record.format.is_empty()
     }
 
     fn apply(&self, ctx: &mut hb_ot_apply_context_t, idx: usize) -> bool {


### PR DESCRIPTION
Also check format bits instead of checking every field for ValueRecord emptiness test.

Some nice wins:

Bench before:
```
running 232 tests
test arabic::paragraph_long::cold_hb       ... bench:     237,518.12 ns/iter (+/- 7,758.91)
test arabic::paragraph_long::cold_hr       ... bench:     287,589.38 ns/iter (+/- 7,830.88)
test arabic::paragraph_long::warm_hb       ... bench:     193,948.75 ns/iter (+/- 5,558.46)
test arabic::paragraph_long::warm_hr       ... bench:     272,902.50 ns/iter (+/- 12,651.25)
test arabic::paragraph_medium::cold_hb     ... bench:     143,570.78 ns/iter (+/- 4,003.70)
test arabic::paragraph_medium::cold_hr     ... bench:     162,000.00 ns/iter (+/- 11,726.50)
test arabic::paragraph_medium::warm_hb     ... bench:     104,270.94 ns/iter (+/- 2,805.83)
test arabic::paragraph_medium::warm_hr     ... bench:     152,046.00 ns/iter (+/- 9,428.40)
test arabic::paragraph_short::cold_hb      ... bench:      57,978.33 ns/iter (+/- 8,405.83)
test arabic::paragraph_short::cold_hr      ... bench:      57,849.69 ns/iter (+/- 1,982.23)
test arabic::paragraph_short::warm_hb      ... bench:      23,995.08 ns/iter (+/- 898.05)
test arabic::paragraph_short::warm_hr      ... bench:      46,915.00 ns/iter (+/- 1,223.29)
test arabic::sentence_1::cold_hb           ... bench:      48,055.00 ns/iter (+/- 1,396.50)
test arabic::sentence_1::cold_hr           ... bench:      39,676.07 ns/iter (+/- 1,010.68)
test arabic::sentence_1::warm_hb           ... bench:      15,835.00 ns/iter (+/- 837.86)
test arabic::sentence_1::warm_hr           ... bench:      29,944.67 ns/iter (+/- 1,115.60)
test arabic::sentence_2::cold_hb           ... bench:      49,642.22 ns/iter (+/- 4,524.56)
test arabic::sentence_2::cold_hr           ... bench:      40,553.64 ns/iter (+/- 1,992.55)
test arabic::sentence_2::warm_hb           ... bench:      16,038.75 ns/iter (+/- 462.11)
test arabic::sentence_2::warm_hr           ... bench:      30,663.00 ns/iter (+/- 1,441.65)
test arabic::word_1::cold_hb               ... bench:      32,100.36 ns/iter (+/- 1,510.32)
test arabic::word_1::cold_hr               ... bench:      10,476.48 ns/iter (+/- 352.43)
test arabic::word_1::warm_hb               ... bench:         700.61 ns/iter (+/- 54.05)
test arabic::word_1::warm_hr               ... bench:       1,287.83 ns/iter (+/- 155.83)
test arabic::word_2::cold_hb               ... bench:      34,004.38 ns/iter (+/- 3,832.29)
test arabic::word_2::cold_hr               ... bench:      11,979.32 ns/iter (+/- 1,089.57)
test arabic::word_2::warm_hb               ... bench:       1,121.26 ns/iter (+/- 72.29)
test arabic::word_2::warm_hr               ... bench:       2,225.14 ns/iter (+/- 58.02)
test arabic::word_3::cold_hb               ... bench:      32,375.45 ns/iter (+/- 3,211.27)
test arabic::word_3::cold_hr               ... bench:      10,553.06 ns/iter (+/- 168.06)
test arabic::word_3::warm_hb               ... bench:         877.29 ns/iter (+/- 18.58)
test arabic::word_3::warm_hr               ... bench:       1,339.93 ns/iter (+/- 25.26)
test english::long_zalgo::cold_hb          ... bench:     886,640.00 ns/iter (+/- 43,071.50)
test english::long_zalgo::cold_hr          ... bench:   1,607,360.00 ns/iter (+/- 41,237.00)
test english::long_zalgo::warm_hb          ... bench:     801,820.00 ns/iter (+/- 18,263.00)
test english::long_zalgo::warm_hr          ... bench:   1,549,050.00 ns/iter (+/- 29,899.00)
test english::paragraph_long::cold_hb      ... bench:     163,873.33 ns/iter (+/- 2,949.83)
test english::paragraph_long::cold_hr      ... bench:     338,820.00 ns/iter (+/- 25,987.50)
test english::paragraph_long::warm_hb      ... bench:      99,585.62 ns/iter (+/- 3,752.19)
test english::paragraph_long::warm_hr      ... bench:     295,350.00 ns/iter (+/- 11,397.33)
test english::paragraph_long_mono::cold_hb ... bench:      19,434.64 ns/iter (+/- 366.50)
test english::paragraph_long_mono::cold_hr ... bench:      32,970.00 ns/iter (+/- 2,137.73)
test english::paragraph_long_mono::warm_hb ... bench:      11,380.29 ns/iter (+/- 447.06)
test english::paragraph_long_mono::warm_hr ... bench:      29,341.18 ns/iter (+/- 537.59)
test english::paragraph_medium::cold_hb    ... bench:     127,377.50 ns/iter (+/- 4,633.50)
test english::paragraph_medium::cold_hr    ... bench:     239,777.50 ns/iter (+/- 7,737.25)
test english::paragraph_medium::warm_hb    ... bench:      65,251.98 ns/iter (+/- 5,641.42)
test english::paragraph_medium::warm_hr    ... bench:     197,447.50 ns/iter (+/- 12,399.75)
test english::paragraph_short::cold_hb     ... bench:      93,670.00 ns/iter (+/- 18,978.20)
test english::paragraph_short::cold_hr     ... bench:     152,713.33 ns/iter (+/- 20,146.33)
test english::paragraph_short::warm_hb     ... bench:      31,331.19 ns/iter (+/- 1,079.79)
test english::paragraph_short::warm_hr     ... bench:     103,255.71 ns/iter (+/- 2,792.29)
test english::sentence_1::cold_hb          ... bench:      72,325.00 ns/iter (+/- 1,605.17)
test english::sentence_1::cold_hr          ... bench:      80,875.00 ns/iter (+/- 1,776.83)
test english::sentence_1::warm_hb          ... bench:      11,763.28 ns/iter (+/- 216.42)
test english::sentence_1::warm_hr          ... bench:      39,223.89 ns/iter (+/- 1,412.86)
test english::sentence_2::cold_hb          ... bench:      70,580.00 ns/iter (+/- 1,429.50)
test english::sentence_2::cold_hr          ... bench:      75,397.86 ns/iter (+/- 6,270.14)
test english::sentence_2::warm_hb          ... bench:      10,298.61 ns/iter (+/- 547.20)
test english::sentence_2::warm_hr          ... bench:      33,337.14 ns/iter (+/- 393.48)
test english::sentence_mono::cold_hb       ... bench:       5,917.60 ns/iter (+/- 81.08)
test english::sentence_mono::cold_hr       ... bench:       6,472.20 ns/iter (+/- 209.06)
test english::sentence_mono::warm_hb       ... bench:       1,870.17 ns/iter (+/- 64.01)
test english::sentence_mono::warm_hr       ... bench:       3,783.31 ns/iter (+/- 148.90)
test english::short_zalgo::cold_hb         ... bench:      88,191.67 ns/iter (+/- 2,147.83)
test english::short_zalgo::cold_hr         ... bench:     105,960.00 ns/iter (+/- 3,664.40)
test english::short_zalgo::warm_hb         ... bench:      27,442.05 ns/iter (+/- 425.67)
test english::short_zalgo::warm_hr         ... bench:      63,346.50 ns/iter (+/- 2,024.85)
test english::variations::cold_hb          ... bench:     187,743.33 ns/iter (+/- 19,433.88)
test english::variations::cold_hr          ... bench:     419,120.00 ns/iter (+/- 9,926.00)
test english::variations::warm_hb          ... bench:     102,548.96 ns/iter (+/- 2,784.85)
test english::variations::warm_hr          ... bench:     375,620.00 ns/iter (+/- 10,093.00)
test english::variations_default::cold_hb  ... bench:     180,406.67 ns/iter (+/- 4,755.67)
test english::variations_default::cold_hr  ... bench:     337,190.00 ns/iter (+/- 10,976.00)
test english::variations_default::warm_hb  ... bench:     102,651.25 ns/iter (+/- 4,176.96)
test english::variations_default::warm_hr  ... bench:     295,130.00 ns/iter (+/- 8,766.50)
test english::word_1::cold_hb              ... bench:      60,376.25 ns/iter (+/- 742.25)
test english::word_1::cold_hr              ... bench:      42,900.00 ns/iter (+/- 438.07)
test english::word_1::warm_hb              ... bench:         774.89 ns/iter (+/- 8.86)
test english::word_1::warm_hr              ... bench:       1,864.44 ns/iter (+/- 52.79)
test english::word_2::cold_hb              ... bench:      60,855.71 ns/iter (+/- 1,319.43)
test english::word_2::cold_hr              ... bench:      44,271.00 ns/iter (+/- 436.70)
test english::word_2::warm_hb              ... bench:       1,219.18 ns/iter (+/- 34.54)
test english::word_2::warm_hr              ... bench:       3,187.64 ns/iter (+/- 28.32)
test english::word_3::cold_hb              ... bench:      60,367.50 ns/iter (+/- 1,754.25)
test english::word_3::cold_hr              ... bench:      43,372.14 ns/iter (+/- 1,696.79)
test english::word_3::warm_hb              ... bench:         668.55 ns/iter (+/- 26.32)
test english::word_3::warm_hr              ... bench:       1,463.74 ns/iter (+/- 72.39)
test english::word_4::cold_hb              ... bench:      60,875.00 ns/iter (+/- 1,980.38)
test english::word_4::cold_hr              ... bench:      44,472.00 ns/iter (+/- 1,029.40)
test english::word_4::warm_hb              ... bench:       1,235.98 ns/iter (+/- 75.13)
test english::word_4::warm_hr              ... bench:       3,355.65 ns/iter (+/- 75.57)
test hebrew::paragraph_long_1::cold_hb     ... bench:      65,020.31 ns/iter (+/- 2,261.59)
test hebrew::paragraph_long_1::cold_hr     ... bench:     152,240.00 ns/iter (+/- 4,683.12)
test hebrew::paragraph_long_1::warm_hb     ... bench:      53,223.75 ns/iter (+/- 1,617.91)
test hebrew::paragraph_long_1::warm_hr     ... bench:     145,480.00 ns/iter (+/- 2,728.40)
test hebrew::paragraph_long_2::cold_hb     ... bench:     114,156.56 ns/iter (+/- 3,680.16)
test hebrew::paragraph_long_2::cold_hr     ... bench:     267,240.00 ns/iter (+/- 24,188.25)
test hebrew::paragraph_long_2::warm_hb     ... bench:     100,916.25 ns/iter (+/- 5,217.42)
test hebrew::paragraph_long_2::warm_hr     ... bench:     254,760.00 ns/iter (+/- 11,199.33)
test hebrew::paragraph_medium::cold_hb     ... bench:      23,989.23 ns/iter (+/- 489.62)
test hebrew::paragraph_medium::cold_hr     ... bench:      41,787.78 ns/iter (+/- 1,808.39)
test hebrew::paragraph_medium::warm_hb     ... bench:      13,772.10 ns/iter (+/- 369.31)
test hebrew::paragraph_medium::warm_hr     ... bench:      35,360.83 ns/iter (+/- 517.08)
test hebrew::sentence_1::cold_hb           ... bench:      14,010.38 ns/iter (+/- 420.58)
test hebrew::sentence_1::cold_hr           ... bench:      17,543.67 ns/iter (+/- 434.33)
test hebrew::sentence_1::warm_hb           ... bench:       4,860.65 ns/iter (+/- 366.05)
test hebrew::sentence_1::warm_hr           ... bench:      11,407.39 ns/iter (+/- 229.70)
test hebrew::sentence_2::cold_hb           ... bench:      13,281.73 ns/iter (+/- 193.69)
test hebrew::sentence_2::cold_hr           ... bench:      15,341.79 ns/iter (+/- 143.50)
test hebrew::sentence_2::warm_hb           ... bench:       3,947.74 ns/iter (+/- 133.27)
test hebrew::sentence_2::warm_hr           ... bench:       9,255.69 ns/iter (+/- 249.39)
test hebrew::word_1::cold_hb               ... bench:       9,701.36 ns/iter (+/- 591.39)
test hebrew::word_1::cold_hr               ... bench:       7,359.88 ns/iter (+/- 276.34)
test hebrew::word_1::warm_hb               ... bench:         944.01 ns/iter (+/- 17.83)
test hebrew::word_1::warm_hr               ... bench:       1,429.17 ns/iter (+/- 48.99)
test hebrew::word_2::cold_hb               ... bench:       9,706.07 ns/iter (+/- 90.40)
test hebrew::word_2::cold_hr               ... bench:       7,502.64 ns/iter (+/- 374.24)
test hebrew::word_2::warm_hb               ... bench:         956.49 ns/iter (+/- 18.80)
test hebrew::word_2::warm_hr               ... bench:       1,533.87 ns/iter (+/- 22.91)
test hindi::paragraph_long::cold_hb        ... bench:     609,915.00 ns/iter (+/- 20,385.50)
test hindi::paragraph_long::cold_hr        ... bench:     733,400.00 ns/iter (+/- 23,135.00)
test hindi::paragraph_long::warm_hb        ... bench:     525,995.00 ns/iter (+/- 7,769.00)
test hindi::paragraph_long::warm_hr        ... bench:     683,610.00 ns/iter (+/- 11,391.00)
test hindi::paragraph_medium::cold_hb      ... bench:     427,240.00 ns/iter (+/- 8,947.00)
test hindi::paragraph_medium::cold_hr      ... bench:     478,555.00 ns/iter (+/- 10,105.00)
test hindi::paragraph_medium::warm_hb      ... bench:     344,875.00 ns/iter (+/- 10,395.75)
test hindi::paragraph_medium::warm_hr      ... bench:     428,936.25 ns/iter (+/- 15,756.12)
test hindi::paragraph_short::cold_hb       ... bench:     258,942.50 ns/iter (+/- 6,536.50)
test hindi::paragraph_short::cold_hr       ... bench:     273,931.88 ns/iter (+/- 5,953.56)
test hindi::paragraph_short::warm_hb       ... bench:     178,855.94 ns/iter (+/- 3,823.66)
test hindi::paragraph_short::warm_hr       ... bench:     224,701.67 ns/iter (+/- 9,685.92)
test hindi::sentence_1::cold_hb            ... bench:     118,333.28 ns/iter (+/- 5,605.94)
test hindi::sentence_1::cold_hr            ... bench:     118,332.50 ns/iter (+/- 12,894.25)
test hindi::sentence_1::warm_hb            ... bench:      48,674.22 ns/iter (+/- 3,203.81)
test hindi::sentence_1::warm_hr            ... bench:      70,747.50 ns/iter (+/- 3,094.66)
test hindi::sentence_2::cold_hb            ... bench:     109,280.00 ns/iter (+/- 4,734.12)
test hindi::sentence_2::cold_hr            ... bench:     107,352.00 ns/iter (+/- 2,491.60)
test hindi::sentence_2::warm_hb            ... bench:      42,193.00 ns/iter (+/- 2,945.05)
test hindi::sentence_2::warm_hr            ... bench:      62,206.67 ns/iter (+/- 3,165.00)
test hindi::word_1::cold_hb                ... bench:      65,883.75 ns/iter (+/- 701.50)
test hindi::word_1::cold_hr                ... bench:      47,244.55 ns/iter (+/- 450.18)
test hindi::word_1::warm_hb                ... bench:       1,794.84 ns/iter (+/- 41.37)
test hindi::word_1::warm_hr                ... bench:       2,067.18 ns/iter (+/- 33.60)
test hindi::word_2::cold_hb                ... bench:      66,418.21 ns/iter (+/- 2,288.71)
test hindi::word_2::cold_hr                ... bench:      48,258.75 ns/iter (+/- 489.50)
test hindi::word_2::warm_hb                ... bench:       2,108.18 ns/iter (+/- 70.73)
test hindi::word_2::warm_hr                ... bench:       2,969.34 ns/iter (+/- 44.69)
test khmer::paragraph_long_1::cold_hb      ... bench:     355,370.00 ns/iter (+/- 5,859.50)
test khmer::paragraph_long_1::cold_hr      ... bench:     592,870.00 ns/iter (+/- 19,101.00)
test khmer::paragraph_long_1::warm_hb      ... bench:     314,026.25 ns/iter (+/- 8,211.88)
test khmer::paragraph_long_1::warm_hr      ... bench:     569,607.50 ns/iter (+/- 6,021.88)
test khmer::paragraph_long_2::cold_hb      ... bench:     451,160.00 ns/iter (+/- 22,877.00)
test khmer::paragraph_long_2::cold_hr      ... bench:     735,490.00 ns/iter (+/- 11,622.50)
test khmer::paragraph_long_2::warm_hb      ... bench:     401,280.00 ns/iter (+/- 16,553.50)
test khmer::paragraph_long_2::warm_hr      ... bench:     733,050.00 ns/iter (+/- 40,003.00)
test khmer::paragraph_medium::cold_hb      ... bench:     226,495.83 ns/iter (+/- 21,945.08)
test khmer::paragraph_medium::cold_hr      ... bench:     367,272.50 ns/iter (+/- 62,401.25)
test khmer::paragraph_medium::warm_hb      ... bench:     184,509.06 ns/iter (+/- 5,725.94)
test khmer::paragraph_medium::warm_hr      ... bench:     330,612.50 ns/iter (+/- 10,411.75)
test khmer::sentence_1::cold_hb            ... bench:      34,664.44 ns/iter (+/- 774.17)
test khmer::sentence_1::cold_hr            ... bench:      26,403.33 ns/iter (+/- 299.62)
test khmer::sentence_1::warm_hb            ... bench:      10,429.09 ns/iter (+/- 93.57)
test khmer::sentence_1::warm_hr            ... bench:      10,902.55 ns/iter (+/- 106.42)
test khmer::sentence_2::cold_hb            ... bench:      44,355.00 ns/iter (+/- 1,212.36)
test khmer::sentence_2::cold_hr            ... bench:      47,785.00 ns/iter (+/- 599.86)
test khmer::sentence_2::warm_hb            ... bench:      15,891.56 ns/iter (+/- 327.69)
test khmer::sentence_2::warm_hr            ... bench:      30,491.25 ns/iter (+/- 1,190.62)
test khmer::word_1::cold_hb                ... bench:      31,176.88 ns/iter (+/- 987.31)
test khmer::word_1::cold_hr                ... bench:      21,887.31 ns/iter (+/- 394.08)
test khmer::word_1::warm_hb                ... bench:       2,717.37 ns/iter (+/- 59.17)
test khmer::word_1::warm_hr                ... bench:       5,079.30 ns/iter (+/- 68.93)
test khmer::word_2::cold_hb                ... bench:      32,961.25 ns/iter (+/- 2,022.62)
test khmer::word_2::cold_hr                ... bench:      25,225.42 ns/iter (+/- 653.00)
test khmer::word_2::warm_hb                ... bench:       4,213.92 ns/iter (+/- 114.48)
test khmer::word_2::warm_hr                ... bench:       8,188.18 ns/iter (+/- 124.98)
test khmer::word_3::cold_hb                ... bench:      31,006.11 ns/iter (+/- 522.06)
test khmer::word_3::cold_hr                ... bench:      22,635.00 ns/iter (+/- 3,506.88)
test khmer::word_3::warm_hb                ... bench:       2,650.97 ns/iter (+/- 81.89)
test khmer::word_3::warm_hr                ... bench:       4,914.63 ns/iter (+/- 92.65)
test myanmar::paragraph_long::cold_hb      ... bench:   1,089,900.00 ns/iter (+/- 35,188.00)
test myanmar::paragraph_long::cold_hr      ... bench:   2,664,950.00 ns/iter (+/- 69,931.50)
test myanmar::paragraph_long::warm_hb      ... bench:   1,042,930.00 ns/iter (+/- 46,821.00)
test myanmar::paragraph_long::warm_hr      ... bench:   2,640,600.00 ns/iter (+/- 75,699.00)
test myanmar::paragraph_medium::cold_hb    ... bench:     463,640.00 ns/iter (+/- 16,813.00)
test myanmar::paragraph_medium::cold_hr    ... bench:   1,032,730.00 ns/iter (+/- 39,477.00)
test myanmar::paragraph_medium::warm_hb    ... bench:     412,830.00 ns/iter (+/- 8,512.00)
test myanmar::paragraph_medium::warm_hr    ... bench:   1,012,080.00 ns/iter (+/- 32,816.00)
test myanmar::paragraph_short::cold_hb     ... bench:     105,926.88 ns/iter (+/- 5,572.81)
test myanmar::paragraph_short::cold_hr     ... bench:     218,650.00 ns/iter (+/- 7,392.00)
test myanmar::paragraph_short::warm_hb     ... bench:      64,220.00 ns/iter (+/- 3,002.40)
test myanmar::paragraph_short::warm_hr     ... bench:     200,510.00 ns/iter (+/- 6,717.00)
test myanmar::sentence_1::cold_hb          ... bench:     107,967.50 ns/iter (+/- 3,110.20)
test myanmar::sentence_1::cold_hr          ... bench:     224,375.00 ns/iter (+/- 5,028.83)
test myanmar::sentence_1::warm_hb          ... bench:      64,242.00 ns/iter (+/- 1,428.50)
test myanmar::sentence_1::warm_hr          ... bench:     205,601.67 ns/iter (+/- 7,386.67)
test myanmar::sentence_2::cold_hb          ... bench:     129,317.50 ns/iter (+/- 11,092.50)
test myanmar::sentence_2::cold_hr          ... bench:     304,360.00 ns/iter (+/- 11,545.75)
test myanmar::sentence_2::warm_hb          ... bench:      87,247.50 ns/iter (+/- 2,923.62)
test myanmar::sentence_2::warm_hr          ... bench:     286,030.00 ns/iter (+/- 9,805.67)
test myanmar::word_1::cold_hb              ... bench:      40,859.00 ns/iter (+/- 2,106.45)
test myanmar::word_1::cold_hr              ... bench:      22,367.69 ns/iter (+/- 558.04)
test myanmar::word_1::warm_hb              ... bench:       1,613.32 ns/iter (+/- 78.39)
test myanmar::word_1::warm_hr              ... bench:       4,941.63 ns/iter (+/- 192.07)
test myanmar::word_2::cold_hb              ... bench:      42,124.55 ns/iter (+/- 756.55)
test myanmar::word_2::cold_hr              ... bench:      23,332.00 ns/iter (+/- 512.33)
test myanmar::word_2::warm_hb              ... bench:       2,451.59 ns/iter (+/- 35.94)
test myanmar::word_2::warm_hr              ... bench:       5,687.05 ns/iter (+/- 219.56)
test thai::paragraph_long::cold_hb         ... bench:     219,812.92 ns/iter (+/- 19,942.88)
test thai::paragraph_long::cold_hr         ... bench:     349,045.00 ns/iter (+/- 27,602.44)
test thai::paragraph_long::warm_hb         ... bench:     190,838.54 ns/iter (+/- 3,747.44)
test thai::paragraph_long::warm_hr         ... bench:     322,114.38 ns/iter (+/- 10,584.06)
test thai::paragraph_medium::cold_hb       ... bench:      55,452.50 ns/iter (+/- 1,361.58)
test thai::paragraph_medium::cold_hr       ... bench:     102,062.00 ns/iter (+/- 2,103.80)
test thai::paragraph_medium::warm_hb       ... bench:      44,299.38 ns/iter (+/- 2,618.46)
test thai::paragraph_medium::warm_hr       ... bench:      93,420.00 ns/iter (+/- 2,382.67)
test thai::paragraph_short::cold_hb        ... bench:      27,377.50 ns/iter (+/- 1,099.62)
test thai::paragraph_short::cold_hr        ... bench:      41,296.11 ns/iter (+/- 3,009.06)
test thai::paragraph_short::warm_hb        ... bench:      17,267.50 ns/iter (+/- 693.68)
test thai::paragraph_short::warm_hr        ... bench:      33,900.91 ns/iter (+/- 2,425.36)
test thai::sentence_1::cold_hb             ... bench:      23,825.71 ns/iter (+/- 2,403.71)
test thai::sentence_1::cold_hr             ... bench:      30,408.65 ns/iter (+/- 1,000.02)
test thai::sentence_1::warm_hb             ... bench:      13,632.00 ns/iter (+/- 264.41)
test thai::sentence_1::warm_hr             ... bench:      22,726.79 ns/iter (+/- 655.00)
test thai::word_1::cold_hb                 ... bench:      10,699.81 ns/iter (+/- 118.35)
test thai::word_1::cold_hr                 ... bench:       9,368.89 ns/iter (+/- 185.06)
test thai::word_1::warm_hb                 ... bench:       1,403.79 ns/iter (+/- 48.34)
test thai::word_1::warm_hr                 ... bench:       2,358.48 ns/iter (+/- 86.82)
test thai::word_2::cold_hb                 ... bench:      10,445.62 ns/iter (+/- 357.97)
test thai::word_2::cold_hr                 ... bench:       9,623.51 ns/iter (+/- 241.78)
test thai::word_2::warm_hb                 ... bench:       1,580.70 ns/iter (+/- 32.17)
test thai::word_2::warm_hr                 ... bench:       2,621.90 ns/iter (+/- 69.90)
```

Bench after:
```
running 232 tests
test arabic::paragraph_long::cold_hb       ... bench:     234,616.25 ns/iter (+/- 8,224.84)
test arabic::paragraph_long::cold_hr       ... bench:     246,805.00 ns/iter (+/- 30,198.50)
test arabic::paragraph_long::warm_hb       ... bench:     191,303.54 ns/iter (+/- 4,324.62)
test arabic::paragraph_long::warm_hr       ... bench:     232,010.00 ns/iter (+/- 10,046.67)
test arabic::paragraph_medium::cold_hb     ... bench:     139,540.62 ns/iter (+/- 4,620.31)
test arabic::paragraph_medium::cold_hr     ... bench:     136,547.50 ns/iter (+/- 6,668.00)
test arabic::paragraph_medium::warm_hb     ... bench:     101,438.75 ns/iter (+/- 2,993.38)
test arabic::paragraph_medium::warm_hr     ... bench:     126,268.33 ns/iter (+/- 3,151.58)
test arabic::paragraph_short::cold_hb      ... bench:      58,124.29 ns/iter (+/- 7,323.86)
test arabic::paragraph_short::cold_hr      ... bench:      48,735.00 ns/iter (+/- 1,642.45)
test arabic::paragraph_short::warm_hb      ... bench:      23,635.62 ns/iter (+/- 1,030.25)
test arabic::paragraph_short::warm_hr      ... bench:      39,054.71 ns/iter (+/- 1,565.18)
test arabic::sentence_1::cold_hb           ... bench:      48,181.43 ns/iter (+/- 2,181.14)
test arabic::sentence_1::cold_hr           ... bench:      34,675.38 ns/iter (+/- 966.46)
test arabic::sentence_1::warm_hb           ... bench:      15,754.91 ns/iter (+/- 323.42)
test arabic::sentence_1::warm_hr           ... bench:      25,253.81 ns/iter (+/- 773.86)
test arabic::sentence_2::cold_hb           ... bench:      49,693.75 ns/iter (+/- 5,382.12)
test arabic::sentence_2::cold_hr           ... bench:      34,480.00 ns/iter (+/- 1,220.10)
test arabic::sentence_2::warm_hb           ... bench:      15,966.75 ns/iter (+/- 403.95)
test arabic::sentence_2::warm_hr           ... bench:      24,856.96 ns/iter (+/- 577.74)
test arabic::word_1::cold_hb               ... bench:      31,827.08 ns/iter (+/- 796.79)
test arabic::word_1::cold_hr               ... bench:      10,347.83 ns/iter (+/- 436.35)
test arabic::word_1::warm_hb               ... bench:         695.41 ns/iter (+/- 20.19)
test arabic::word_1::warm_hr               ... bench:       1,130.97 ns/iter (+/- 31.35)
test arabic::word_2::cold_hb               ... bench:      32,971.54 ns/iter (+/- 1,868.69)
test arabic::word_2::cold_hr               ... bench:      11,256.34 ns/iter (+/- 410.87)
test arabic::word_2::warm_hb               ... bench:       1,124.46 ns/iter (+/- 34.62)
test arabic::word_2::warm_hr               ... bench:       1,882.50 ns/iter (+/- 29.52)
test arabic::word_3::cold_hb               ... bench:      32,088.50 ns/iter (+/- 1,923.55)
test arabic::word_3::cold_hr               ... bench:      10,349.53 ns/iter (+/- 97.81)
test arabic::word_3::warm_hb               ... bench:         882.92 ns/iter (+/- 15.35)
test arabic::word_3::warm_hr               ... bench:       1,156.37 ns/iter (+/- 45.72)
test english::long_zalgo::cold_hb          ... bench:     894,280.00 ns/iter (+/- 37,102.00)
test english::long_zalgo::cold_hr          ... bench:   1,416,390.00 ns/iter (+/- 50,489.00)
test english::long_zalgo::warm_hb          ... bench:     805,100.00 ns/iter (+/- 20,059.00)
test english::long_zalgo::warm_hr          ... bench:   1,357,510.00 ns/iter (+/- 56,286.00)
test english::paragraph_long::cold_hb      ... bench:     166,389.58 ns/iter (+/- 5,051.58)
test english::paragraph_long::cold_hr      ... bench:     314,800.00 ns/iter (+/- 9,852.50)
test english::paragraph_long::warm_hb      ... bench:      99,327.92 ns/iter (+/- 4,204.29)
test english::paragraph_long::warm_hr      ... bench:     271,216.67 ns/iter (+/- 9,192.33)
test english::paragraph_long_mono::cold_hb ... bench:      18,843.93 ns/iter (+/- 551.50)
test english::paragraph_long_mono::cold_hr ... bench:      31,975.00 ns/iter (+/- 1,040.38)
test english::paragraph_long_mono::warm_hb ... bench:      11,424.38 ns/iter (+/- 147.58)
test english::paragraph_long_mono::warm_hr ... bench:      28,637.92 ns/iter (+/- 798.75)
test english::paragraph_medium::cold_hb    ... bench:     129,828.00 ns/iter (+/- 7,893.90)
test english::paragraph_medium::cold_hr    ... bench:     223,956.67 ns/iter (+/- 9,794.00)
test english::paragraph_medium::warm_hb    ... bench:      63,703.00 ns/iter (+/- 2,722.80)
test english::paragraph_medium::warm_hr    ... bench:     181,530.00 ns/iter (+/- 4,614.38)
test english::paragraph_short::cold_hb     ... bench:      93,542.50 ns/iter (+/- 4,735.25)
test english::paragraph_short::cold_hr     ... bench:     137,052.00 ns/iter (+/- 2,112.60)
test english::paragraph_short::warm_hb     ... bench:      31,278.12 ns/iter (+/- 985.46)
test english::paragraph_short::warm_hr     ... bench:      94,877.50 ns/iter (+/- 2,307.12)
test english::sentence_1::cold_hb          ... bench:      72,488.75 ns/iter (+/- 2,323.38)
test english::sentence_1::cold_hr          ... bench:      76,833.33 ns/iter (+/- 2,651.89)
test english::sentence_1::warm_hb          ... bench:      11,756.46 ns/iter (+/- 333.46)
test english::sentence_1::warm_hr          ... bench:      35,521.75 ns/iter (+/- 804.38)
test english::sentence_2::cold_hb          ... bench:      71,127.14 ns/iter (+/- 4,275.14)
test english::sentence_2::cold_hr          ... bench:      71,704.17 ns/iter (+/- 1,829.92)
test english::sentence_2::warm_hb          ... bench:      10,258.39 ns/iter (+/- 176.50)
test english::sentence_2::warm_hr          ... bench:      30,465.91 ns/iter (+/- 665.95)
test english::sentence_mono::cold_hb       ... bench:       6,004.41 ns/iter (+/- 403.31)
test english::sentence_mono::cold_hr       ... bench:       6,399.42 ns/iter (+/- 209.71)
test english::sentence_mono::warm_hb       ... bench:       1,776.50 ns/iter (+/- 44.53)
test english::sentence_mono::warm_hr       ... bench:       3,764.77 ns/iter (+/- 81.90)
test english::short_zalgo::cold_hb         ... bench:      89,241.67 ns/iter (+/- 6,562.33)
test english::short_zalgo::cold_hr         ... bench:      97,691.67 ns/iter (+/- 5,866.17)
test english::short_zalgo::warm_hb         ... bench:      27,433.75 ns/iter (+/- 1,100.88)
test english::short_zalgo::warm_hr         ... bench:      55,262.50 ns/iter (+/- 1,881.50)
test english::variations::cold_hb          ... bench:     183,257.50 ns/iter (+/- 12,378.75)
test english::variations::cold_hr          ... bench:     397,370.00 ns/iter (+/- 24,059.00)
test english::variations::warm_hb          ... bench:     103,154.90 ns/iter (+/- 2,697.86)
test english::variations::warm_hr          ... bench:     354,021.25 ns/iter (+/- 12,368.25)
test english::variations_default::cold_hb  ... bench:     183,110.00 ns/iter (+/- 8,956.17)
test english::variations_default::cold_hr  ... bench:     315,402.50 ns/iter (+/- 11,976.50)
test english::variations_default::warm_hb  ... bench:     103,004.38 ns/iter (+/- 2,179.29)
test english::variations_default::warm_hr  ... bench:     270,966.67 ns/iter (+/- 6,382.67)
test english::word_1::cold_hb              ... bench:      60,408.33 ns/iter (+/- 1,484.67)
test english::word_1::cold_hr              ... bench:      42,421.67 ns/iter (+/- 2,866.17)
test english::word_1::warm_hb              ... bench:         770.18 ns/iter (+/- 27.90)
test english::word_1::warm_hr              ... bench:       1,718.66 ns/iter (+/- 39.56)
test english::word_2::cold_hb              ... bench:      61,177.78 ns/iter (+/- 2,636.67)
test english::word_2::cold_hr              ... bench:      43,607.69 ns/iter (+/- 1,896.69)
test english::word_2::warm_hb              ... bench:       1,211.94 ns/iter (+/- 31.95)
test english::word_2::warm_hr              ... bench:       2,947.98 ns/iter (+/- 73.52)
test english::word_3::cold_hb              ... bench:      60,168.89 ns/iter (+/- 1,040.00)
test english::word_3::cold_hr              ... bench:      42,316.00 ns/iter (+/- 1,226.40)
test english::word_3::warm_hb              ... bench:         660.78 ns/iter (+/- 17.57)
test english::word_3::warm_hr              ... bench:       1,315.65 ns/iter (+/- 30.64)
test english::word_4::cold_hb              ... bench:      61,052.22 ns/iter (+/- 1,533.89)
test english::word_4::cold_hr              ... bench:      43,716.11 ns/iter (+/- 357.72)
test english::word_4::warm_hb              ... bench:       1,228.03 ns/iter (+/- 28.96)
test english::word_4::warm_hr              ... bench:       3,020.90 ns/iter (+/- 80.16)
test hebrew::paragraph_long_1::cold_hb     ... bench:      65,408.75 ns/iter (+/- 2,953.36)
test hebrew::paragraph_long_1::cold_hr     ... bench:     127,220.00 ns/iter (+/- 4,168.50)
test hebrew::paragraph_long_1::warm_hb     ... bench:      53,230.31 ns/iter (+/- 1,968.15)
test hebrew::paragraph_long_1::warm_hr     ... bench:     120,572.00 ns/iter (+/- 3,182.20)
test hebrew::paragraph_long_2::cold_hb     ... bench:     112,755.00 ns/iter (+/- 5,159.97)
test hebrew::paragraph_long_2::cold_hr     ... bench:     224,793.33 ns/iter (+/- 9,736.00)
test hebrew::paragraph_long_2::warm_hb     ... bench:      99,230.47 ns/iter (+/- 3,022.78)
test hebrew::paragraph_long_2::warm_hr     ... bench:     218,760.00 ns/iter (+/- 11,277.00)
test hebrew::paragraph_medium::cold_hb     ... bench:      24,086.77 ns/iter (+/- 739.33)
test hebrew::paragraph_medium::cold_hr     ... bench:      35,071.11 ns/iter (+/- 1,412.78)
test hebrew::paragraph_medium::warm_hb     ... bench:      13,882.02 ns/iter (+/- 371.76)
test hebrew::paragraph_medium::warm_hr     ... bench:      28,634.64 ns/iter (+/- 1,338.75)
test hebrew::sentence_1::cold_hb           ... bench:      14,099.71 ns/iter (+/- 400.38)
test hebrew::sentence_1::cold_hr           ... bench:      15,149.64 ns/iter (+/- 510.54)
test hebrew::sentence_1::warm_hb           ... bench:       4,727.48 ns/iter (+/- 70.40)
test hebrew::sentence_1::warm_hr           ... bench:       9,008.67 ns/iter (+/- 70.88)
test hebrew::sentence_2::cold_hb           ... bench:      13,700.83 ns/iter (+/- 638.78)
test hebrew::sentence_2::cold_hr           ... bench:      13,602.88 ns/iter (+/- 139.17)
test hebrew::sentence_2::warm_hb           ... bench:       3,969.27 ns/iter (+/- 173.32)
test hebrew::sentence_2::warm_hr           ... bench:       7,591.23 ns/iter (+/- 256.77)
test hebrew::word_1::cold_hb               ... bench:       9,690.66 ns/iter (+/- 135.39)
test hebrew::word_1::cold_hr               ... bench:       7,205.00 ns/iter (+/- 202.14)
test hebrew::word_1::warm_hb               ... bench:         951.54 ns/iter (+/- 14.72)
test hebrew::word_1::warm_hr               ... bench:       1,264.04 ns/iter (+/- 25.97)
test hebrew::word_2::cold_hb               ... bench:       9,862.35 ns/iter (+/- 403.29)
test hebrew::word_2::cold_hr               ... bench:       7,326.45 ns/iter (+/- 238.33)
test hebrew::word_2::warm_hb               ... bench:         971.61 ns/iter (+/- 57.54)
test hebrew::word_2::warm_hr               ... bench:       1,383.44 ns/iter (+/- 81.98)
test hindi::paragraph_long::cold_hb        ... bench:     612,170.00 ns/iter (+/- 13,964.00)
test hindi::paragraph_long::cold_hr        ... bench:     710,565.00 ns/iter (+/- 19,964.25)
test hindi::paragraph_long::warm_hb        ... bench:     529,650.00 ns/iter (+/- 11,982.25)
test hindi::paragraph_long::warm_hr        ... bench:     660,120.00 ns/iter (+/- 24,928.00)
test hindi::paragraph_medium::cold_hb      ... bench:     429,700.00 ns/iter (+/- 15,510.75)
test hindi::paragraph_medium::cold_hr      ... bench:     463,215.00 ns/iter (+/- 20,977.75)
test hindi::paragraph_medium::warm_hb      ... bench:     348,770.00 ns/iter (+/- 13,194.50)
test hindi::paragraph_medium::warm_hr      ... bench:     416,328.75 ns/iter (+/- 11,982.50)
test hindi::paragraph_short::cold_hb       ... bench:     261,512.50 ns/iter (+/- 11,116.88)
test hindi::paragraph_short::cold_hr       ... bench:     263,911.25 ns/iter (+/- 12,473.62)
test hindi::paragraph_short::warm_hb       ... bench:     179,951.25 ns/iter (+/- 3,178.12)
test hindi::paragraph_short::warm_hr       ... bench:     214,860.42 ns/iter (+/- 7,330.21)
test hindi::sentence_1::cold_hb            ... bench:     118,609.38 ns/iter (+/- 6,212.28)
test hindi::sentence_1::cold_hr            ... bench:     113,205.00 ns/iter (+/- 4,415.00)
test hindi::sentence_1::warm_hb            ... bench:      48,141.00 ns/iter (+/- 1,647.85)
test hindi::sentence_1::warm_hr            ... bench:      68,398.75 ns/iter (+/- 5,165.12)
test hindi::sentence_2::cold_hb            ... bench:     110,778.75 ns/iter (+/- 7,875.50)
test hindi::sentence_2::cold_hr            ... bench:     104,630.00 ns/iter (+/- 3,043.12)
test hindi::sentence_2::warm_hb            ... bench:      43,130.00 ns/iter (+/- 2,845.12)
test hindi::sentence_2::warm_hr            ... bench:      58,783.89 ns/iter (+/- 2,666.94)
test hindi::word_1::cold_hb                ... bench:      66,538.57 ns/iter (+/- 2,108.57)
test hindi::word_1::cold_hr                ... bench:      46,192.86 ns/iter (+/- 1,195.79)
test hindi::word_1::warm_hb                ... bench:       1,831.58 ns/iter (+/- 54.15)
test hindi::word_1::warm_hr                ... bench:       2,041.62 ns/iter (+/- 66.68)
test hindi::word_2::cold_hb                ... bench:      67,371.43 ns/iter (+/- 4,384.29)
test hindi::word_2::cold_hr                ... bench:      47,403.12 ns/iter (+/- 1,181.38)
test hindi::word_2::warm_hb                ... bench:       2,158.70 ns/iter (+/- 72.93)
test hindi::word_2::warm_hr                ... bench:       2,872.65 ns/iter (+/- 75.78)
test khmer::paragraph_long_1::cold_hb      ... bench:     358,175.00 ns/iter (+/- 21,734.00)
test khmer::paragraph_long_1::cold_hr      ... bench:     569,552.50 ns/iter (+/- 19,614.00)
test khmer::paragraph_long_1::warm_hb      ... bench:     317,320.00 ns/iter (+/- 17,683.00)
test khmer::paragraph_long_1::warm_hr      ... bench:     545,722.50 ns/iter (+/- 17,216.50)
test khmer::paragraph_long_2::cold_hb      ... bench:     444,550.00 ns/iter (+/- 14,721.00)
test khmer::paragraph_long_2::cold_hr      ... bench:     711,855.00 ns/iter (+/- 23,522.50)
test khmer::paragraph_long_2::warm_hb      ... bench:     403,355.00 ns/iter (+/- 12,734.38)
test khmer::paragraph_long_2::warm_hr      ... bench:     690,010.00 ns/iter (+/- 27,451.50)
test khmer::paragraph_medium::cold_hb      ... bench:     228,087.50 ns/iter (+/- 7,379.79)
test khmer::paragraph_medium::cold_hr      ... bench:     340,421.88 ns/iter (+/- 10,479.94)
test khmer::paragraph_medium::warm_hb      ... bench:     185,828.75 ns/iter (+/- 6,409.79)
test khmer::paragraph_medium::warm_hr      ... bench:     322,776.25 ns/iter (+/- 23,882.44)
test khmer::sentence_1::cold_hb            ... bench:      35,216.67 ns/iter (+/- 4,086.11)
test khmer::sentence_1::cold_hr            ... bench:      23,763.64 ns/iter (+/- 2,604.84)
test khmer::sentence_1::warm_hb            ... bench:      10,976.73 ns/iter (+/- 927.60)
test khmer::sentence_1::warm_hr            ... bench:       7,921.00 ns/iter (+/- 352.08)
test khmer::sentence_2::cold_hb            ... bench:      45,241.25 ns/iter (+/- 3,172.88)
test khmer::sentence_2::cold_hr            ... bench:      47,185.00 ns/iter (+/- 3,790.50)
test khmer::sentence_2::warm_hb            ... bench:      16,218.26 ns/iter (+/- 400.70)
test khmer::sentence_2::warm_hr            ... bench:      30,167.27 ns/iter (+/- 3,964.73)
test khmer::word_1::cold_hb                ... bench:      31,295.56 ns/iter (+/- 889.67)
test khmer::word_1::cold_hr                ... bench:      21,210.00 ns/iter (+/- 468.73)
test khmer::word_1::warm_hb                ... bench:       2,732.33 ns/iter (+/- 59.60)
test khmer::word_1::warm_hr                ... bench:       4,957.95 ns/iter (+/- 155.14)
test khmer::word_2::cold_hb                ... bench:      33,699.00 ns/iter (+/- 5,971.10)
test khmer::word_2::cold_hr                ... bench:      24,464.06 ns/iter (+/- 796.91)
test khmer::word_2::warm_hb                ... bench:       4,300.13 ns/iter (+/- 249.14)
test khmer::word_2::warm_hr                ... bench:       7,921.29 ns/iter (+/- 336.50)
test khmer::word_3::cold_hb                ... bench:      31,160.00 ns/iter (+/- 1,285.00)
test khmer::word_3::cold_hr                ... bench:      21,083.75 ns/iter (+/- 882.85)
test khmer::word_3::warm_hb                ... bench:       2,678.27 ns/iter (+/- 37.87)
test khmer::word_3::warm_hr                ... bench:       4,699.94 ns/iter (+/- 132.92)
test myanmar::paragraph_long::cold_hb      ... bench:   1,091,740.00 ns/iter (+/- 34,333.00)
test myanmar::paragraph_long::cold_hr      ... bench:   2,630,180.00 ns/iter (+/- 87,426.00)
test myanmar::paragraph_long::warm_hb      ... bench:   1,038,260.00 ns/iter (+/- 31,892.00)
test myanmar::paragraph_long::warm_hr      ... bench:   2,606,180.00 ns/iter (+/- 80,048.00)
test myanmar::paragraph_medium::cold_hb    ... bench:     465,740.00 ns/iter (+/- 9,120.00)
test myanmar::paragraph_medium::cold_hr    ... bench:   1,017,280.00 ns/iter (+/- 33,576.00)
test myanmar::paragraph_medium::warm_hb    ... bench:     413,530.00 ns/iter (+/- 10,619.00)
test myanmar::paragraph_medium::warm_hr    ... bench:     997,260.00 ns/iter (+/- 26,929.50)
test myanmar::paragraph_short::cold_hb     ... bench:     106,722.50 ns/iter (+/- 4,453.00)
test myanmar::paragraph_short::cold_hr     ... bench:     214,283.33 ns/iter (+/- 8,522.33)
test myanmar::paragraph_short::warm_hb     ... bench:      64,748.75 ns/iter (+/- 4,974.38)
test myanmar::paragraph_short::warm_hr     ... bench:     195,795.00 ns/iter (+/- 3,777.25)
test myanmar::sentence_1::cold_hb          ... bench:     110,535.50 ns/iter (+/- 5,648.10)
test myanmar::sentence_1::cold_hr          ... bench:     221,726.67 ns/iter (+/- 15,305.67)
test myanmar::sentence_1::warm_hb          ... bench:      64,583.12 ns/iter (+/- 997.31)
test myanmar::sentence_1::warm_hr          ... bench:     202,466.67 ns/iter (+/- 7,723.33)
test myanmar::sentence_2::cold_hb          ... bench:     131,380.00 ns/iter (+/- 8,506.50)
test myanmar::sentence_2::cold_hr          ... bench:     299,385.00 ns/iter (+/- 6,659.25)
test myanmar::sentence_2::warm_hb          ... bench:      87,845.00 ns/iter (+/- 2,021.00)
test myanmar::sentence_2::warm_hr          ... bench:     280,516.67 ns/iter (+/- 4,960.17)
test myanmar::word_1::cold_hb              ... bench:      41,829.49 ns/iter (+/- 780.49)
test myanmar::word_1::cold_hr              ... bench:      22,306.36 ns/iter (+/- 336.41)
test myanmar::word_1::warm_hb              ... bench:       1,621.41 ns/iter (+/- 45.33)
test myanmar::word_1::warm_hr              ... bench:       4,831.69 ns/iter (+/- 175.13)
test myanmar::word_2::cold_hb              ... bench:      42,696.00 ns/iter (+/- 1,466.65)
test myanmar::word_2::cold_hr              ... bench:      23,216.25 ns/iter (+/- 617.02)
test myanmar::word_2::warm_hb              ... bench:       2,544.31 ns/iter (+/- 62.57)
test myanmar::word_2::warm_hr              ... bench:       5,517.95 ns/iter (+/- 143.22)
test thai::paragraph_long::cold_hb         ... bench:     209,481.25 ns/iter (+/- 5,832.67)
test thai::paragraph_long::cold_hr         ... bench:     305,026.25 ns/iter (+/- 9,341.50)
test thai::paragraph_long::warm_hb         ... bench:     193,388.12 ns/iter (+/- 5,768.90)
test thai::paragraph_long::warm_hr         ... bench:     295,765.00 ns/iter (+/- 16,724.00)
test thai::paragraph_medium::cold_hb       ... bench:      55,711.00 ns/iter (+/- 6,194.60)
test thai::paragraph_medium::cold_hr       ... bench:      92,960.83 ns/iter (+/- 4,099.08)
test thai::paragraph_medium::warm_hb       ... bench:      44,402.50 ns/iter (+/- 2,251.58)
test thai::paragraph_medium::warm_hr       ... bench:      84,087.50 ns/iter (+/- 3,647.54)
test thai::paragraph_short::cold_hb        ... bench:      27,680.56 ns/iter (+/- 1,008.89)
test thai::paragraph_short::cold_hr        ... bench:      37,625.56 ns/iter (+/- 1,768.67)
test thai::paragraph_short::warm_hb        ... bench:      17,167.22 ns/iter (+/- 703.54)
test thai::paragraph_short::warm_hr        ... bench:      30,295.45 ns/iter (+/- 1,287.77)
test thai::sentence_1::cold_hb             ... bench:      23,613.08 ns/iter (+/- 1,377.31)
test thai::sentence_1::cold_hr             ... bench:      27,739.00 ns/iter (+/- 1,230.62)
test thai::sentence_1::warm_hb             ... bench:      13,665.65 ns/iter (+/- 394.40)
test thai::sentence_1::warm_hr             ... bench:      20,294.00 ns/iter (+/- 1,240.95)
test thai::word_1::cold_hb                 ... bench:      11,225.86 ns/iter (+/- 267.61)
test thai::word_1::cold_hr                 ... bench:       9,156.80 ns/iter (+/- 216.02)
test thai::word_1::warm_hb                 ... bench:       1,435.23 ns/iter (+/- 41.35)
test thai::word_1::warm_hr                 ... bench:       2,135.89 ns/iter (+/- 79.47)
test thai::word_2::cold_hb                 ... bench:      10,504.71 ns/iter (+/- 677.62)
test thai::word_2::cold_hr                 ... bench:       9,384.56 ns/iter (+/- 358.75)
test thai::word_2::warm_hb                 ... bench:       1,593.13 ns/iter (+/- 30.96)
test thai::word_2::warm_hr                 ... bench:       2,394.44 ns/iter (+/- 121.56)
```