### PR TITLE
[buffer] Fix buffer size enlargement

### DIFF
--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -1248,7 +1248,7 @@ impl hb_buffer_t {
 
     #[must_use]
     pub fn ensure(&mut self, size: usize) -> bool {
-        if size < self.len {
+        if size <= self.info.len() {
             return true;
         }
 


### PR DESCRIPTION
We were wrongly, comparing with self.len, not the self.info.len which is the current length of the info/pos arrays. This was resulting in inadverently shrinking the buffer sometimes, causing out-of-bounds access and crash, for example in text-rendering-tests MORX-31 test.