### PR TITLE
Fix MSRV build and test in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,8 @@ jobs:
     - name: Build with std
       run: cargo build
 
+    - name: MSRV Build (Rust 1.75)
+      run: cargo +1.75 build
+
     - name: Run tests
       run: cargo test --verbose

--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -547,12 +547,13 @@ pub struct SubtableCache<'a> {
 impl<'a> SubtableCache<'a> {
     pub fn new(table_data: &'a [u8], lookups: &'a LookupCache, lookup: LookupInfo) -> Self {
         let subtable_infos = lookups.subtables(&lookup).unwrap_or_default();
+        const VACANT_ENTRY: SubtableCacheEntry = SubtableCacheEntry::Vacant;
         Self {
             table_data,
             lookups,
             lookup,
             subtable_infos,
-            subtables: [const { SubtableCacheEntry::Vacant }; SUBTABLE_CACHE_SIZE],
+            subtables: [VACANT_ENTRY; SUBTABLE_CACHE_SIZE],
         }
     }
 


### PR DESCRIPTION
HarfRust declares it's MSRV to be `1.75` (matching `read-fonts`/`skrifa`). However, due to use of an inline const expression (`const { ... }`) it only actually compiles with Rust `1.79`:

- Use a separately declared `const` to lower MSRV back down to `1.75`
- Test MSRV rust version in CI