### PR TITLE
chore: fix unused_qualifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ pico-args = { version = "0.5", features = ["eq-separator"] }
 libc = "0.2"
 
 [lints.rust]
-# TODO: enable this and fix related code
-unused_qualifications = "allow"
+unused_qualifications = "warn"
 
 [lints.clippy]
 cargo = { level = "warn", priority = -1 }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+avoid-breaking-exported-api = false

--- a/src/hb/aat_layout_trak_table.rs
+++ b/src/hb/aat_layout_trak_table.rs
@@ -125,7 +125,7 @@ trait TrackEntryExt {
     fn get_value(&self, ptem: f32, sizes: &[BigEndian<Fixed>], values: &[BigEndian<i16>]) -> f32;
 }
 
-impl TrackEntryExt for read_fonts::tables::trak::TrackTableEntry {
+impl TrackEntryExt for TrackTableEntry {
     fn get_value(&self, ptem: f32, sizes: &[BigEndian<Fixed>], values: &[BigEndian<i16>]) -> f32 {
         let n = sizes.len().min(values.len());
         if n == 0 {

--- a/src/hb/aat_map.rs
+++ b/src/hb/aat_map.rs
@@ -32,7 +32,7 @@ impl PartialOrd for feature_info_t {
         } else if !self.is_exclusive && (self.setting & !1) != (other.setting & !1) {
             Some(self.setting.cmp(&other.setting))
         } else {
-            Some(core::cmp::Ordering::Equal)
+            Some(Ordering::Equal)
         }
     }
 }

--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -184,7 +184,7 @@ impl hb_glyph_info_t {
     /// after line-breaking, or limiting the reshaping to a small piece around
     /// the breaking point only.
     pub fn unsafe_to_break(&self) -> bool {
-        self.mask & glyph_flag::UNSAFE_TO_BREAK != 0
+        self.mask & UNSAFE_TO_BREAK != 0
     }
 
     /// Indicates that if input text is changed on one side of the beginning of the cluster
@@ -219,7 +219,7 @@ impl hb_glyph_info_t {
     ///    always imply this flag. To use this flag, you must enable the buffer flag [`BufferFlags::PRODUCE_UNSAFE_TO_CONCAT`]
     ///    during shaping, otherwise the buffer flag will not be reliably produced.
     pub fn unsafe_to_concat(&self) -> bool {
-        self.mask & glyph_flag::UNSAFE_TO_CONCAT != 0
+        self.mask & UNSAFE_TO_CONCAT != 0
     }
 
     /// In scripts that use elongation (Arabic, Mongolian, Syriac, etc.), this flag signifies that it is
@@ -227,7 +227,7 @@ impl hb_glyph_info_t {
     /// determine the script-specific elongation places, but only when it is safe to do the elongation
     /// without interrupting text shaping.
     pub fn safe_to_insert_tatweel(&self) -> bool {
-        self.mask & glyph_flag::SAFE_TO_INSERT_TATWEEL != 0
+        self.mask & SAFE_TO_INSERT_TATWEEL != 0
     }
 
     #[inline]
@@ -673,7 +673,7 @@ impl hb_buffer_t {
         if self.script.is_none() {
             for info in &self.info {
                 match info.as_char().script() {
-                    crate::script::COMMON | crate::script::INHERITED | crate::script::UNKNOWN => {}
+                    script::COMMON | script::INHERITED | script::UNKNOWN => {}
                     s => {
                         self.script = Some(s);
                         break;
@@ -920,7 +920,7 @@ impl hb_buffer_t {
         let mut cluster = self.info[start].cluster;
 
         for i in start + 1..end {
-            cluster = core::cmp::min(cluster, self.info[i].cluster);
+            cluster = min(cluster, self.info[i].cluster);
         }
 
         // Extend end
@@ -963,7 +963,7 @@ impl hb_buffer_t {
         let mut cluster = self.out_info()[start].cluster;
 
         for i in start + 1..end {
-            cluster = core::cmp::min(cluster, self.out_info()[i].cluster);
+            cluster = min(cluster, self.out_info()[i].cluster);
         }
 
         // Extend start
@@ -1384,7 +1384,7 @@ impl hb_buffer_t {
 
         if self.cluster_level == HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS {
             for glyph_info in &info[start..end] {
-                cluster = core::cmp::min(cluster, glyph_info.cluster);
+                cluster = min(cluster, glyph_info.cluster);
             }
         }
 
@@ -1526,7 +1526,7 @@ pub(crate) fn _cluster_group_func(a: &hb_glyph_info_t, b: &hb_glyph_info_t) -> b
 
 macro_rules! foreach_cluster {
     ($buffer:expr, $start:ident, $end:ident, $($body:tt)*) => {
-        foreach_group!($buffer, $start, $end, crate::hb::buffer::_cluster_group_func, $($body)*)
+        foreach_group!($buffer, $start, $end, $crate::hb::buffer::_cluster_group_func, $($body)*)
     };
 }
 
@@ -1558,7 +1558,7 @@ macro_rules! foreach_syllable {
 
 macro_rules! foreach_grapheme {
     ($buffer:expr, $start:ident, $end:ident, $($body:tt)*) => {
-        foreach_group!($buffer, $start, $end, crate::hb::ot_layout::_hb_grapheme_group_func, $($body)*)
+        foreach_group!($buffer, $start, $end, $crate::hb::ot_layout::_hb_grapheme_group_func, $($body)*)
     };
 }
 

--- a/src/hb/common.rs
+++ b/src/hb/common.rs
@@ -167,7 +167,7 @@ impl Default for Direction {
     }
 }
 
-impl core::str::FromStr for Direction {
+impl FromStr for Direction {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -198,7 +198,7 @@ impl Language {
     }
 }
 
-impl core::str::FromStr for Language {
+impl FromStr for Language {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -266,7 +266,7 @@ impl Script {
     }
 }
 
-impl core::str::FromStr for Script {
+impl FromStr for Script {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -521,7 +521,7 @@ impl Feature {
     }
 }
 
-impl core::str::FromStr for Feature {
+impl FromStr for Feature {
     type Err = &'static str;
 
     /// Parses a `Feature` form a string.
@@ -679,7 +679,7 @@ pub struct Variation {
     pub value: f32,
 }
 
-impl core::str::FromStr for Variation {
+impl FromStr for Variation {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/hb/kerning.rs
+++ b/src/hb/kerning.rs
@@ -188,7 +188,7 @@ fn apply_state_machine_kerning(
                 .and_then(|gid| subtable.class(gid).ok())
                 .unwrap_or(1)
         } else {
-            read_fonts::tables::aat::class::END_OF_TEXT
+            aat::class::END_OF_TEXT
         };
 
         let Ok(entry) = subtable.entry(state, class) else {

--- a/src/hb/ot/contextual.rs
+++ b/src/hb/ot/contextual.rs
@@ -38,10 +38,7 @@ impl WouldApply for SequenceContextFormat1<'_> {
 }
 
 impl Apply for SequenceContextFormat1<'_> {
-    fn apply(
-        &self,
-        ctx: &mut crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t,
-    ) -> Option<()> {
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
         let glyph = ctx.buffer.cur(0).as_glyph();
         let index = self.coverage().ok()?.get(glyph)? as usize;
         let set = self.seq_rule_sets().get(index)?.ok()?;
@@ -118,10 +115,7 @@ impl WouldApply for SequenceContextFormat3<'_> {
 }
 
 impl Apply for SequenceContextFormat3<'_> {
-    fn apply(
-        &self,
-        ctx: &mut crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t,
-    ) -> Option<()> {
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
         let glyph = ctx.buffer.cur(0).as_glyph();
         let input_coverages = self.coverages();
         input_coverages.get(0).ok()?.get(glyph)?;
@@ -252,9 +246,7 @@ fn get_class(class_def: &ClassDef, gid: GlyphId) -> u16 {
 }
 
 /// Value represents glyph class.
-fn match_class<'a>(
-    class_def: &'a Option<read_fonts::tables::layout::ClassDef<'a>>,
-) -> impl Fn(GlyphId, u16) -> bool + 'a {
+fn match_class<'a>(class_def: &'a Option<ClassDef<'a>>) -> impl Fn(GlyphId, u16) -> bool + 'a {
     |glyph, value| {
         class_def
             .as_ref()

--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -282,7 +282,7 @@ impl LookupInfo {
         self.is_reversed
     }
 
-    pub fn digest(&self) -> &crate::hb::set_digest::hb_set_digest_t {
+    pub fn digest(&self) -> &hb_set_digest_t {
         &self.digest
     }
 }

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -597,7 +597,7 @@ pub trait WouldApply {
 /// Apply a lookup.
 pub trait Apply {
     /// Apply the lookup.
-    fn apply(&self, ctx: &mut OT::hb_ot_apply_context_t) -> Option<()>;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()>;
 }
 
 pub struct WouldApplyContext<'a> {

--- a/src/hb/ot_map.rs
+++ b/src/hb/ot_map.rs
@@ -8,6 +8,9 @@ use super::ot_layout::TableIndex;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::{hb_font_t, hb_mask_t, hb_tag_t, tag, Language, Script};
 
+// TODO: Remove once MSRV is 1.80+
+use core::mem::{size_of, size_of_val};
+
 pub struct hb_ot_map_t {
     found_script: [bool; 2],
     chosen_script: [Option<hb_tag_t>; 2],
@@ -195,7 +198,7 @@ struct stage_info_t {
     pause_func: Option<pause_func_t>,
 }
 
-const GLOBAL_BIT_SHIFT: u32 = 8 * core::mem::size_of::<u32>() as u32 - 1;
+const GLOBAL_BIT_SHIFT: u32 = 8 * size_of::<u32>() as u32 - 1;
 const GLOBAL_BIT_MASK: hb_mask_t = 1 << GLOBAL_BIT_SHIFT;
 
 impl<'a> hb_ot_map_builder_t<'a> {
@@ -357,7 +360,7 @@ impl<'a> hb_ot_map_builder_t<'a> {
             } else {
                 // Limit bits per feature.
                 let v = info.max_value;
-                let num_bits = 8 * core::mem::size_of_val(&v) as u32 - v.leading_zeros();
+                let num_bits = 8 * size_of_val(&v) as u32 - v.leading_zeros();
                 hb_ot_map_t::MAX_BITS.min(num_bits)
             };
 

--- a/src/hb/ot_shape.rs
+++ b/src/hb/ot_shape.rs
@@ -344,7 +344,7 @@ fn substitute_pre(ctx: &mut hb_ot_shape_context_t) {
 
 fn substitute_post(ctx: &mut hb_ot_shape_context_t) {
     if ctx.plan.apply_morx && !ctx.plan.apply_gpos {
-        aat_layout::hb_aat_layout_remove_deleted_glyphs(ctx.buffer);
+        hb_aat_layout_remove_deleted_glyphs(ctx.buffer);
     }
 
     deal_with_variation_selectors(ctx.buffer);
@@ -382,7 +382,7 @@ fn hb_ot_substitute_plan(ctx: &mut hb_ot_shape_context_t) {
     if ctx.plan.apply_morx {
         aat_layout::hb_aat_layout_substitute(ctx.plan, ctx.face, ctx.buffer, ctx.features);
     } else {
-        super::ot_layout_gsub_table::substitute(ctx.plan, ctx.face, ctx.buffer);
+        ot_layout_gsub_table::substitute(ctx.plan, ctx.face, ctx.buffer);
     }
 }
 
@@ -477,12 +477,12 @@ fn position_complex(ctx: &mut hb_ot_shape_context_t) {
 
 fn position_by_plan(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
     if plan.apply_gpos {
-        super::ot_layout_gpos_table::position(plan, face, buffer);
+        ot_layout_gpos_table::position(plan, face, buffer);
     } else if plan.apply_kerx {
         aat_layout::hb_aat_layout_position(plan, face, buffer);
     }
     if plan.apply_kern {
-        super::kerning::hb_ot_layout_kern(plan, face, buffer);
+        kerning::hb_ot_layout_kern(plan, face, buffer);
     } else if plan.apply_fallback_kern {
         ot_shape_fallback::_hb_ot_shape_fallback_kern(plan, face, buffer);
     }

--- a/src/hb/ot_shaper_myanmar.rs
+++ b/src/hb/ot_shaper_myanmar.rs
@@ -290,7 +290,7 @@ fn initial_reordering_consonant_syllable(start: usize, end: usize, buffer: &mut 
         let mut i = first_left_matra;
 
         for j in i..=last_left_matra {
-            if buffer.info[j].myanmar_category() == ot_category_t::OT_VPre {
+            if buffer.info[j].myanmar_category() == OT_VPre {
                 buffer.reverse_range(i, j + 1);
                 i = j + 1;
             }

--- a/src/hb/ot_shaper_use.rs
+++ b/src/hb/ot_shaper_use.rs
@@ -199,14 +199,14 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     // Reordering group
     planner
         .ot_map
-        .add_gsub_pause(Some(crate::hb::ot_layout::_hb_clear_substitution_flags));
+        .add_gsub_pause(Some(_hb_clear_substitution_flags));
     planner
         .ot_map
         .add_feature(hb_tag_t::new(b"rphf"), F_MANUAL_ZWJ | F_PER_SYLLABLE, 1);
     planner.ot_map.add_gsub_pause(Some(record_rphf));
     planner
         .ot_map
-        .add_gsub_pause(Some(crate::hb::ot_layout::_hb_clear_substitution_flags));
+        .add_gsub_pause(Some(_hb_clear_substitution_flags));
     planner
         .ot_map
         .enable_feature(hb_tag_t::new(b"pref"), F_MANUAL_ZWJ | F_PER_SYLLABLE, 1);


### PR DESCRIPTION
Fix inconsistencies in how each identifier is used using `cargo fix`.  This is important because it eliminates inconsistent usage of the same ident within one file - making all references to a type the same.

A few additional minor changes:
* add `clippy.toml` to ensure some edge cases are caught before they are accidentally released
* fix macros to use `$crate` instead of `crate`