### PR TITLE
chore: cleanup unreadable literals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ cast_lossless = "allow"  # 274
 cast_sign_loss = "allow"  # 192
 used_underscore_binding = "allow"  # 160
 cast_possible_truncation = "allow"  # 160
-unreadable_literal = "allow"  # 116
 wildcard_imports = "allow"  # 72
 cast_possible_wrap = "allow"  # 66
 semicolon_if_nothing_returned = "allow"  # 64

--- a/src/hb/aat_layout_morx_table.rs
+++ b/src/hb/aat_layout_morx_table.rs
@@ -740,9 +740,9 @@ impl LigatureCtx<'_> {
     const DONT_ADVANCE: u16 = 0x4000;
     const PERFORM_ACTION: u16 = 0x2000;
 
-    const LIG_ACTION_LAST: u32 = 0x80000000;
-    const LIG_ACTION_STORE: u32 = 0x40000000;
-    const LIG_ACTION_OFFSET: u32 = 0x3FFFFFFF;
+    const LIG_ACTION_LAST: u32 = 0x8000_0000;
+    const LIG_ACTION_STORE: u32 = 0x4000_0000;
+    const LIG_ACTION_OFFSET: u32 = 0x3FFF_FFFF;
 }
 
 impl driver_context_t<BigEndian<u16>> for LigatureCtx<'_> {
@@ -814,8 +814,8 @@ impl driver_context_t<BigEndian<u16>> for LigatureCtx<'_> {
                 };
 
                 let mut uoffset = action & Self::LIG_ACTION_OFFSET;
-                if uoffset & 0x20000000 != 0 {
-                    uoffset |= 0xC0000000; // Sign-extend.
+                if uoffset & 0x2000_0000 != 0 {
+                    uoffset |= 0xC000_0000; // Sign-extend.
                 }
 
                 let offset = uoffset as i32;

--- a/src/hb/algs.rs
+++ b/src/hb/algs.rs
@@ -48,11 +48,11 @@ pub const fn HB_CODEPOINT_DECODE3_1(v: u64) -> u32 {
 }
 #[allow(non_snake_case, dead_code)]
 pub const fn HB_CODEPOINT_DECODE3_2(v: u64) -> u32 {
-    ((v >> 21) & 0x1FFFFF) as u32
+    ((v >> 21) & 0x001F_FFFF) as u32
 }
 #[allow(non_snake_case, dead_code)]
 pub const fn HB_CODEPOINT_DECODE3_3(v: u64) -> u32 {
-    (v & 0x1FFFFF) as u32
+    (v & 0x001F_FFFF) as u32
 }
 
 /* Custom encoding used by hb-ucd. */

--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -28,7 +28,7 @@ pub mod glyph_flag {
     ///
     /// This can be used to optimize paragraph layout,
     /// by avoiding re-shaping of each line after line-breaking.
-    pub const UNSAFE_TO_BREAK: u32 = 0x00000001;
+    pub const UNSAFE_TO_BREAK: u32 = 0x0000_0001;
     /// Indicates that if input text is changed on one side
     /// of the beginning of the cluster this glyph is part
     /// of, then the shaping results for the other side
@@ -89,16 +89,16 @@ pub mod glyph_flag {
     /// To use this flag, you must enable the buffer flag
     /// PRODUCE_UNSAFE_TO_CONCAT during shaping, otherwise
     /// the buffer flag will not be reliably produced.
-    pub const UNSAFE_TO_CONCAT: u32 = 0x00000002;
+    pub const UNSAFE_TO_CONCAT: u32 = 0x0000_0002;
 
     /// In scripts that use elongation (Arabic,
     /// Mongolian, Syriac, etc.), this flag signifies
     /// that it is safe to insert a U+0640 TATWEEL
     /// character *before* this cluster for elongation.
-    pub const SAFE_TO_INSERT_TATWEEL: u32 = 0x00000004;
+    pub const SAFE_TO_INSERT_TATWEEL: u32 = 0x0000_0004;
 
     /// All the currently defined flags.
-    pub const DEFINED: u32 = 0x00000007; // OR of all defined flags
+    pub const DEFINED: u32 = 0x0000_0007; // OR of all defined flags
 }
 
 /// Holds the positions of the glyph in both horizontal and vertical directions.
@@ -423,12 +423,12 @@ impl hb_buffer_t {
     pub const MAX_LEN_FACTOR: usize = 64;
     pub const MAX_LEN_MIN: usize = 16384;
     // Shaping more than a billion chars? Let us know!
-    pub const MAX_LEN_DEFAULT: usize = 0x3FFFFFFF;
+    pub const MAX_LEN_DEFAULT: usize = 0x3FFF_FFFF;
 
     pub const MAX_OPS_FACTOR: i32 = 1024;
     pub const MAX_OPS_MIN: i32 = 16384;
     // Shaping more than a billion operations? Let us know!
-    pub const MAX_OPS_DEFAULT: i32 = 0x1FFFFFFF;
+    pub const MAX_OPS_DEFAULT: i32 = 0x1FFF_FFFF;
 
     /// Creates a new `Buffer`.
     pub fn new() -> Self {
@@ -1598,18 +1598,18 @@ bitflags::bitflags! {
 }
 
 pub type hb_buffer_scratch_flags_t = u32;
-pub const HB_BUFFER_SCRATCH_FLAG_DEFAULT: u32 = 0x00000000;
-pub const HB_BUFFER_SCRATCH_FLAG_HAS_NON_ASCII: u32 = 0x00000001;
-pub const HB_BUFFER_SCRATCH_FLAG_HAS_DEFAULT_IGNORABLES: u32 = 0x00000002;
-pub const HB_BUFFER_SCRATCH_FLAG_HAS_SPACE_FALLBACK: u32 = 0x00000004;
-pub const HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_ATTACHMENT: u32 = 0x00000008;
-pub const HB_BUFFER_SCRATCH_FLAG_HAS_CGJ: u32 = 0x00000010;
-pub const HB_BUFFER_SCRATCH_FLAG_HAS_GLYPH_FLAGS: u32 = 0x00000020;
-pub const HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE: u32 = 0x00000040;
-pub const HB_BUFFER_SCRATCH_FLAG_HAS_VARIATION_SELECTOR_FALLBACK: u32 = 0x00000080;
+pub const HB_BUFFER_SCRATCH_FLAG_DEFAULT: u32 = 0x0000_0000;
+pub const HB_BUFFER_SCRATCH_FLAG_HAS_NON_ASCII: u32 = 0x0000_0001;
+pub const HB_BUFFER_SCRATCH_FLAG_HAS_DEFAULT_IGNORABLES: u32 = 0x0000_0002;
+pub const HB_BUFFER_SCRATCH_FLAG_HAS_SPACE_FALLBACK: u32 = 0x0000_0004;
+pub const HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_ATTACHMENT: u32 = 0x0000_0008;
+pub const HB_BUFFER_SCRATCH_FLAG_HAS_CGJ: u32 = 0x0000_0010;
+pub const HB_BUFFER_SCRATCH_FLAG_HAS_GLYPH_FLAGS: u32 = 0x0000_0020;
+pub const HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE: u32 = 0x0000_0040;
+pub const HB_BUFFER_SCRATCH_FLAG_HAS_VARIATION_SELECTOR_FALLBACK: u32 = 0x0000_0080;
 
 /* Reserved for shapers' internal use. */
-pub const HB_BUFFER_SCRATCH_FLAG_SHAPER0: u32 = 0x01000000;
+pub const HB_BUFFER_SCRATCH_FLAG_SHAPER0: u32 = 0x0100_0000;
 // pub const HB_BUFFER_SCRATCH_FLAG_SHAPER1: u32 = 0x02000000;
 // pub const HB_BUFFER_SCRATCH_FLAG_SHAPER2: u32 = 0x04000000;
 // pub const HB_BUFFER_SCRATCH_FLAG_SHAPER3: u32 = 0x08000000;

--- a/src/hb/common.rs
+++ b/src/hb/common.rs
@@ -231,7 +231,7 @@ impl Script {
         }
 
         // Be lenient, adjust case (one capital letter followed by three small letters).
-        let tag = Tag::from_u32((tag.as_u32() & 0xDFDFDFDF) | 0x00202020);
+        let tag = Tag::from_u32((tag.as_u32() & 0xDFDF_DFDF) | 0x0020_2020);
 
         match &tag.to_be_bytes() {
             // These graduated from the 'Q' private-area codes, but
@@ -252,7 +252,7 @@ impl Script {
             _ => {}
         }
 
-        if tag.as_u32() & 0xE0E0E0E0 == 0x40606060 {
+        if tag.as_u32() & 0xE0E0_E0E0 == 0x4060_6060 {
             Some(Script(tag))
         } else {
             Some(script::UNKNOWN)

--- a/src/hb/mod.rs
+++ b/src/hb/mod.rs
@@ -65,6 +65,7 @@ mod ot_shaper_thai;
 mod ot_shaper_use;
 mod ot_shaper_use_machine;
 #[rustfmt::skip]
+#[allow(clippy::unreadable_literal)]
 mod ot_shaper_use_table;
 mod aat_layout_common;
 mod ot_shaper_vowel_constraints;

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -696,7 +696,7 @@ pub mod OT {
 
         pub fn random_number(&mut self) -> u32 {
             // http://www.cplusplus.com/reference/random/minstd_rand/
-            self.random_state = self.random_state.wrapping_mul(48271) % 2147483647;
+            self.random_state = self.random_state.wrapping_mul(48271) % (i32::MAX as u32);
             self.random_state
         }
 

--- a/src/hb/tag.rs
+++ b/src/hb/tag.rs
@@ -122,8 +122,8 @@ fn parse_private_use_subtag(
     let mut tag = hb_tag_t::from_bytes_lossy(tag.as_slice());
 
     // Some bits magic from HarfBuzz...
-    if tag.as_u32() & 0xDFDFDFDF == hb_tag_t::default_script().as_u32() {
-        tag = hb_tag_t::from_u32(tag.as_u32() ^ !0xDFDFDFDF);
+    if tag.as_u32() & 0xDFDF_DFDF == hb_tag_t::default_script().as_u32() {
+        tag = hb_tag_t::from_u32(tag.as_u32() ^ !0xDFDF_DFDF);
     }
 
     tags.push(tag);
@@ -251,7 +251,7 @@ fn old_tag_from_script(script: Script) -> hb_tag_t {
         script::VAI => hb_tag_t::new(b"vai "),
 
         // Else, just change first char to lowercase and return.
-        _ => hb_tag_t::from_u32(script.tag().as_u32() | 0x20000000),
+        _ => hb_tag_t::from_u32(script.tag().as_u32() | 0x2000_0000),
     }
 }
 

--- a/src/hb/ucd_table.rs
+++ b/src/hb/ucd_table.rs
@@ -10,7 +10,7 @@
 pub(crate) mod ucd {
 
 #![allow(unused_parens)]
-#![allow(clippy::unnecessary_cast)]
+#![allow(clippy::unnecessary_cast, clippy::unreadable_literal)]
 
 use crate::hb::algs::{HB_CODEPOINT_ENCODE3, HB_CODEPOINT_ENCODE3_11_7_14};
 use crate::hb::common::script;

--- a/src/hb/unicode.rs
+++ b/src/hb/unicode.rs
@@ -740,14 +740,14 @@ pub fn compose(a: char, b: char) -> Option<char> {
     let b = b as u32;
     let u: u32;
 
-    if (a & 0xFFFFF800) == 0x0000 && (b & 0xFFFFFF80) == 0x0300 {
+    if (a & 0xFFFF_F800) == 0x0000 && (b & 0xFFFF_FF80) == 0x0300 {
         /* If "a" is small enough and "b" is in the U+0300 range,
          * the composition data is encoded in a 32bit array sorted
          * by "a,b" pair. */
         let k = HB_CODEPOINT_ENCODE3_11_7_14(a, b, 0);
         let v = _hb_ucd_dm2_u32_map
             .binary_search_by(|probe| {
-                let key = probe & HB_CODEPOINT_ENCODE3_11_7_14(0x1FFFFF, 0x1FFFFF, 0);
+                let key = probe & HB_CODEPOINT_ENCODE3_11_7_14(0x001F_FFFF, 0x001F_FFFF, 0);
                 key.cmp(&k)
             })
             .ok()
@@ -764,7 +764,7 @@ pub fn compose(a: char, b: char) -> Option<char> {
         let k = HB_CODEPOINT_ENCODE3(a, b, 0);
         let v = _hb_ucd_dm2_u64_map
             .binary_search_by(|probe| {
-                let key = probe & HB_CODEPOINT_ENCODE3(0x1FFFFF, 0x1FFFFF, 0);
+                let key = probe & HB_CODEPOINT_ENCODE3(0x001F_FFFF, 0x001F_FFFF, 0);
                 key.cmp(&k)
             })
             .ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,23 +31,23 @@ bitflags::bitflags! {
     #[derive(Default, Debug, Clone, Copy)]
     pub struct BufferFlags: u32 {
         /// Indicates that special handling of the beginning of text paragraph can be applied to this buffer. Should usually be set, unless you are passing to the buffer only part of the text without the full context.
-        const BEGINNING_OF_TEXT             = 0x00000001;
+        const BEGINNING_OF_TEXT             = 0x0000_0001;
         /// Indicates that special handling of the end of text paragraph can be applied to this buffer, similar to [`BufferFlags::BEGINNING_OF_TEXT`].
-        const END_OF_TEXT                   = 0x00000002;
+        const END_OF_TEXT                   = 0x0000_0002;
         /// Indicates that characters with `Default_Ignorable` Unicode property should use the corresponding glyph from the font, instead of hiding them (done by replacing them with the space glyph and zeroing the advance width.) This flag takes precedence over [`BufferFlags::REMOVE_DEFAULT_IGNORABLES`].
-        const PRESERVE_DEFAULT_IGNORABLES   = 0x00000004;
+        const PRESERVE_DEFAULT_IGNORABLES   = 0x0000_0004;
         /// Indicates that characters with `Default_Ignorable` Unicode property should be removed from glyph string instead of hiding them (done by replacing them with the space glyph and zeroing the advance width.) [`BufferFlags::PRESERVE_DEFAULT_IGNORABLES`] takes precedence over this flag.
-        const REMOVE_DEFAULT_IGNORABLES     = 0x00000008;
+        const REMOVE_DEFAULT_IGNORABLES     = 0x0000_0008;
         /// Indicates that a dotted circle should not be inserted in the rendering of incorrect character sequences (such as `<0905 093E>`).
-        const DO_NOT_INSERT_DOTTED_CIRCLE   = 0x00000010;
+        const DO_NOT_INSERT_DOTTED_CIRCLE   = 0x0000_0010;
         /// Indicates that the shape() call and its variants should perform various verification processes on the results of the shaping operation on the buffer. If the verification fails, then either a buffer message is sent, if a message handler is installed on the buffer, or a message is written to standard error. In either case, the shaping result might be modified to show the failed output.
-        const VERIFY                        = 0x00000020;
+        const VERIFY                        = 0x0000_0020;
         /// Indicates that the `UNSAFE_TO_CONCAT` glyph-flag should be produced by the shaper. By default it will not be produced since it incurs a cost.
-        const PRODUCE_UNSAFE_TO_CONCAT      = 0x00000040;
+        const PRODUCE_UNSAFE_TO_CONCAT      = 0x0000_0040;
         /// Indicates that the `SAFE_TO_INSERT_TATWEEL` glyph-flag should be produced by the shaper. By default it will not be produced.
-        const PRODUCE_SAFE_TO_INSERT_TATWEEL      = 0x00000080;
+        const PRODUCE_SAFE_TO_INSERT_TATWEEL      = 0x0000_0080;
         /// All currently defined flags
-        const DEFINED = 0x000000FF;
+        const DEFINED = 0x0000_00FF;
     }
 }
 
@@ -98,19 +98,19 @@ bitflags::bitflags! {
     #[derive(Default)]
     pub struct SerializeFlags: u8 {
         /// Do not serialize glyph cluster.
-        const NO_CLUSTERS       = 0b00000001;
+        const NO_CLUSTERS       = 0b0000_0001;
         /// Do not serialize glyph position information.
-        const NO_POSITIONS      = 0b00000010;
+        const NO_POSITIONS      = 0b0000_0010;
         /// Do no serialize glyph name.
-        const NO_GLYPH_NAMES    = 0b00000100;
+        const NO_GLYPH_NAMES    = 0b0000_0100;
         /// Serialize glyph extents.
-        const GLYPH_EXTENTS     = 0b00001000;
+        const GLYPH_EXTENTS     = 0b0000_1000;
         /// Serialize glyph flags.
-        const GLYPH_FLAGS       = 0b00010000;
+        const GLYPH_FLAGS       = 0b0001_0000;
         /// Do not serialize glyph advances, glyph offsets will reflect absolute
         /// glyph positions.
-        const NO_ADVANCES       = 0b00100000;
+        const NO_ADVANCES       = 0b0010_0000;
         /// All currently defined flags.
-        const DEFINED = 0b00111111;
+        const DEFINED = 0b0011_1111;
     }
 }


### PR DESCRIPTION
Used this command:

```sh
__CARGO_FIX_YOLO=1 cargo clippy --fix --allow-dirty --workspace --all-targets --all-features ; cargo fmt
```

and manually reverted a few ones that are part of auto-generated code.

This change makes numbers easier to read, and helps spot various mis-positioned bits in long numbers.