### PR TITLE
Call buffer.guess_segment_properties() in examples/shape.rs

### DIFF
--- a/examples/shape.rs
+++ b/examples/shape.rs
@@ -205,6 +205,8 @@ fn main() {
             buffer.set_not_found_variation_selector_glyph(g);
         }
 
+        buffer.guess_segment_properties();
+
         let glyph_buffer = shaper.shape(buffer, &args.features);
 
         let mut format_flags = harfrust::SerializeFlags::default();


### PR DESCRIPTION
Otherwise it will panic if no direction is given.