### PR TITLE
[lookup] Use set-digest union instead of using coverage twice

### DIFF
--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -189,7 +189,7 @@ impl LookupCache {
             let subtable = subtable_info.materialize(data.table_data.as_bytes())?;
             let (coverage, coverage_offset) = subtable.coverage_and_offset()?;
             subtable_info.digest.add_coverage(&coverage);
-            entry.digest.add_coverage(&coverage);
+            entry.digest.union(&subtable_info.digest);
             subtable_info.coverage_offset = coverage_offset;
             self.subtables.push(subtable_info);
             entry.subtables_count += 1;

--- a/src/hb/set_digest.rs
+++ b/src/hb/set_digest.rs
@@ -39,6 +39,12 @@ impl hb_set_digest_t {
         Self { masks: [ALL; N] }
     }
 
+    pub fn union(&mut self, other: &Self) {
+        for i in 0..N {
+            self.masks[i] |= other.masks[i];
+        }
+    }
+
     pub fn add(&mut self, g: GlyphId) {
         let gid = g.to_u32();
         for i in 0..N {


### PR DESCRIPTION
This is what HB does. No measurable perf found, but is improvement.