### PR TITLE
Precompute matcher state per lookup

### DIFF
--- a/src/hb/kerning.rs
+++ b/src/hb/kerning.rs
@@ -90,6 +90,7 @@ fn machine_kern(
     let mut ctx = hb_ot_apply_context_t::new(TableIndex::GPOS, face, buffer);
     ctx.set_lookup_mask(kern_mask);
     ctx.lookup_props = u32::from(lookup_flags::IGNORE_MARKS);
+    ctx.update_matchers();
 
     let horizontal = ctx.buffer.direction.is_horizontal();
 

--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -143,6 +143,7 @@ fn apply_string<T: LayoutTable>(ctx: &mut OT::hb_ot_apply_context_t, lookup: &Lo
     }
 
     ctx.lookup_props = lookup.props();
+    ctx.update_matchers();
 
     if !lookup.is_reverse() {
         // in/out forward substitution/positioning

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -209,64 +209,34 @@ pub enum may_skip_t {
     SKIP_MAYBE,
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Default)]
 pub struct matcher_t {
     lookup_props: u32,
     mask: hb_mask_t,
-    flags: u8,
-    syllable: u8,
+    ignore_zwnj: bool,
+    ignore_zwj: bool,
+    ignore_hidden: bool,
+    per_syllable: bool,
 }
 
 impl matcher_t {
-    const IGNORE_ZWNJ: u8 = 1;
-    const IGNORE_ZWJ: u8 = 2;
-    const IGNORE_HIDDEN: u8 = 4;
-    const PER_SYLLABLE: u8 = 8;
-
     fn new(ctx: &hb_ot_apply_context_t, context_match: bool) -> Self {
-        let mut flags = 0;
-        // Ignore ZWNJ if we are matching GPOS, or matching GSUB context and asked to.
-        if ctx.table_index == TableIndex::GPOS || (context_match && ctx.auto_zwnj) {
-            flags |= Self::IGNORE_ZWNJ;
-        }
-        // Ignore ZWJ if we are matching context, or asked to.
-        if context_match || ctx.auto_zwj {
-            flags |= Self::IGNORE_ZWJ;
-        }
-        // Ignore hidden glyphs (like CGJ) during GPOS.
-        if ctx.table_index == TableIndex::GPOS {
-            flags |= Self::IGNORE_HIDDEN;
-        }
-        /* Per syllable matching is only for GSUB. */
-        if ctx.table_index == TableIndex::GSUB && ctx.per_syllable {
-            flags |= Self::PER_SYLLABLE;
-        }
         matcher_t {
             lookup_props: ctx.lookup_props,
+            // Ignore ZWNJ if we are matching GPOS, or matching GSUB context and asked to.
+            ignore_zwnj: ctx.table_index == TableIndex::GPOS || (context_match && ctx.auto_zwnj),
+            // Ignore ZWJ if we are matching context, or asked to.
+            ignore_zwj: context_match || ctx.auto_zwj,
+            // Ignore hidden glyphs (like CGJ) during GPOS.
+            ignore_hidden: ctx.table_index == TableIndex::GPOS,
             mask: if context_match {
                 u32::MAX
             } else {
                 ctx.lookup_mask()
             },
-            flags,
-            syllable: 0,
+            /* Per syllable matching is only for GSUB. */
+            per_syllable: ctx.table_index == TableIndex::GSUB && ctx.per_syllable,
         }
-    }
-
-    fn ignore_zwnj(&self) -> bool {
-        self.flags & Self::IGNORE_ZWNJ != 0
-    }
-
-    fn ignore_zwj(&self) -> bool {
-        self.flags & Self::IGNORE_ZWJ != 0
-    }
-
-    fn ignore_hidden(&self) -> bool {
-        self.flags & Self::IGNORE_HIDDEN != 0
-    }
-
-    fn per_syllable(&self) -> bool {
-        self.flags & Self::PER_SYLLABLE != 0
     }
 
     fn may_match(
@@ -274,9 +244,10 @@ impl matcher_t {
         info: &hb_glyph_info_t,
         glyph_data: u16,
         match_func: Option<&impl Fn(GlyphId, u16) -> bool>,
+        syllable: u8,
     ) -> may_match_t {
         if (info.mask & self.mask) == 0
-            || (self.per_syllable() && self.syllable != 0 && self.syllable != info.syllable())
+            || (self.per_syllable && syllable != 0 && syllable != info.syllable())
         {
             return may_match_t::MATCH_NO;
         }
@@ -292,15 +263,15 @@ impl matcher_t {
         may_match_t::MATCH_MAYBE
     }
 
-    fn may_skip(&self, info: &hb_glyph_info_t, face: &hb_font_t) -> may_skip_t {
-        if !check_glyph_property(face, info, self.lookup_props) {
+    fn may_skip(&self, info: &hb_glyph_info_t, face: &hb_font_t, lookup_props: u32) -> may_skip_t {
+        if !check_glyph_property(face, info, lookup_props) {
             return may_skip_t::SKIP_YES;
         }
 
         if _hb_glyph_info_is_default_ignorable(info)
-            && (self.ignore_zwnj() || !_hb_glyph_info_is_zwnj(info))
-            && (self.ignore_zwj() || !_hb_glyph_info_is_zwj(info))
-            && (self.ignore_hidden() || !_hb_glyph_info_is_hidden(info))
+            && (self.ignore_zwnj || !_hb_glyph_info_is_zwnj(info))
+            && (self.ignore_zwj || !_hb_glyph_info_is_zwj(info))
+            && (self.ignore_hidden || !_hb_glyph_info_is_hidden(info))
         {
             return may_skip_t::SKIP_MAYBE;
         }
@@ -318,11 +289,13 @@ impl matcher_t {
 pub struct skipping_iterator_t<'a, 'b, F> {
     buffer: &'a hb_buffer_t,
     face: &'a hb_font_t<'b>,
-    matcher: matcher_t,
+    matcher: &'a matcher_t,
     buf_len: usize,
     glyph_data: u16,
     pub(crate) buf_idx: usize,
     match_func: Option<F>,
+    lookup_props: u32,
+    syllable: u8,
 }
 
 impl<'a, 'b> skipping_iterator_t<'a, 'b, fn(GlyphId, u16) -> bool> {
@@ -341,9 +314,9 @@ where
         match_fn: Option<F>,
     ) -> Self {
         let matcher = if context_match {
-            ctx.context_matcher
+            &ctx.context_matcher
         } else {
-            ctx.matcher
+            &ctx.matcher
         };
         skipping_iterator_t {
             buffer: ctx.buffer,
@@ -353,6 +326,8 @@ where
             buf_idx: 0,
             matcher,
             match_func: match_fn,
+            lookup_props: matcher.lookup_props,
+            syllable: 0,
         }
     }
 
@@ -365,7 +340,7 @@ where
     }
 
     pub fn set_lookup_props(&mut self, lookup_props: u32) {
-        self.matcher.lookup_props = lookup_props;
+        self.lookup_props = lookup_props;
     }
 
     pub fn index(&self) -> usize {
@@ -439,7 +414,7 @@ where
     pub fn reset(&mut self, start_index: usize) {
         self.buf_idx = start_index;
         self.buf_len = self.buffer.len;
-        self.matcher.syllable = if self.buf_idx == self.buffer.idx {
+        self.syllable = if self.buf_idx == self.buffer.idx {
             self.buffer.cur(0).syllable()
         } else {
             0
@@ -452,20 +427,23 @@ where
     }
 
     pub fn may_skip(&self, info: &hb_glyph_info_t) -> may_skip_t {
-        self.matcher.may_skip(info, self.face)
+        self.matcher.may_skip(info, self.face, self.lookup_props)
     }
 
     #[inline]
     pub fn match_(&self, info: &hb_glyph_info_t) -> match_t {
-        let skip = self.matcher.may_skip(info, self.face);
+        let skip = self.matcher.may_skip(info, self.face, self.lookup_props);
 
         if skip == may_skip_t::SKIP_YES {
             return match_t::SKIP;
         }
 
-        let _match = self
-            .matcher
-            .may_match(info, self.glyph_data, self.match_func.as_ref());
+        let _match = self.matcher.may_match(
+            info,
+            self.glyph_data,
+            self.match_func.as_ref(),
+            self.syllable,
+        );
 
         if _match == may_match_t::MATCH_YES
             || (_match == may_match_t::MATCH_MAYBE && skip == may_skip_t::SKIP_NO)


### PR DESCRIPTION
Store these in the context and keep a reference on skipping_iterator_t