### PR TITLE
Experiment: check overhead of read-fonts

### DIFF
--- a/src/hb/ot/gpos/mod.rs
+++ b/src/hb/ot/gpos/mod.rs
@@ -3,7 +3,7 @@
 use crate::{hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t, GlyphPosition};
 use read_fonts::{
     tables::{
-        gpos::{DeviceOrVariationIndex, ValueRecord},
+        gpos::{DeviceOrVariationIndex, ValueFormat, ValueRecord},
         variations::DeltaSetIndex,
     },
     FontData, ReadError,
@@ -13,6 +13,132 @@ mod cursive;
 mod mark;
 mod pair;
 mod single;
+
+pub(crate) use pair::{apply_pair_pos1, apply_pair_pos2};
+
+struct ValueReader<'a> {
+    data: FontData<'a>,
+    parent_offset: usize,
+    offset: usize,
+    format: ValueFormat,
+}
+
+impl<'a> ValueReader<'a> {
+    pub fn new(
+        data: FontData<'a>,
+        parent_offset: usize,
+        offset: usize,
+        format: ValueFormat,
+    ) -> Self {
+        Self {
+            data,
+            parent_offset,
+            offset,
+            format,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.format.is_empty()
+    }
+
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, idx: usize) -> bool {
+        let mut pos = ctx.buffer.pos[idx];
+        let worked = self.apply_to_pos(ctx, &mut pos);
+        ctx.buffer.pos[idx] = pos;
+        worked == Some(true)
+    }
+
+    fn apply_to_pos(
+        &self,
+        ctx: &mut hb_ot_apply_context_t,
+        pos: &mut GlyphPosition,
+    ) -> Option<bool> {
+        let horizontal = ctx.buffer.direction.is_horizontal();
+        let mut worked = false;
+        let mut offset = self.offset;
+        if self.format.contains(ValueFormat::X_PLACEMENT) {
+            let value = self.data.read_at::<i16>(offset).ok()?;
+            offset += 2;
+            if value != 0 {
+                pos.x_offset += value as i32;
+                worked = true;
+            }
+        }
+        if self.format.contains(ValueFormat::Y_PLACEMENT) {
+            let value = self.data.read_at::<i16>(offset).ok()?;
+            offset += 2;
+            if value != 0 {
+                pos.y_offset += value as i32;
+                worked = true;
+            }
+        }
+        if self.format.contains(ValueFormat::X_ADVANCE) {
+            if horizontal {
+                let value = self.data.read_at::<i16>(offset).ok()?;
+                if value != 0 {
+                    pos.x_advance += value as i32;
+                    worked = true;
+                }
+            }
+            offset += 2;
+        }
+        if self.format.contains(ValueFormat::Y_ADVANCE) {
+            if !horizontal {
+                let value = self.data.read_at::<i16>(offset).ok()?;
+                if value != 0 {
+                    // y_advance values grow downward but font-space grows upward, hence negation
+                    pos.y_advance -= value as i32;
+                    worked = true;
+                }
+            }
+            offset += 2;
+        }
+        if let (false, Some(vs)) = (
+            ctx.face.ot_tables.coords.is_empty(),
+            ctx.face.ot_tables.var_store.as_ref(),
+        ) {
+            let coords = ctx.face.ot_tables.coords;
+            let delta = |offset: usize| {
+                let rec_offset =
+                    self.parent_offset + self.data.read_at::<u16>(offset).ok()? as usize;
+                let format = self.data.read_at::<u16>(rec_offset + 4).ok()?;
+                if format != 0x8000 {
+                    return Some(0);
+                }
+                let outer = self.data.read_at::<u16>(rec_offset).ok()?;
+                let inner = self.data.read_at::<u16>(rec_offset + 2).ok()?;
+                vs.compute_delta(DeltaSetIndex { outer, inner }, coords)
+                    .ok()
+            };
+            if self.format.contains(ValueFormat::X_PLACEMENT_DEVICE) {
+                pos.x_offset += delta(offset).unwrap_or_default();
+                offset += 2;
+                worked = true;
+            }
+            if self.format.contains(ValueFormat::Y_PLACEMENT_DEVICE) {
+                pos.y_offset += delta(offset).unwrap_or_default();
+                offset += 2;
+                worked = true;
+            }
+            if self.format.contains(ValueFormat::X_ADVANCE_DEVICE) {
+                if horizontal {
+                    pos.x_advance += delta(offset).unwrap_or_default();
+                    worked = true;
+                }
+                offset += 2;
+            }
+            if self.format.contains(ValueFormat::Y_ADVANCE_DEVICE) {
+                if !horizontal {
+                    // y_advance values grow downward but face-space grows upward, hence negation
+                    pos.y_advance -= delta(offset).unwrap_or_default();
+                    worked = true;
+                }
+            }
+        }
+        Some(worked)
+    }
+}
 
 struct Value<'a> {
     record: ValueRecord,

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -4,7 +4,8 @@ use crate::hb::ot_layout_gsubgpos::{
     WouldApplyContext,
 };
 use read_fonts::tables::gsub::{Ligature, LigatureSet, LigatureSubstFormat1};
-use read_fonts::types::GlyphId;
+use read_fonts::types::{BigEndian, GlyphId, GlyphId16};
+use read_fonts::FontData;
 
 // TODO HarfBuzz caches coverage ala PairPos1
 
@@ -147,4 +148,142 @@ impl Apply for LigatureSubstFormat1<'_> {
             .and_then(|index| self.ligature_sets().get(index as usize).ok())
             .and_then(|set| set.apply(ctx))
     }
+}
+
+struct LigSet<'a> {
+    data: FontData<'a>,
+    base: usize,
+    count: usize,
+}
+
+impl<'a> LigSet<'a> {
+    fn new(table_data: &'a [u8], base: usize, coverage_index: usize) -> Option<Self> {
+        let data = FontData::new(table_data);
+        let base = base + data.read_at::<u16>(base + 6 + coverage_index * 2).ok()? as usize;
+        let count = data.read_at::<u16>(base).ok()? as usize;
+        Some(Self { data, base, count })
+    }
+
+    fn check_first_component(
+        &self,
+        index: usize,
+        glyph_id: GlyphId,
+        out_comp_count: &mut usize,
+    ) -> Option<bool> {
+        let lig_base =
+            self.base + self.data.read_at::<u16>(self.base + 2 + index * 2).ok()? as usize;
+        let comp_count = (self.data.read_at::<u16>(lig_base + 2).ok()? as usize).checked_sub(1)?;
+        *out_comp_count = comp_count;
+        if comp_count == 0
+            || self.data.read_at::<u16>(lig_base + 4).ok()? as u32 == glyph_id.to_u32()
+        {
+            return Some(true);
+        }
+        None
+    }
+
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, index: usize) -> Option<()> {
+        let lig_base =
+            self.base + self.data.read_at::<u16>(self.base + 2 + index * 2).ok()? as usize;
+        let comp_count = (self.data.read_at::<u16>(lig_base + 2).ok()? as usize).checked_sub(1)?;
+        let components = self
+            .data
+            .read_array::<BigEndian<GlyphId16>>(lig_base + 4..lig_base + 4 + comp_count * 2)
+            .ok()?;
+        if components.is_empty() {
+            let liga_glyph = self.data.read_at::<u16>(lig_base).ok()? as u32;
+            ctx.replace_glyph(liga_glyph.into());
+            Some(())
+        } else {
+            let f = |glyph, index| {
+                let value = components.get(index as usize).unwrap().get().to_u16();
+                match_glyph(glyph, value)
+            };
+            let mut match_end = 0;
+            let mut match_positions = smallvec::SmallVec::from_elem(0, 4);
+            let mut total_component_count = 0;
+            if !match_input(
+                ctx,
+                components.len() as u16,
+                f,
+                &mut match_end,
+                &mut match_positions,
+                Some(&mut total_component_count),
+            ) {
+                ctx.buffer
+                    .unsafe_to_concat(Some(ctx.buffer.idx), Some(match_end));
+                return None;
+            }
+            let liga_glyph = self.data.read_at::<u16>(lig_base).ok()? as u32;
+            let count = components.len() + 1;
+            ligate_input(
+                ctx,
+                count,
+                &match_positions,
+                match_end,
+                total_component_count,
+                liga_glyph.into(),
+            );
+            Some(())
+        }
+    }
+}
+
+pub fn apply_ligature_set(
+    ctx: &mut hb_ot_apply_context_t,
+    table_data: &[u8],
+    base: usize,
+    coverage_index: usize,
+) -> Option<()> {
+    let set = LigSet::new(table_data, base, coverage_index)?;
+    let mut first = GlyphId::new(u32::MAX);
+    let mut unsafe_to = 0;
+    let slow_path = if set.count <= 4 {
+        true
+    } else {
+        let mut iter = skipping_iterator_t::new(ctx, false);
+        iter.reset(ctx.buffer.idx);
+        let matched = iter.next(Some(&mut unsafe_to));
+        if !matched {
+            true
+        } else {
+            first = ctx.buffer.info[iter.index()].glyph_id.into();
+            unsafe_to = iter.index() + 1;
+
+            // Can't use the fast path if eg. the next char is a default-ignorable
+            // or other skippable.
+            iter.may_skip(&ctx.buffer.info[iter.index()]) != may_skip_t::SKIP_NO
+        }
+    };
+
+    if slow_path {
+        // Slow path
+        for i in 0..set.count {
+            if set.apply(ctx, i).is_some() {
+                return Some(());
+            }
+        }
+    } else {
+        // Fast path
+        let mut unsafe_to_concat = false;
+        for i in 0..set.count {
+            let mut comp_count = 0;
+            if set.check_first_component(i, first, &mut comp_count) == Some(true) {
+                if set.apply(ctx, i).is_some() {
+                    if unsafe_to_concat {
+                        ctx.buffer
+                            .unsafe_to_concat(Some(ctx.buffer.idx), Some(unsafe_to));
+                    }
+                    return Some(());
+                }
+            } else if comp_count != 0 {
+                unsafe_to_concat = true;
+            }
+        }
+        if unsafe_to_concat {
+            ctx.buffer
+                .unsafe_to_concat(Some(ctx.buffer.idx), Some(unsafe_to));
+        }
+    }
+    None
 }

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -229,7 +229,7 @@ impl<'a> LigSet<'a> {
     }
 }
 
-pub fn apply_ligature_set(
+pub fn apply_lig_subst1(
     ctx: &mut hb_ot_apply_context_t,
     table_data: &[u8],
     base: usize,

--- a/src/hb/ot/gsub/mod.rs
+++ b/src/hb/ot/gsub/mod.rs
@@ -6,4 +6,4 @@ mod multiple;
 mod reverse_chain;
 mod single;
 
-pub(crate) use ligature::apply_ligature_set;
+pub(crate) use ligature::apply_lig_subst1;

--- a/src/hb/ot/gsub/mod.rs
+++ b/src/hb/ot/gsub/mod.rs
@@ -5,3 +5,5 @@ mod ligature;
 mod multiple;
 mod reverse_chain;
 mod single;
+
+pub(crate) use ligature::apply_ligature_set;


### PR DESCRIPTION
This does some ugly hand rolled parsing of the ligature table. No unsafe, so this is meant to measure the straight overhead of read-fonts style parsing for lookup subtables.

Based on #108 but this one should not be merged. For measurement only.