### PR TITLE
Check coverage before reading subtables

### DIFF
--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -1,5 +1,5 @@
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{skipping_iterator_t, Apply};
+use crate::hb::ot_layout_gsubgpos::{skipping_iterator_t, Apply, ApplyState};
 use read_fonts::tables::gpos::{PairPosFormat1, PairPosFormat2, PairValueRecord};
 use read_fonts::types::GlyphId;
 use read_fonts::FontData;
@@ -9,9 +9,8 @@ use super::Value;
 // TODO: HarfBuzz uses two class caches, for left and right, as well as coverage.
 
 impl Apply for PairPosFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let first_glyph = ctx.buffer.cur(0).as_glyph();
-        let first_glyph_coverage_index = self.coverage().ok()?.get(first_glyph)?;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let first_glyph_coverage_index = state.index;
 
         let mut iter = skipping_iterator_t::new(ctx, false);
         iter.reset(ctx.buffer.idx);
@@ -123,9 +122,8 @@ fn find_second_glyph<'a>(
 }
 
 impl Apply for PairPosFormat2<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let first_glyph = ctx.buffer.cur(0).as_glyph();
-        self.coverage().ok()?.get(first_glyph)?;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let first_glyph = state.glyph;
 
         let mut iter = skipping_iterator_t::new(ctx, false);
         iter.reset(ctx.buffer.idx);

--- a/src/hb/ot/gpos/single.rs
+++ b/src/hb/ot/gpos/single.rs
@@ -1,12 +1,10 @@
 use super::Value;
-use crate::hb::ot_layout_gsubgpos::Apply;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
+use crate::hb::ot_layout_gsubgpos::{Apply, ApplyState};
 use read_fonts::tables::gpos::{SinglePosFormat1, SinglePosFormat2};
 
 impl Apply for SinglePosFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        self.coverage().ok()?.get(glyph)?;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, _state: &ApplyState) -> Option<()> {
         let record = self.value_record();
         let value = Value {
             record,
@@ -19,10 +17,8 @@ impl Apply for SinglePosFormat1<'_> {
 }
 
 impl Apply for SinglePosFormat2<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        let index = self.coverage().ok()?.get(glyph)? as usize;
-        let record = self.value_records().get(index).ok()?;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let record = self.value_records().get(state.index).ok()?;
         let value = Value {
             record,
             data: self.offset_data(),

--- a/src/hb/ot/gsub/alternate.rs
+++ b/src/hb/ot/gsub/alternate.rs
@@ -1,9 +1,9 @@
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{Apply, WouldApply, WouldApplyContext};
+use crate::hb::ot_layout_gsubgpos::{Apply, ApplyState, WouldApply, WouldApplyContext};
 use read_fonts::tables::gsub::{AlternateSet, AlternateSubstFormat1};
 
 impl Apply for AlternateSet<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, _state: &ApplyState) -> Option<()> {
         let alternates = self.alternate_glyph_ids();
         let len = alternates.len() as u16;
         if len == 0 {
@@ -41,10 +41,8 @@ impl WouldApply for AlternateSubstFormat1<'_> {
 }
 
 impl Apply for AlternateSubstFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        let index = self.coverage().ok()?.get(glyph)?;
-        let set = self.alternate_sets().get(index as usize).ok()?;
-        set.apply(ctx)
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let set = self.alternate_sets().get(state.index).ok()?;
+        set.apply(ctx, state)
     }
 }

--- a/src/hb/ot/gsub/multiple.rs
+++ b/src/hb/ot/gsub/multiple.rs
@@ -4,7 +4,7 @@ use crate::hb::ot_layout::{
     _hb_glyph_info_set_lig_props_for_component,
 };
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{Apply, WouldApply, WouldApplyContext};
+use crate::hb::ot_layout_gsubgpos::{Apply, ApplyState, WouldApply, WouldApplyContext};
 use read_fonts::tables::gsub::MultipleSubstFormat1;
 
 impl WouldApply for MultipleSubstFormat1<'_> {
@@ -17,10 +17,12 @@ impl WouldApply for MultipleSubstFormat1<'_> {
 }
 
 impl Apply for MultipleSubstFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let gid = ctx.buffer.cur(0).as_glyph();
-        let index = self.coverage().ok()?.get(gid)? as usize;
-        let substs = self.sequences().get(index).ok()?.substitute_glyph_ids();
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let substs = self
+            .sequences()
+            .get(state.index)
+            .ok()?
+            .substitute_glyph_ids();
         match substs.len() {
             // Spec disallows this, but Uniscribe allows it.
             // https://github.com/harfbuzz/harfbuzz/issues/253

--- a/src/hb/ot/gsub/single.rs
+++ b/src/hb/ot/gsub/single.rs
@@ -1,5 +1,5 @@
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{Apply, WouldApply, WouldApplyContext};
+use crate::hb::ot_layout_gsubgpos::{Apply, ApplyState, WouldApply, WouldApplyContext};
 use read_fonts::tables::gsub::{SingleSubstFormat1, SingleSubstFormat2};
 
 impl WouldApply for SingleSubstFormat1<'_> {
@@ -10,10 +10,8 @@ impl WouldApply for SingleSubstFormat1<'_> {
 }
 
 impl Apply for SingleSubstFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        self.coverage().ok()?.get(glyph)?;
-        let subst = (glyph.to_u32() as i32 + self.delta_glyph_id() as i32) as u16;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let subst = (state.glyph.to_u32() as i32 + self.delta_glyph_id() as i32) as u16;
         ctx.replace_glyph(subst.into());
         Some(())
     }
@@ -29,10 +27,8 @@ impl WouldApply for SingleSubstFormat2<'_> {
 }
 
 impl Apply for SingleSubstFormat2<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        let index = self.coverage().ok()?.get(glyph)? as usize;
-        let subst = self.substitute_glyph_ids().get(index)?.get().to_u16();
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let subst = self.substitute_glyph_ids().get(state.index)?.get().to_u16();
         ctx.replace_glyph(subst.into());
         Some(())
     }

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -9,6 +9,7 @@ use super::ot_layout_common::*;
 use super::unicode::hb_unicode_general_category_t;
 use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use read_fonts::tables::layout::SequenceLookupRecord;
+use read_fonts::tables::varc::CoverageTable;
 use read_fonts::types::GlyphId;
 
 /// Value represents glyph id.
@@ -605,7 +606,14 @@ pub trait WouldApply {
 /// Apply a lookup.
 pub trait Apply {
     /// Apply the lookup.
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()>;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()>;
+}
+
+#[derive(Clone)]
+pub struct ApplyState<'a> {
+    pub glyph: GlyphId,
+    pub coverage: CoverageTable<'a>,
+    pub index: usize,
 }
 
 pub struct WouldApplyContext<'a> {


### PR DESCRIPTION
The intent is to avoid both redundant and unnecessary work. For each subtable, before doing the full parse, read the primary coverage table and then compute the index for the current glyph. If successful, bundle up the glyph, coverage table and coverage index so we can pass that data on to the subtable apply function. If unsuccessful, don't parse the subtable at all.