### PR TITLE
Pass `&mut hb_glyph_info_t` to match functions

### DIFF
--- a/src/hb/ot/contextual.rs
+++ b/src/hb/ot/contextual.rs
@@ -1,4 +1,5 @@
 use super::{coverage_index, covered, glyph_class};
+use crate::hb::buffer::hb_glyph_info_t;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
     apply_lookup, match_backtrack, match_glyph, match_input, match_lookahead, may_skip_t,
@@ -29,7 +30,11 @@ impl WouldApply for SequenceContextFormat1<'_> {
                         let input = rule.input_sequence();
                         ctx.glyphs.len() == input.len() + 1
                             && input.iter().enumerate().all(|(i, value)| {
-                                match_glyph(ctx.glyphs[i + 1], value.get().to_u16())
+                                let info = hb_glyph_info_t {
+                                    glyph_id: ctx.glyphs[i + 1].into(),
+                                    ..hb_glyph_info_t::default()
+                                };
+                                match_glyph(&info, value.get().to_u16())
                             })
                     })
                     .unwrap_or(false)
@@ -62,10 +67,13 @@ impl WouldApply for SequenceContextFormat2<'_> {
                     rule.map(|rule| {
                         let input = rule.input_sequence();
                         ctx.glyphs.len() == input.len() + 1
-                            && input
-                                .iter()
-                                .enumerate()
-                                .all(|(i, value)| match_fn(ctx.glyphs[i + 1], value.get()))
+                            && input.iter().enumerate().all(|(i, value)| {
+                                let info = hb_glyph_info_t {
+                                    glyph_id: ctx.glyphs[i + 1].into(),
+                                    ..hb_glyph_info_t::default()
+                                };
+                                match_fn(&info, value.get())
+                            })
                     })
                     .unwrap_or(false)
                 })
@@ -100,10 +108,10 @@ impl Apply for SequenceContextFormat3<'_> {
         let glyph = ctx.buffer.cur(0).as_glyph();
         let input_coverages = self.coverages();
         input_coverages.get(0).ok()?.get(glyph)?;
-        let input = |glyph: GlyphId, index: u16| {
+        let input = |info: &hb_glyph_info_t, index: u16| {
             input_coverages
                 .get(index as usize + 1)
-                .is_ok_and(|cov| cov.get(glyph).is_some())
+                .is_ok_and(|cov| cov.get(info.glyph_id).is_some())
         };
         let mut match_end = 0;
         let mut match_positions = smallvec::SmallVec::from_elem(0, 4);
@@ -152,7 +160,11 @@ impl WouldApply for ChainedSequenceContextFormat1<'_> {
                                 && rule.lookahead_glyph_count() == 0))
                             && ctx.glyphs.len() == input.len() + 1
                             && input.iter().enumerate().all(|(i, value)| {
-                                match_glyph(ctx.glyphs[i + 1], value.get().to_u16())
+                                let info = hb_glyph_info_t {
+                                    glyph_id: ctx.glyphs[i + 1].into(),
+                                    ..hb_glyph_info_t::default()
+                                };
+                                match_glyph(&info, value.get().to_u16())
                             })
                     })
                     .unwrap_or(false)
@@ -188,10 +200,13 @@ impl WouldApply for ChainedSequenceContextFormat2<'_> {
                             || (rule.backtrack_glyph_count() == 0
                                 && rule.lookahead_glyph_count() == 0))
                             && ctx.glyphs.len() == input.len() + 1
-                            && input
-                                .iter()
-                                .enumerate()
-                                .all(|(i, value)| match_fn(ctx.glyphs[i + 1], value.get()))
+                            && input.iter().enumerate().all(|(i, value)| {
+                                let info = hb_glyph_info_t {
+                                    glyph_id: ctx.glyphs[i + 1].into(),
+                                    ..hb_glyph_info_t::default()
+                                };
+                                match_fn(&info, value.get())
+                            })
                     })
                     .unwrap_or(false)
                 })
@@ -207,11 +222,13 @@ fn get_class(class_def: &ClassDef, gid: GlyphId) -> u16 {
 }
 
 /// Value represents glyph class.
-fn match_class<'a>(class_def: &'a Option<ClassDef<'a>>) -> impl Fn(GlyphId, u16) -> bool + 'a {
-    |glyph, value| {
+fn match_class<'a>(
+    class_def: &'a Option<ClassDef<'a>>,
+) -> impl Fn(&hb_glyph_info_t, u16) -> bool + 'a {
+    |&info, value| {
         class_def
             .as_ref()
-            .is_some_and(|class_def| get_class(class_def, glyph) == value)
+            .is_some_and(|class_def| get_class(class_def, info.as_glyph()) == value)
     }
 }
 
@@ -261,22 +278,22 @@ impl Apply for ChainedSequenceContextFormat3<'_> {
         let backtrack_coverages = self.backtrack_coverages();
         let lookahead_coverages = self.lookahead_coverages();
 
-        let back = |glyph: GlyphId, index: u16| {
+        let back = |info: &hb_glyph_info_t, index: u16| {
             backtrack_coverages
                 .get(index as usize)
-                .is_ok_and(|cov| cov.get(glyph).is_some())
+                .is_ok_and(|cov| cov.get(info.glyph_id).is_some())
         };
 
-        let ahead = |glyph: GlyphId, index: u16| {
+        let ahead = |info: &hb_glyph_info_t, index: u16| {
             lookahead_coverages
                 .get(index as usize)
-                .is_ok_and(|cov| cov.get(glyph).is_some())
+                .is_ok_and(|cov| cov.get(info.glyph_id).is_some())
         };
 
-        let input = |glyph: GlyphId, index: u16| {
+        let input = |info: &hb_glyph_info_t, index: u16| {
             input_coverages
                 .get(index as usize + 1)
-                .is_ok_and(|cov| cov.get(glyph).is_some())
+                .is_ok_and(|cov| cov.get(info.glyph_id).is_some())
         };
 
         let mut end_index = ctx.buffer.idx;
@@ -362,12 +379,12 @@ trait ContextRule<'a>: FontRead<'a> {
     fn apply(
         &self,
         ctx: &mut hb_ot_apply_context_t,
-        match_func: &impl Fn(GlyphId, u16) -> bool,
+        match_func: &impl Fn(&hb_glyph_info_t, u16) -> bool,
     ) -> Option<()> {
         let inputs = self.input();
-        let match_func = |glyph, index| {
+        let match_func = |info: &hb_glyph_info_t, index| {
             let value = inputs.get(index as usize).unwrap().to_u16();
-            match_func(glyph, value)
+            match_func(info, value)
         };
 
         let mut match_end = 0;
@@ -423,7 +440,7 @@ impl<'a> ContextRule<'a> for ClassSequenceRule<'a> {
 fn apply_context_rules<'a, 'b, R: ContextRule<'a>>(
     ctx: &mut hb_ot_apply_context_t,
     rules: &'b ArrayOfOffsets<'a, R, Offset16>,
-    match_func: impl Fn(GlyphId, u16) -> bool,
+    match_func: impl Fn(&hb_glyph_info_t, u16) -> bool,
 ) -> Option<()> {
     if rules.len() <= 4 {
         for rule in rules.iter().filter_map(|r| r.ok()) {
@@ -442,9 +459,9 @@ fn apply_context_rules<'a, 'b, R: ContextRule<'a>>(
     let mut unsafe_to2 = 0;
     let mut second = None;
     let first = if skippy_iter.next(None) {
-        let g1 = &skippy_iter.buffer.info[skippy_iter.index()];
+        let g1 = skippy_iter.index();
         unsafe_to = Some(skippy_iter.index() + 1);
-        if skippy_iter.may_skip(g1) != may_skip_t::SKIP_NO {
+        if skippy_iter.may_skip(&skippy_iter.buffer.info[g1]) != may_skip_t::SKIP_NO {
             // Can't use the fast path if eg. the next char is a default-ignorable
             // or other skippable.
             for rule in rules.iter().filter_map(|r| r.ok()) {
@@ -454,7 +471,7 @@ fn apply_context_rules<'a, 'b, R: ContextRule<'a>>(
             }
             return None;
         }
-        g1.as_glyph()
+        g1
     } else {
         // Failed to match a next glyph. Only try applying rules that have no
         // further impact.
@@ -470,22 +487,24 @@ fn apply_context_rules<'a, 'b, R: ContextRule<'a>>(
         return None;
     };
     let matched = skippy_iter.next(None);
-    let g2 = &skippy_iter.buffer.info[skippy_iter.index()];
-    if matched && skippy_iter.may_skip(g2) == may_skip_t::SKIP_NO {
-        second = Some(g2.as_glyph());
+    let g2 = skippy_iter.index();
+    if matched && skippy_iter.may_skip(&skippy_iter.buffer.info[g2]) == may_skip_t::SKIP_NO {
+        second = Some(g2);
         unsafe_to2 = skippy_iter.index() + 1;
     }
     for rule in rules.iter().filter_map(|r| r.ok()) {
         let inputs = rule.input();
-        let match_func2 = |glyph, index| {
+        let match_func2 = |info, index| {
             if let Some(value) = inputs.get(index as usize).map(|v| v.to_u16()) {
-                match_func(glyph, value)
+                match_func(info, value)
             } else {
                 false
             }
         };
-        if inputs.len() <= 1 || match_func2(first, 0) {
-            if second.is_none() || (inputs.len() <= 2 || match_func2(second.unwrap(), 1)) {
+        if inputs.len() <= 1 || match_func2(&ctx.buffer.info[first], 0) {
+            if second.is_none()
+                || (inputs.len() <= 2 || match_func2(&ctx.buffer.info[second.unwrap()], 1))
+            {
                 if rule.apply(ctx, &match_func).is_some() {
                     if let Some(unsafe_to) = unsafe_to {
                         ctx.buffer
@@ -509,7 +528,7 @@ trait ChainContextRule<'a>: ContextRule<'a> {
     fn backtrack(&self) -> &'a [Self::Input];
     fn lookahead(&self) -> &'a [Self::Input];
 
-    fn apply_chain<F: Fn(GlyphId, u16) -> bool>(
+    fn apply_chain<F: Fn(&hb_glyph_info_t, u16) -> bool>(
         &self,
         ctx: &mut hb_ot_apply_context_t,
         match_funcs: &[F; 3],
@@ -520,19 +539,19 @@ trait ChainContextRule<'a>: ContextRule<'a> {
 
         // NOTE: Whenever something in this method changes, we also need to
         // change it in the `apply` implementation for ChainedContextLookup.
-        let f1 = |glyph, index| {
+        let f1 = |info: &hb_glyph_info_t, index| {
             let value = (*backtrack.get(index as usize).unwrap()).to_u16();
-            match_funcs[0](glyph, value)
+            match_funcs[0](info, value)
         };
 
-        let f2 = |glyph, index| {
+        let f2 = |info: &hb_glyph_info_t, index| {
             let value = (*lookahead.get(index as usize).unwrap()).to_u16();
-            match_funcs[2](glyph, value)
+            match_funcs[2](info, value)
         };
 
-        let f3 = |glyph, index| {
+        let f3 = |info: &hb_glyph_info_t, index| {
             let value = (*input.get(index as usize).unwrap()).to_u16();
-            match_funcs[1](glyph, value)
+            match_funcs[1](info, value)
         };
 
         let mut end_index = ctx.buffer.idx;
@@ -626,7 +645,12 @@ impl<'a> ChainContextRule<'a> for ChainedClassSequenceRule<'a> {
     }
 }
 
-fn apply_chain_context_rules<'a, 'b, R: ChainContextRule<'a>, F: Fn(GlyphId, u16) -> bool>(
+fn apply_chain_context_rules<
+    'a,
+    'b,
+    R: ChainContextRule<'a>,
+    F: Fn(&hb_glyph_info_t, u16) -> bool,
+>(
     ctx: &mut hb_ot_apply_context_t,
     rules: &'b ArrayOfOffsets<'a, R, Offset16>,
     match_funcs: [F; 3],
@@ -652,9 +676,9 @@ fn apply_chain_context_rules<'a, 'b, R: ChainContextRule<'a>, F: Fn(GlyphId, u16
     let mut unsafe_to2 = 0;
     let mut second = None;
     let first = if skippy_iter.next(None) {
-        let g1 = &skippy_iter.buffer.info[skippy_iter.index()];
+        let g1 = skippy_iter.index();
         unsafe_to = Some(skippy_iter.index() + 1);
-        if skippy_iter.may_skip(g1) != may_skip_t::SKIP_NO {
+        if skippy_iter.may_skip(&skippy_iter.buffer.info[g1]) != may_skip_t::SKIP_NO {
             // Can't use the fast path if eg. the next char is a default-ignorable
             // or other skippable.
             for rule in rules.iter().filter_map(|r| r.ok()) {
@@ -664,7 +688,7 @@ fn apply_chain_context_rules<'a, 'b, R: ChainContextRule<'a>, F: Fn(GlyphId, u16
             }
             return None;
         }
-        g1.as_glyph()
+        g1
     } else {
         // Failed to match a next glyph. Only try applying rules that have no
         // further impact.
@@ -680,36 +704,37 @@ fn apply_chain_context_rules<'a, 'b, R: ChainContextRule<'a>, F: Fn(GlyphId, u16
         return None;
     };
     let matched = skippy_iter.next(None);
-    let g2 = &skippy_iter.buffer.info[skippy_iter.index()];
-    if matched && skippy_iter.may_skip(g2) == may_skip_t::SKIP_NO {
-        second = Some(g2.as_glyph());
+    let g2 = skippy_iter.index();
+    if matched && skippy_iter.may_skip(&skippy_iter.buffer.info[g2]) == may_skip_t::SKIP_NO {
+        second = Some(g2);
         unsafe_to2 = skippy_iter.index() + 1;
     }
     for rule in rules.iter().filter_map(|r| r.ok()) {
         let input = rule.input();
         let lookahead = rule.lookahead();
-        let match_input = |glyph, index: usize| {
+        let match_input = |info, index: usize| {
             input
                 .get(index)
-                .is_some_and(|v| match_funcs[1](glyph, v.to_u16()))
+                .is_some_and(|v| match_funcs[1](info, v.to_u16()))
         };
-        let match_lookahead = |glyph, index: usize| {
+        let match_lookahead = |info, index: usize| {
             lookahead
                 .get(index)
-                .is_some_and(|v| match_funcs[2](glyph, v.to_u16()))
+                .is_some_and(|v| match_funcs[2](info, v.to_u16()))
         };
         let len_p1 = (input.len() + 1).max(1);
         let matched_first = if len_p1 > 1 {
-            match_input(first, 0)
+            match_input(&ctx.buffer.info[first], 0)
         } else {
-            lookahead.is_empty() || match_lookahead(first, 0)
+            lookahead.is_empty() || match_lookahead(&ctx.buffer.info[first], 0)
         };
         if matched_first {
             let matched_second = if let Some(second) = second {
                 if len_p1 > 2 {
-                    match_input(second, 1)
+                    match_input(&ctx.buffer.info[second], 1)
                 } else {
-                    (lookahead.len() <= 2 - len_p1) || match_lookahead(second, 2 - len_p1)
+                    (lookahead.len() <= 2 - len_p1)
+                        || match_lookahead(&ctx.buffer.info[second], 2 - len_p1)
                 }
             } else {
                 true

--- a/src/hb/ot/gpos/mark.rs
+++ b/src/hb/ot/gpos/mark.rs
@@ -6,7 +6,7 @@ use crate::hb::ot_layout::{
 use crate::hb::ot_layout_common::lookup_flags;
 use crate::hb::ot_layout_gpos_table::attach_type;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{match_t, skipping_iterator_t, Apply};
+use crate::hb::ot_layout_gsubgpos::{match_t, skipping_iterator_t, Apply, MatchSource};
 use read_fonts::tables::gpos::{
     AnchorTable, MarkArray, MarkBasePosFormat1, MarkLigPosFormat1, MarkMarkPosFormat1,
 };
@@ -75,7 +75,7 @@ impl Apply for MarkBasePosFormat1<'_> {
 
         let mut j = iter.buffer.idx;
         while j > last_base_until as usize {
-            let mut _match = iter.match_(&iter.buffer.info[j - 1]);
+            let mut _match = iter.match_at(j - 1, MatchSource::Info);
             if _match == match_t::MATCH {
                 // https://github.com/harfbuzz/harfbuzz/issues/4124
                 if !accept(iter.buffer, j - 1)
@@ -231,7 +231,7 @@ impl Apply for MarkLigPosFormat1<'_> {
 
         let mut j = iter.buffer.idx;
         while j > last_base_until as usize {
-            let mut _match = iter.match_(&iter.buffer.info[j - 1]);
+            let mut _match = iter.match_at(j - 1, MatchSource::Info);
             if _match == match_t::MATCH {
                 last_base = j as i32 - 1;
                 break;

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -30,7 +30,7 @@ impl Apply for Ligature<'_> {
             ctx.replace_glyph(self.ligature_glyph().into());
             Some(())
         } else {
-            let f = |info: &hb_glyph_info_t, index| {
+            let f = |info: &mut hb_glyph_info_t, index| {
                 let value = components.get(index as usize).unwrap().get().to_u16();
                 match_glyph(info, value)
             };

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -1,3 +1,4 @@
+use crate::hb::buffer::hb_glyph_info_t;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
     ligate_input, match_glyph, match_input, may_skip_t, skipping_iterator_t, Apply, WouldApply,
@@ -29,9 +30,9 @@ impl Apply for Ligature<'_> {
             ctx.replace_glyph(self.ligature_glyph().into());
             Some(())
         } else {
-            let f = |glyph, index| {
+            let f = |info: &hb_glyph_info_t, index| {
                 let value = components.get(index as usize).unwrap().get().to_u16();
-                match_glyph(glyph, value)
+                match_glyph(info, value)
             };
 
             let mut match_end = 0;

--- a/src/hb/ot/gsub/reverse_chain.rs
+++ b/src/hb/ot/gsub/reverse_chain.rs
@@ -1,10 +1,10 @@
+use crate::hb::buffer::hb_glyph_info_t;
 use crate::hb::ot_layout::MAX_NESTING_LEVEL;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
     match_backtrack, match_lookahead, Apply, WouldApply, WouldApplyContext,
 };
 use read_fonts::tables::gsub::ReverseChainSingleSubstFormat1;
-use read_fonts::types::GlyphId;
 
 impl WouldApply for ReverseChainSingleSubstFormat1<'_> {
     fn would_apply(&self, ctx: &WouldApplyContext) -> bool {
@@ -37,19 +37,19 @@ impl Apply for ReverseChainSingleSubstFormat1<'_> {
         let backtrack_coverages = self.backtrack_coverages();
         let lookahead_coverages = self.lookahead_coverages();
 
-        let f1 = |glyph: GlyphId, index| {
+        let f1 = |info: &hb_glyph_info_t, index| {
             backtrack_coverages
                 .get(index as usize)
                 .ok()
-                .and_then(|coverage| coverage.get(glyph))
+                .and_then(|coverage| coverage.get(info.glyph_id))
                 .is_some()
         };
 
-        let f2 = |glyph: GlyphId, index| {
+        let f2 = |info: &hb_glyph_info_t, index| {
             lookahead_coverages
                 .get(index as usize)
                 .ok()
-                .and_then(|coverage| coverage.get(glyph))
+                .and_then(|coverage| coverage.get(info.glyph_id))
                 .is_some()
         };
 

--- a/src/hb/ot/gsub/reverse_chain.rs
+++ b/src/hb/ot/gsub/reverse_chain.rs
@@ -37,7 +37,7 @@ impl Apply for ReverseChainSingleSubstFormat1<'_> {
         let backtrack_coverages = self.backtrack_coverages();
         let lookahead_coverages = self.lookahead_coverages();
 
-        let f1 = |info: &hb_glyph_info_t, index| {
+        let f1 = |info: &mut hb_glyph_info_t, index| {
             backtrack_coverages
                 .get(index as usize)
                 .ok()
@@ -45,7 +45,7 @@ impl Apply for ReverseChainSingleSubstFormat1<'_> {
                 .is_some()
         };
 
-        let f2 = |info: &hb_glyph_info_t, index| {
+        let f2 = |info: &mut hb_glyph_info_t, index| {
             lookahead_coverages
                 .get(index as usize)
                 .ok()

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -12,14 +12,14 @@ use read_fonts::tables::layout::SequenceLookupRecord;
 use read_fonts::types::GlyphId;
 
 /// Value represents glyph id.
-pub fn match_glyph(glyph: GlyphId, value: u16) -> bool {
-    glyph.to_u32() == value as u32
+pub fn match_glyph(info: &hb_glyph_info_t, value: u16) -> bool {
+    info.glyph_id == value as u32
 }
 
 pub fn match_input(
     ctx: &mut hb_ot_apply_context_t,
     input_len: u16,
-    match_func: impl Fn(GlyphId, u16) -> bool,
+    match_func: impl Fn(&hb_glyph_info_t, u16) -> bool,
     end_position: &mut usize,
     match_positions: &mut smallvec::SmallVec<[usize; 4]>,
     p_total_component_count: Option<&mut u8>,
@@ -143,7 +143,7 @@ pub fn match_input(
 pub fn match_backtrack(
     ctx: &mut hb_ot_apply_context_t,
     backtrack_len: u16,
-    match_func: impl Fn(GlyphId, u16) -> bool,
+    match_func: impl Fn(&hb_glyph_info_t, u16) -> bool,
     match_start: &mut usize,
 ) -> bool {
     let mut iter = skipping_iterator_t::with_match_fn(ctx, true, Some(match_func));
@@ -165,7 +165,7 @@ pub fn match_backtrack(
 pub fn match_lookahead(
     ctx: &mut hb_ot_apply_context_t,
     lookahead_len: u16,
-    match_func: impl Fn(GlyphId, u16) -> bool,
+    match_func: impl Fn(&hb_glyph_info_t, u16) -> bool,
     start_index: usize,
     end_index: &mut usize,
 ) -> bool {
@@ -243,7 +243,7 @@ impl matcher_t {
         &self,
         info: &hb_glyph_info_t,
         glyph_data: u16,
-        match_func: Option<&impl Fn(GlyphId, u16) -> bool>,
+        match_func: Option<&impl Fn(&hb_glyph_info_t, u16) -> bool>,
         syllable: u8,
     ) -> may_match_t {
         if (info.mask & self.mask) == 0
@@ -253,7 +253,7 @@ impl matcher_t {
         }
 
         if let Some(match_func) = match_func {
-            return if match_func(info.as_glyph(), glyph_data) {
+            return if match_func(info, glyph_data) {
                 may_match_t::MATCH_YES
             } else {
                 may_match_t::MATCH_NO
@@ -298,7 +298,7 @@ pub struct skipping_iterator_t<'f, 'c, F> {
     syllable: u8,
 }
 
-impl<'f, 'c> skipping_iterator_t<'f, 'c, fn(GlyphId, u16) -> bool> {
+impl<'f, 'c> skipping_iterator_t<'f, 'c, fn(&hb_glyph_info_t, u16) -> bool> {
     pub fn new(ctx: &'c mut hb_ot_apply_context_t<'f>, context_match: bool) -> Self {
         Self::with_match_fn(ctx, context_match, None)
     }
@@ -306,7 +306,7 @@ impl<'f, 'c> skipping_iterator_t<'f, 'c, fn(GlyphId, u16) -> bool> {
 
 impl<'f, 'c, F> skipping_iterator_t<'f, 'c, F>
 where
-    F: Fn(GlyphId, u16) -> bool,
+    F: Fn(&hb_glyph_info_t, u16) -> bool,
 {
     pub fn with_match_fn(
         ctx: &'c mut hb_ot_apply_context_t<'f>,


### PR DESCRIPTION
Going with `mut` was fighting a losing battle with the borrow checker. I made it to passing `&hb_glyph_info_t`. My plan is to use `UnsafeCell` for free vars in `hb_glyph_info_t` so we can modify them without mutability.