### PR TITLE
[proof-of-concept] Show speedup using unsafe dynamic dispatch for subtables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@ A complete [harfbuzz](https://github.com/harfbuzz/harfbuzz) shaping algorithm po
 */
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// Forbidding unsafe code only applies to the lib
-// examples continue to use it, so this cannot be placed into Cargo.toml
-#![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
 extern crate alloc;


### PR DESCRIPTION
Speedups:
```
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0505         -0.0511           188           178           187           177
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          -0.0870         -0.0869           211           193           210           192
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           -0.1719         -0.1719            67            55            66            55
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        -0.1838         -0.1840            41            34            41            34
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.0552         -0.0565            21            20            21            20
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    -0.0694         -0.0707            28            26            28            26
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        -0.0759         -0.0749           234           217           233           216
OVERALL_GEOMEAN                                                                      -0.1006         -0.1009             0             0             0             0
```