### PR TITLE
[LookupInfo] inline apply()

### DIFF
--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -297,6 +297,7 @@ impl LookupInfo {
 }
 
 impl LookupInfo {
+    #[inline]
     pub(crate) fn apply(
         &self,
         ctx: &mut hb_ot_apply_context_t,


### PR DESCRIPTION
```
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0695         -0.0698           142           132           142           132
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          -0.0635         -0.0642           166           155           165           155
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           -0.0707         -0.0706            75            69            74            69
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        -0.0275         -0.0273            42            41            42            41
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.0183         -0.0180            23            23            23            22
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    -0.0111         -0.0117            31            30            30            30
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        -0.0120         -0.0110           256           253           254           252
OVERALL_GEOMEAN                                                                      -0.0393         -0.0393             0             0             0             0
```