### PR TITLE
[buffer] Inline next_glyph() and micro-optimize

### DIFF
--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -885,6 +885,7 @@ impl hb_buffer_t {
     /// Copies glyph at idx to output and advance idx.
     ///
     /// If there's no output, just advance idx.
+    #[inline]
     pub fn next_glyph(&mut self) {
         if self.have_output {
             if self.have_separate_output || self.out_len != self.idx {
@@ -892,7 +893,8 @@ impl hb_buffer_t {
                     return;
                 }
 
-                self.set_out_info(self.out_len, self.info[self.idx]);
+                let i = self.out_len;
+                self.out_info_mut()[i] = self.info[self.idx];
             }
 
             self.out_len += 1;


### PR DESCRIPTION
```
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0166         -0.0161           134           131           133           131
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          +0.0019         +0.0016           157           158           156           157
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           -0.0664         -0.0666            70            65            70            65
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        -0.0153         -0.0152            42            41            41            41
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.0307         -0.0303            23            22            23            22
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    -0.0243         -0.0239            31            30            31            30
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        -0.0306         -0.0302           260           252           259           251
OVERALL_GEOMEAN                                                                      -0.0262         -0.0260             0             0             0             0
```