### PR TITLE
[face] inline glyph_props

### DIFF
--- a/src/hb/face.rs
+++ b/src/hb/face.rs
@@ -347,6 +347,7 @@ impl<'a> crate::Shaper<'a> {
         GlyphNames::new(&self.font)
     }
 
+    #[inline]
     pub(crate) fn glyph_props(&self, glyph: GlyphId) -> u16 {
         let glyph = glyph.to_u32();
         match self.ot_tables.glyph_class(glyph) {


### PR DESCRIPTION
```
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0013         -0.0012           131           131           131           131
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          -0.0055         -0.0056           155           154           155           154
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           -0.0211         -0.0210            66            64            66            64
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        -0.0057         -0.0057            41            40            40            40
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.0188         -0.0185            22            22            22            22
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    -0.0173         -0.0170            30            30            30            29
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        -0.0337         -0.0334           255           246           254           245
OVERALL_GEOMEAN                                                                      -0.0148         -0.0147             0             0             0             0
```