### PR TITLE
Implement external caches for LigatureSubset & PairPos

### DIFF
--- a/src/hb/cache.rs
+++ b/src/hb/cache.rs
@@ -114,14 +114,17 @@ impl<const KEY_BITS: usize, const VALUE_BITS: usize, const CACHE_SIZE: usize, T:
     }
 
     #[inline]
-    pub fn set(&self, key: u32, value: u32) -> bool {
+    pub fn set(&self, key: u32, value: u32) {
         if (key >> KEY_BITS) != 0 || (value >> VALUE_BITS) != 0 {
-            return false;
+            return;
         }
+        self.set_unchecked(key, value);
+    }
 
+    #[inline]
+    pub fn set_unchecked(&self, key: u32, value: u32) {
         let index = (key as usize) & (CACHE_SIZE - 1);
         let packed = ((key >> (CACHE_SIZE as u32).ilog2()) << VALUE_BITS) | value;
         self.values[index].set(packed);
-        true
     }
 }

--- a/src/hb/cache.rs
+++ b/src/hb/cache.rs
@@ -75,6 +75,8 @@ pub struct hb_cache_core_t<
 impl<const KEY_BITS: usize, const VALUE_BITS: usize, const CACHE_SIZE: usize, T: AtomicStorage>
     hb_cache_core_t<KEY_BITS, VALUE_BITS, CACHE_SIZE, T>
 {
+    pub const MAX_VALUE: u32 = (1 << VALUE_BITS) - 1;
+
     pub fn new() -> Self {
         debug_assert!(
             CACHE_SIZE.is_power_of_two(),

--- a/src/hb/ot/contextual.rs
+++ b/src/hb/ot/contextual.rs
@@ -3,7 +3,7 @@ use crate::hb::buffer::hb_glyph_info_t;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
     apply_lookup, match_backtrack, match_glyph, match_input, match_lookahead, may_skip_t,
-    skipping_iterator_t, Apply, WouldApply, WouldApplyContext,
+    skipping_iterator_t, Apply, SubtableExternalCache, WouldApply, WouldApplyContext,
 };
 use read_fonts::tables::gsub::ClassDef;
 use read_fonts::tables::layout::{
@@ -90,7 +90,11 @@ impl Apply for SequenceContextFormat2<'_> {
         let set = self.class_seq_rule_sets().get(index)?.ok()?;
         apply_context_rules(ctx, &set.class_seq_rules(), match_class(&input_classes))
     }
-    fn apply_cached(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
+    fn apply_cached(
+        &self,
+        ctx: &mut hb_ot_apply_context_t,
+        _: &SubtableExternalCache,
+    ) -> Option<()> {
         let glyph = ctx.buffer.cur(0).as_gid16()?;
         self.coverage().ok()?.get(glyph)?;
         let input_classes = self.class_def().ok();
@@ -341,7 +345,11 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
             ),
         )
     }
-    fn apply_cached(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
+    fn apply_cached(
+        &self,
+        ctx: &mut hb_ot_apply_context_t,
+        _: &SubtableExternalCache,
+    ) -> Option<()> {
         let backtrack_classes = self.backtrack_class_def().ok();
         let input_classes = self.input_class_def().ok();
         let lookahead_classes = self.lookahead_class_def().ok();

--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -18,7 +18,7 @@ impl Apply for PairPosFormat1<'_> {
 
         let first_glyph_coverage_index =
             if let SubtableExternalCache::MappingCache(cache) = external_cache {
-                coverage_index_cached(self.coverage(), first_glyph, cache)?
+                coverage_index_cached(|gid| self.coverage().ok()?.get(gid), first_glyph, cache)?
             } else {
                 coverage_index(self.coverage(), first_glyph)?
             };
@@ -142,7 +142,11 @@ impl Apply for PairPosFormat2<'_> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
 
         let _ = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
-            coverage_index_cached(self.coverage(), first_glyph, &cache.coverage)?
+            coverage_index_cached(
+                |gid| self.coverage().ok()?.get(gid),
+                first_glyph,
+                &cache.coverage,
+            )?
         } else {
             coverage_index(self.coverage(), first_glyph)?
         };
@@ -201,12 +205,20 @@ impl Apply for PairPosFormat2<'_> {
             };
 
         let class1 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
-            glyph_class_cached(self.class_def1(), first_glyph, &cache.first)
+            glyph_class_cached(
+                |gid| glyph_class(self.class_def1(), gid),
+                first_glyph,
+                &cache.first,
+            )
         } else {
             glyph_class(self.class_def1(), first_glyph)
         };
         let class2 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
-            glyph_class_cached(self.class_def2(), second_glyph, &cache.second)
+            glyph_class_cached(
+                |gid| glyph_class(self.class_def2(), gid),
+                second_glyph,
+                &cache.second,
+            )
         } else {
             glyph_class(self.class_def2(), second_glyph)
         };

--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -141,22 +141,10 @@ impl Apply for PairPosFormat2<'_> {
     ) -> Option<()> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
 
-        let get_coverage = || {
-            self.coverage()
-                .ok()
-                .and_then(|coverage| coverage.get(first_glyph))
-        };
-
         let _ = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
-            if let Some(index) = cache.coverage.get(first_glyph.into()) {
-                index as u16
-            } else {
-                let index = get_coverage()?;
-                cache.coverage.set(first_glyph.into(), index as u32);
-                index
-            }
+            coverage_index_cached(self.coverage(), first_glyph, &cache.coverage)?
         } else {
-            get_coverage()?
+            coverage_index(self.coverage(), first_glyph)?
         };
 
         let mut iter = skipping_iterator_t::new(ctx, false);

--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -1,5 +1,5 @@
-use crate::hb::ot::coverage_index_cached;
-use crate::hb::ot::glyph_class_cached;
+use crate::hb::ot::{coverage_index, coverage_index_cached};
+use crate::hb::ot::{glyph_class, glyph_class_cached};
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{skipping_iterator_t, Apply, SubtableExternalCache};
 use read_fonts::tables::gpos::{PairPosFormat1, PairPosFormat2, PairValueRecord};
@@ -16,11 +16,12 @@ impl Apply for PairPosFormat1<'_> {
     ) -> Option<()> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
 
-        let SubtableExternalCache::MappingCache(cache) = external_cache else {
-            return None;
-        };
         let first_glyph_coverage_index =
-            coverage_index_cached(self.coverage(), first_glyph, cache)?;
+            if let SubtableExternalCache::MappingCache(cache) = external_cache {
+                coverage_index_cached(self.coverage(), first_glyph, cache)?
+            } else {
+                coverage_index(self.coverage(), first_glyph)?
+            };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
         iter.reset(iter.buffer.idx);
@@ -140,10 +141,11 @@ impl Apply for PairPosFormat2<'_> {
     ) -> Option<()> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
 
-        let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache else {
-            return None;
+        let _ = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
+            coverage_index_cached(self.coverage(), first_glyph, &cache.coverage)?
+        } else {
+            coverage_index(self.coverage(), first_glyph)?
         };
-        let _ = coverage_index_cached(self.coverage(), first_glyph, &cache.coverage)?;
 
         let mut iter = skipping_iterator_t::new(ctx, false);
         iter.reset(iter.buffer.idx);
@@ -198,8 +200,16 @@ impl Apply for PairPosFormat2<'_> {
                 success(ctx, iter_index, flag1, flag2, has_record2)
             };
 
-        let class1 = glyph_class_cached(self.class_def1(), first_glyph, &cache.first);
-        let class2 = glyph_class_cached(self.class_def2(), second_glyph, &cache.second);
+        let class1 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
+            glyph_class_cached(self.class_def1(), first_glyph, &cache.first)
+        } else {
+            glyph_class(self.class_def1(), first_glyph)
+        };
+        let class2 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
+            glyph_class_cached(self.class_def2(), second_glyph, &cache.second)
+        } else {
+            glyph_class(self.class_def2(), second_glyph)
+        };
 
         let data = self.offset_data();
         if let Ok(class2_record) = self

--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -1,17 +1,27 @@
+use crate::hb::ot::{coverage_index, coverage_index_cached};
+use crate::hb::ot::{glyph_class, glyph_class_cached};
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{skipping_iterator_t, Apply};
+use crate::hb::ot_layout_gsubgpos::{skipping_iterator_t, Apply, SubtableExternalCache};
 use read_fonts::tables::gpos::{PairPosFormat1, PairPosFormat2, PairValueRecord};
 use read_fonts::types::GlyphId;
 use read_fonts::FontData;
 
 use super::Value;
 
-// TODO: HarfBuzz uses two class caches, for left and right, as well as coverage.
-
 impl Apply for PairPosFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
+    fn apply_with_external_cache(
+        &self,
+        ctx: &mut hb_ot_apply_context_t,
+        external_cache: &SubtableExternalCache,
+    ) -> Option<()> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
-        let first_glyph_coverage_index = self.coverage().ok()?.get(first_glyph)?;
+
+        let first_glyph_coverage_index =
+            if let SubtableExternalCache::MappingCache(cache) = external_cache {
+                coverage_index_cached(self.coverage(), first_glyph, cache)?
+            } else {
+                coverage_index(self.coverage(), first_glyph)?
+            };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
         iter.reset(iter.buffer.idx);
@@ -124,9 +134,30 @@ fn find_second_glyph<'a>(
 }
 
 impl Apply for PairPosFormat2<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
+    fn apply_with_external_cache(
+        &self,
+        ctx: &mut hb_ot_apply_context_t,
+        external_cache: &SubtableExternalCache,
+    ) -> Option<()> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
-        self.coverage().ok()?.get(first_glyph)?;
+
+        let get_coverage = || {
+            self.coverage()
+                .ok()
+                .and_then(|coverage| coverage.get(first_glyph))
+        };
+
+        let _ = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
+            if let Some(index) = cache.coverage.get(first_glyph.into()) {
+                index as u16
+            } else {
+                let index = get_coverage()?;
+                cache.coverage.set(first_glyph.into(), index as u32);
+                index
+            }
+        } else {
+            get_coverage()?
+        };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
         iter.reset(iter.buffer.idx);
@@ -181,8 +212,16 @@ impl Apply for PairPosFormat2<'_> {
                 success(ctx, iter_index, flag1, flag2, has_record2)
             };
 
-        let class1 = super::super::glyph_class(self.class_def1(), first_glyph);
-        let class2 = super::super::glyph_class(self.class_def2(), second_glyph);
+        let class1 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
+            glyph_class_cached(self.class_def1(), first_glyph, &cache.first)
+        } else {
+            glyph_class(self.class_def1(), first_glyph)
+        };
+        let class2 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
+            glyph_class_cached(self.class_def2(), second_glyph, &cache.second)
+        } else {
+            glyph_class(self.class_def2(), second_glyph)
+        };
 
         let data = self.offset_data();
         if let Ok(class2_record) = self

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -147,7 +147,7 @@ impl Apply for LigatureSubstFormat1<'_> {
         let glyph = ctx.buffer.cur(0).as_glyph();
 
         let index = if let SubtableExternalCache::MappingCache(cache) = external_cache {
-            coverage_index_cached(self.coverage(), glyph, cache)?
+            coverage_index_cached(|gid| self.coverage().ok()?.get(gid), glyph, cache)?
         } else {
             coverage_index(self.coverage(), glyph)?
         };

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -1,5 +1,5 @@
 use crate::hb::buffer::hb_glyph_info_t;
-use crate::hb::ot::{coverage_index, coverage_index_cached};
+use crate::hb::ot::coverage_index_cached;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
     ligate_input, match_glyph, match_input, may_skip_t, skipping_iterator_t, Apply,
@@ -146,11 +146,10 @@ impl Apply for LigatureSubstFormat1<'_> {
     ) -> Option<()> {
         let glyph = ctx.buffer.cur(0).as_glyph();
 
-        let index = if let SubtableExternalCache::MappingCache(cache) = external_cache {
-            coverage_index_cached(self.coverage(), glyph, cache)?
-        } else {
-            coverage_index(self.coverage(), glyph)?
+        let SubtableExternalCache::MappingCache(cache) = external_cache else {
+            return None;
         };
+        let index = coverage_index_cached(self.coverage(), glyph, cache)?;
         self.ligature_sets()
             .get(index as usize)
             .ok()

--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::hb::{
     hb_font_t, hb_glyph_info_t,
     ot_layout_gsubgpos::{
@@ -7,7 +9,6 @@ use crate::hb::{
     set_digest::hb_set_digest_t,
 };
 
-use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::ops::Range;
 use read_fonts::{
@@ -94,7 +95,7 @@ pub struct LookupData<'a> {
 
 /// Cache containing lookup and subtable information for a single GSUB or
 /// GPOS table.
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub struct LookupCache {
     pub lookups: Vec<LookupInfo>,
     pub subtables: Vec<SubtableInfo>,
@@ -388,7 +389,6 @@ impl LookupInfo {
 }
 
 /// Cached information about a subtable.
-#[derive(Clone)]
 pub struct SubtableInfo {
     /// The fully resolved type of the subtable.
     pub kind: SubtableKind,
@@ -668,10 +668,10 @@ impl SubtableInfo {
         digest.add_coverage(&coverage);
         let external_cache = match kind {
             SubtableKind::LigatureSubst1 | SubtableKind::PairPos1 => {
-                SubtableExternalCache::MappingCache(Rc::new(MappingCache::new()))
+                SubtableExternalCache::MappingCache(Box::new(MappingCache::new()))
             }
             SubtableKind::PairPos2 => {
-                SubtableExternalCache::PairPosFormat2Cache(Rc::new(PairPosFormat2Cache::new()))
+                SubtableExternalCache::PairPosFormat2Cache(Box::new(PairPosFormat2Cache::new()))
             }
             _ => SubtableExternalCache::None,
         };

--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -1,9 +1,13 @@
 use crate::hb::{
     hb_font_t, hb_glyph_info_t,
-    ot_layout_gsubgpos::{Apply, WouldApply, WouldApplyContext, OT::hb_ot_apply_context_t},
+    ot_layout_gsubgpos::{
+        Apply, MappingCache, PairPosFormat2Cache, SubtableExternalCache, WouldApply,
+        WouldApplyContext, OT::hb_ot_apply_context_t,
+    },
     set_digest::hb_set_digest_t,
 };
 
+use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::ops::Range;
 use read_fonts::{
@@ -393,9 +397,11 @@ pub struct SubtableInfo {
     pub offset: u32,
     pub digest: hb_set_digest_t,
     pub apply_fns: [SubtableApplyFn; 2],
+    pub external_cache: SubtableExternalCache,
 }
 
-pub type SubtableApplyFn = fn(&mut hb_ot_apply_context_t, &[u8]) -> Option<()>;
+pub type SubtableApplyFn =
+    fn(&mut hb_ot_apply_context_t, &SubtableExternalCache, &[u8]) -> Option<()>;
 
 impl SubtableInfo {
     #[inline]
@@ -406,20 +412,28 @@ impl SubtableInfo {
         is_cached: bool,
     ) -> Option<()> {
         let subtable_data = table_data.get(self.offset as usize..)?;
-        self.apply_fns[is_cached as usize](ctx, subtable_data)
+        self.apply_fns[is_cached as usize](ctx, &self.external_cache, subtable_data)
     }
 }
 
 macro_rules! apply_fns {
     ($apply:ident, $apply_cached:ident, $ty:ident) => {
-        fn $apply(ctx: &mut hb_ot_apply_context_t, table_data: &[u8]) -> Option<()> {
+        fn $apply(
+            ctx: &mut hb_ot_apply_context_t,
+            external_cache: &SubtableExternalCache,
+            table_data: &[u8],
+        ) -> Option<()> {
             let t = $ty::read(FontData::new(table_data)).ok()?;
-            t.apply(ctx)
+            t.apply_with_external_cache(ctx, external_cache)
         }
 
-        fn $apply_cached(ctx: &mut hb_ot_apply_context_t, table_data: &[u8]) -> Option<()> {
+        fn $apply_cached(
+            ctx: &mut hb_ot_apply_context_t,
+            external_cache: &SubtableExternalCache,
+            table_data: &[u8],
+        ) -> Option<()> {
             let t = $ty::read(FontData::new(table_data)).ok()?;
-            t.apply_cached(ctx)
+            t.apply_cached(ctx, external_cache)
         }
     };
 }
@@ -652,12 +666,22 @@ impl SubtableInfo {
         };
         let mut digest = hb_set_digest_t::new();
         digest.add_coverage(&coverage);
+        let external_cache = match kind {
+            SubtableKind::LigatureSubst1 | SubtableKind::PairPos1 => {
+                SubtableExternalCache::MappingCache(Rc::new(MappingCache::new()))
+            }
+            SubtableKind::PairPos2 => {
+                SubtableExternalCache::PairPosFormat2Cache(Rc::new(PairPosFormat2Cache::new()))
+            }
+            _ => SubtableExternalCache::None,
+        };
         Some((
             SubtableInfo {
                 kind,
                 offset: subtable_offset,
                 digest,
                 apply_fns,
+                external_cache,
             },
             cache_cost,
         ))

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -460,7 +460,7 @@ fn coverage_index(coverage: Result<CoverageTable, ReadError>, gid: GlyphId) -> O
 }
 
 fn coverage_index_cached(
-    coverage: Result<CoverageTable, ReadError>,
+    coverage: impl Fn(GlyphId) -> Option<u16>,
     gid: GlyphId,
     cache: &MappingCache,
 ) -> Option<u16> {
@@ -471,7 +471,7 @@ fn coverage_index_cached(
             Some(index as u16)
         }
     } else {
-        let index = coverage_index(coverage, gid);
+        let index = coverage(gid);
         if index.is_none() {
             cache.set_unchecked(gid.into(), MappingCache::MAX_VALUE);
             return None;
@@ -498,14 +498,14 @@ fn glyph_class(class_def: Result<ClassDef, ReadError>, gid: GlyphId) -> u16 {
 }
 
 fn glyph_class_cached(
-    class_def: Result<ClassDef, ReadError>,
+    class_def: impl Fn(GlyphId) -> u16,
     gid: GlyphId,
     cache: &MappingCache,
 ) -> u16 {
     if let Some(index) = cache.get(gid.into()) {
         index as u16
     } else {
-        let index = glyph_class(class_def, gid);
+        let index = class_def(gid);
         cache.set(gid.into(), index as u32);
         index
     }

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -1,6 +1,7 @@
 use super::ot_layout::TableIndex;
 use super::{common::TagExt, set_digest::hb_set_digest_t};
 use crate::hb::hb_tag_t;
+use crate::hb::ot_layout_gsubgpos::MappingCache;
 use alloc::vec::Vec;
 use lookup::{LookupCache, LookupInfo};
 use read_fonts::{
@@ -458,6 +459,31 @@ fn coverage_index(coverage: Result<CoverageTable, ReadError>, gid: GlyphId) -> O
     coverage.ok().and_then(|coverage| coverage.get(gid))
 }
 
+fn coverage_index_cached(
+    coverage: Result<CoverageTable, ReadError>,
+    gid: GlyphId,
+    cache: &MappingCache,
+) -> Option<u16> {
+    if let Some(index) = cache.get(gid.into()) {
+        if index == MappingCache::MAX_VALUE {
+            None
+        } else {
+            Some(index as u16)
+        }
+    } else {
+        let index = coverage_index(coverage, gid);
+        if index.is_none() {
+            cache.set(gid.into(), MappingCache::MAX_VALUE);
+            return None;
+        }
+        let index = index.unwrap();
+        if (index as u32) < MappingCache::MAX_VALUE {
+            cache.set(gid.into(), index as u32);
+        }
+        Some(index)
+    }
+}
+
 fn covered(coverage: Result<CoverageTable, ReadError>, gid: GlyphId) -> bool {
     coverage_index(coverage, gid).is_some()
 }
@@ -469,4 +495,18 @@ fn glyph_class(class_def: Result<ClassDef, ReadError>, gid: GlyphId) -> u16 {
     class_def
         .map(|class_def| class_def.get(gid16))
         .unwrap_or_default()
+}
+
+fn glyph_class_cached(
+    class_def: Result<ClassDef, ReadError>,
+    gid: GlyphId,
+    cache: &MappingCache,
+) -> u16 {
+    if let Some(index) = cache.get(gid.into()) {
+        index as u16
+    } else {
+        let index = glyph_class(class_def, gid);
+        cache.set(gid.into(), index as u32);
+        index
+    }
 }

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -473,12 +473,12 @@ fn coverage_index_cached(
     } else {
         let index = coverage_index(coverage, gid);
         if index.is_none() {
-            cache.set(gid.into(), MappingCache::MAX_VALUE);
+            cache.set_unchecked(gid.into(), MappingCache::MAX_VALUE);
             return None;
         }
         let index = index.unwrap();
         if (index as u32) < MappingCache::MAX_VALUE {
-            cache.set(gid.into(), index as u32);
+            cache.set_unchecked(gid.into(), index as u32);
         }
         Some(index)
     }

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -474,13 +474,14 @@ fn coverage_index_cached(
         let index = coverage(gid);
         if index.is_none() {
             cache.set_unchecked(gid.into(), MappingCache::MAX_VALUE);
-            return None;
+            None
+        } else {
+            let index = index.unwrap();
+            if (index as u32) < MappingCache::MAX_VALUE {
+                cache.set_unchecked(gid.into(), index as u32);
+            }
+            Some(index)
         }
-        let index = index.unwrap();
-        if (index as u32) < MappingCache::MAX_VALUE {
-            cache.set_unchecked(gid.into(), index as u32);
-        }
-        Some(index)
     }
 }
 

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -9,7 +9,7 @@ use super::ot_layout::*;
 use super::ot_layout_common::*;
 use super::unicode::hb_unicode_general_category_t;
 use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
-use alloc::rc::Rc;
+use alloc::boxed::Box;
 use read_fonts::tables::layout::SequenceLookupRecord;
 use read_fonts::types::GlyphId;
 
@@ -635,11 +635,10 @@ impl PairPosFormat2Cache {
     }
 }
 
-#[derive(Clone)]
 pub(crate) enum SubtableExternalCache {
     None,
-    MappingCache(Rc<MappingCache>),
-    PairPosFormat2Cache(Rc<PairPosFormat2Cache>),
+    MappingCache(Box<MappingCache>),
+    PairPosFormat2Cache(Box<PairPosFormat2Cache>),
 }
 
 /// Apply a lookup.

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -2,12 +2,14 @@
 
 use super::buffer::hb_glyph_info_t;
 use super::buffer::{hb_buffer_t, GlyphPropsFlags};
+use super::cache::hb_cache_t;
 use super::hb_font_t;
 use super::hb_mask_t;
 use super::ot_layout::*;
 use super::ot_layout_common::*;
 use super::unicode::hb_unicode_general_category_t;
 use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
+use alloc::rc::Rc;
 use read_fonts::tables::layout::SequenceLookupRecord;
 use read_fonts::types::GlyphId;
 
@@ -610,16 +612,62 @@ pub trait WouldApply {
     fn would_apply(&self, ctx: &WouldApplyContext) -> bool;
 }
 
+pub(crate) type MappingCache = hb_cache_t<
+    15,  // KEY_BITS
+    8,   // VALUE_BITS
+    128, // CACHE_SIZE
+    16,  // STORAGE_BITS
+>;
+
+pub(crate) struct PairPosFormat2Cache {
+    pub coverage: MappingCache,
+    pub first: MappingCache,
+    pub second: MappingCache,
+}
+
+impl PairPosFormat2Cache {
+    pub fn new() -> Self {
+        PairPosFormat2Cache {
+            coverage: MappingCache::new(),
+            first: MappingCache::new(),
+            second: MappingCache::new(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum SubtableExternalCache {
+    None,
+    MappingCache(Rc<MappingCache>),
+    PairPosFormat2Cache(Rc<PairPosFormat2Cache>),
+}
+
 /// Apply a lookup.
 pub trait Apply {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()>;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
+        // Default implementation just calls `apply_with_external_cache`.
+        self.apply_with_external_cache(ctx, &SubtableExternalCache::None)
+    }
 
     // The rest are relevant to subtables only
 
-    fn apply_cached(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
+    fn apply_with_external_cache(
+        &self,
+        ctx: &mut hb_ot_apply_context_t,
+        _external_cache: &SubtableExternalCache,
+    ) -> Option<()> {
         // Default implementation just calls `apply`.
-        // This is used to apply the lookup with caching.
         self.apply(ctx)
+    }
+
+    fn apply_cached(
+        &self,
+        ctx: &mut hb_ot_apply_context_t,
+        external_cache: &SubtableExternalCache,
+    ) -> Option<()> {
+        // Default implementation just calls `apply_with_external_cache`.
+        // This is used to apply the lookup with glyph-info caching.
+        self.apply_with_external_cache(ctx, external_cache)
     }
 
     fn cache_cost(&self) -> u32 {


### PR DESCRIPTION
Needs Chad's cleanup, but amazing speedup on Roboto:
```
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0077         -0.0073           117           116           116           115
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          -0.0045         -0.0045           130           129           129           129
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           +0.0013         +0.0016            52            52            51            51
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        -0.0201         -0.0200            33            33            33            33
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.2917         -0.2915            20            14            20            14
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    -0.1963         -0.1967            26            21            26            21
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        -0.2708         -0.2728           217           158           215           157
OVERALL_GEOMEAN                                                                      -0.1220         -0.1222             0             0             0             0

```