### PR TITLE
Defer parsing coverage/classdef for external caches

### DIFF
--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -18,7 +18,7 @@ impl Apply for PairPosFormat1<'_> {
 
         let first_glyph_coverage_index =
             if let SubtableExternalCache::MappingCache(cache) = external_cache {
-                coverage_index_cached(self.coverage(), first_glyph, cache)?
+                coverage_index_cached(|gid| self.coverage().ok()?.get(gid), first_glyph, cache)?
             } else {
                 coverage_index(self.coverage(), first_glyph)?
             };
@@ -142,7 +142,11 @@ impl Apply for PairPosFormat2<'_> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
 
         let _ = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
-            coverage_index_cached(self.coverage(), first_glyph, &cache.coverage)?
+            coverage_index_cached(
+                |gid| self.coverage().ok()?.get(gid),
+                first_glyph,
+                &cache.coverage,
+            )?
         } else {
             coverage_index(self.coverage(), first_glyph)?
         };
@@ -201,12 +205,20 @@ impl Apply for PairPosFormat2<'_> {
             };
 
         let class1 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
-            glyph_class_cached(self.class_def1(), first_glyph, &cache.first)
+            glyph_class_cached(
+                |gid| glyph_class(self.class_def1(), gid),
+                first_glyph,
+                &cache.first,
+            )
         } else {
             glyph_class(self.class_def1(), first_glyph)
         };
         let class2 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
-            glyph_class_cached(self.class_def2(), second_glyph, &cache.second)
+            glyph_class_cached(
+                |gid| glyph_class(self.class_def2(), gid),
+                second_glyph,
+                &cache.second,
+            )
         } else {
             glyph_class(self.class_def2(), second_glyph)
         };

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -147,7 +147,7 @@ impl Apply for LigatureSubstFormat1<'_> {
         let glyph = ctx.buffer.cur(0).as_glyph();
 
         let index = if let SubtableExternalCache::MappingCache(cache) = external_cache {
-            coverage_index_cached(self.coverage(), glyph, cache)?
+            coverage_index_cached(|gid| self.coverage().ok()?.get(gid), glyph, cache)?
         } else {
             coverage_index(self.coverage(), glyph)?
         };

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -460,7 +460,7 @@ fn coverage_index(coverage: Result<CoverageTable, ReadError>, gid: GlyphId) -> O
 }
 
 fn coverage_index_cached(
-    coverage: Result<CoverageTable, ReadError>,
+    coverage: impl Fn(GlyphId) -> Option<u16>,
     gid: GlyphId,
     cache: &MappingCache,
 ) -> Option<u16> {
@@ -471,7 +471,7 @@ fn coverage_index_cached(
             Some(index as u16)
         }
     } else {
-        let index = coverage_index(coverage, gid);
+        let index = coverage(gid);
         if index.is_none() {
             cache.set_unchecked(gid.into(), MappingCache::MAX_VALUE);
             return None;
@@ -498,14 +498,14 @@ fn glyph_class(class_def: Result<ClassDef, ReadError>, gid: GlyphId) -> u16 {
 }
 
 fn glyph_class_cached(
-    class_def: Result<ClassDef, ReadError>,
+    class_def: impl Fn(GlyphId) -> u16,
     gid: GlyphId,
     cache: &MappingCache,
 ) -> u16 {
     if let Some(index) = cache.get(gid.into()) {
         index as u16
     } else {
-        let index = glyph_class(class_def, gid);
+        let index = class_def(gid);
         cache.set(gid.into(), index as u32);
         index
     }


### PR DESCRIPTION
Instead of passing a parsed `CoverageTable` or `ClassDef`, send a closure instead that only reads those tables on a cache miss. In my measurements, this buys us a little bit more from the Latin benches.

Based on #134