### PR TITLE
Always inline check_glyph_property

### DIFF
--- a/src/hb/mod.rs
+++ b/src/hb/mod.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::wildcard_in_or_patterns)]
 #![allow(clippy::identity_op)]
+#![allow(clippy::inline_always)]
 #![allow(clippy::mut_range_bound)]
 #![allow(clippy::enum_variant_names)]
 #![allow(clippy::manual_range_patterns)]

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -711,6 +711,7 @@ pub mod OT {
         true
     }
 
+    #[inline(always)]
     pub fn check_glyph_property(
         face: &hb_font_t,
         info: &hb_glyph_info_t,


### PR DESCRIPTION
```
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0435         -0.0439           117           112           117           111
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          -0.0434         -0.0438           132           126           131           126
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           -0.0995         -0.0993            54            49            54            49
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        -0.0107         -0.0106            32            32            32            32
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.0159         -0.0159            14            14            14            13
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    +0.0009         +0.0010            20            20            20            20
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        -0.0054         -0.0048           148           147           147           146
OVERALL_GEOMEAN                                                                      -0.0316         -0.0316             0             0             0             0
```