### PR TITLE
Cache glyph props

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["benches/", "tests/"]
 bitflags = "2.9"
 bytemuck = { version = "1.22", features = ["extern_crate_alloc"] }
 core_maths = "0.1" # only for no_std builds
-read-fonts = { version = "0.31.3", default-features = false, features = ["libm"] }
+read-fonts = { path = "../fontations/read-fonts", default-features = false, features = ["libm"] }
 smallvec = "1.14"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["benches/", "tests/"]
 bitflags = "2.9"
 bytemuck = { version = "1.22", features = ["extern_crate_alloc"] }
 core_maths = "0.1" # only for no_std builds
-read-fonts = { path = "../fontations/read-fonts", default-features = false, features = ["libm"] }
+read-fonts = { version = "0.31.1", default-features = false, features = ["libm"] }
 smallvec = "1.14"
 
 [features]

--- a/src/hb/aat/layout_common.rs
+++ b/src/hb/aat/layout_common.rs
@@ -38,7 +38,7 @@ impl<'a> AatApplyContext<'a> {
             if self.has_glyph_classes {
                 self.buffer
                     .cur_mut(0)
-                    .set_glyph_props(self.face.glyph_props(glyph.into()));
+                    .set_glyph_props(self.face.ot_tables.glyph_props(glyph.into()));
             }
         }
         self.buffer.output_glyph(glyph);
@@ -53,7 +53,7 @@ impl<'a> AatApplyContext<'a> {
         if self.has_glyph_classes {
             self.buffer
                 .cur_mut(0)
-                .set_glyph_props(self.face.glyph_props(glyph.into()));
+                .set_glyph_props(self.face.ot_tables.glyph_props(glyph.into()));
         }
         self.buffer.replace_glyph(glyph);
     }
@@ -67,7 +67,7 @@ impl<'a> AatApplyContext<'a> {
     pub fn replace_glyph_inplace(&mut self, i: usize, glyph: u32) {
         self.buffer.info[i].glyph_id = glyph;
         if self.has_glyph_classes {
-            self.buffer.info[i].set_glyph_props(self.face.glyph_props(glyph.into()));
+            self.buffer.info[i].set_glyph_props(self.face.ot_tables.glyph_props(glyph.into()));
         }
     }
 }

--- a/src/hb/cache.rs
+++ b/src/hb/cache.rs
@@ -128,3 +128,17 @@ impl<const KEY_BITS: usize, const VALUE_BITS: usize, const CACHE_SIZE: usize, T:
         self.values[index].set(packed);
     }
 }
+
+impl<const KEY_BITS: usize, const VALUE_BITS: usize, const CACHE_SIZE: usize, T: AtomicStorage>
+    Clone for hb_cache_core_t<KEY_BITS, VALUE_BITS, CACHE_SIZE, T>
+{
+    fn clone(&self) -> Self {
+        Self {
+            values: core::array::from_fn(|i| {
+                let t = T::default();
+                t.set(self.values[i].get());
+                t
+            }),
+        }
+    }
+}

--- a/src/hb/cache.rs
+++ b/src/hb/cache.rs
@@ -128,17 +128,3 @@ impl<const KEY_BITS: usize, const VALUE_BITS: usize, const CACHE_SIZE: usize, T:
         self.values[index].set(packed);
     }
 }
-
-impl<const KEY_BITS: usize, const VALUE_BITS: usize, const CACHE_SIZE: usize, T: AtomicStorage>
-    Clone for hb_cache_core_t<KEY_BITS, VALUE_BITS, CACHE_SIZE, T>
-{
-    fn clone(&self) -> Self {
-        Self {
-            values: core::array::from_fn(|i| {
-                let t = T::default();
-                t.set(self.values[i].get());
-                t
-            }),
-        }
-    }
-}

--- a/src/hb/face.rs
+++ b/src/hb/face.rs
@@ -3,7 +3,6 @@ use read_fonts::{FontRef, TableProvider};
 use smallvec::SmallVec;
 
 use super::aat::AatTables;
-use super::buffer::GlyphPropsFlags;
 use super::charmap::{cache_t as cmap_cache_t, Charmap};
 use super::glyph_metrics::GlyphMetrics;
 use super::glyph_names::GlyphNames;
@@ -345,20 +344,6 @@ impl<'a> crate::Shaper<'a> {
 
     pub(crate) fn glyph_names(&self) -> GlyphNames<'a> {
         GlyphNames::new(&self.font)
-    }
-
-    #[inline]
-    pub(crate) fn glyph_props(&self, glyph: GlyphId) -> u16 {
-        let glyph = glyph.to_u32();
-        match self.ot_tables.glyph_class(glyph) {
-            1 => GlyphPropsFlags::BASE_GLYPH.bits(),
-            2 => GlyphPropsFlags::LIGATURE.bits(),
-            3 => {
-                let class = self.ot_tables.glyph_mark_attachment_class(glyph);
-                (class << 8) | GlyphPropsFlags::MARK.bits()
-            }
-            _ => 0,
-        }
     }
 
     pub(crate) fn layout_table(&self, table_index: TableIndex) -> Option<LayoutTable<'a>> {

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -26,6 +26,7 @@ pub mod lookup;
 pub struct OtCache {
     pub gsub: LookupCache,
     pub gpos: LookupCache,
+    pub gdef_glyph_props_cache: MappingCache,
     pub gdef_mark_set_digests: Vec<hb_set_digest_t>,
 }
 
@@ -60,6 +61,7 @@ impl OtCache {
         Self {
             gsub,
             gpos,
+            gdef_glyph_props_cache: MappingCache::new(),
             gdef_mark_set_digests,
         }
     }
@@ -133,7 +135,7 @@ pub struct OtTables<'a> {
     pub gsub: Option<GsubTable<'a>>,
     pub gpos: Option<GposTable<'a>>,
     pub gdef: GdefTable<'a>,
-    pub gdef_glyph_props_cache: MappingCache,
+    pub gdef_glyph_props_cache: &'a MappingCache,
     pub gdef_mark_set_digests: &'a [hb_set_digest_t],
     pub coords: &'a [F2Dot14],
     pub var_store: Option<ItemVariationStore<'a>>,
@@ -166,7 +168,7 @@ impl<'a> OtTables<'a> {
             gsub,
             gpos,
             gdef,
-            gdef_glyph_props_cache: MappingCache::new(),
+            gdef_glyph_props_cache: &cache.gdef_glyph_props_cache,
             gdef_mark_set_digests: &cache.gdef_mark_set_digests,
             var_store,
             coords,

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -1,3 +1,4 @@
+use super::buffer::GlyphPropsFlags;
 use super::ot_layout::TableIndex;
 use super::{common::TagExt, set_digest::hb_set_digest_t};
 use crate::hb::hb_tag_t;
@@ -186,6 +187,19 @@ impl<'a> OtTables<'a> {
             .mark_classes
             .as_ref()
             .map_or(0, |class_def| class_def.get((glyph_id as u16).into()))
+    }
+
+    pub(crate) fn glyph_props(&self, glyph: GlyphId) -> u16 {
+        let glyph = glyph.to_u32();
+        match self.glyph_class(glyph) {
+            1 => GlyphPropsFlags::BASE_GLYPH.bits(),
+            2 => GlyphPropsFlags::LIGATURE.bits(),
+            3 => {
+                let class = self.glyph_mark_attachment_class(glyph);
+                (class << 8) | GlyphPropsFlags::MARK.bits()
+            }
+            _ => 0,
+        }
     }
 
     pub fn is_mark_glyph(&self, glyph_id: u32, set_index: u16) -> bool {

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -196,7 +196,7 @@ impl<'a> OtTables<'a> {
     pub(crate) fn glyph_props(&self, glyph: GlyphId) -> u16 {
         let glyph = glyph.to_u32();
 
-        if let Some(props) = self.gdef_glyph_props_cache.get(glyph.into()) {
+        if let Some(props) = self.gdef_glyph_props_cache.get(glyph) {
             return props as u16;
         }
 
@@ -210,7 +210,7 @@ impl<'a> OtTables<'a> {
             _ => 0,
         };
 
-        self.gdef_glyph_props_cache.set(glyph.into(), props as u32);
+        self.gdef_glyph_props_cache.set(glyph, props as u32);
 
         props
     }

--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -85,7 +85,7 @@ pub fn _hb_ot_layout_set_glyph_props(face: &hb_font_t, buffer: &mut hb_buffer_t)
 
     let len = buffer.len;
     for info in &mut buffer.info[..len] {
-        info.set_glyph_props(face.glyph_props(info.as_glyph()));
+        info.set_glyph_props(face.ot_tables.glyph_props(info.as_glyph()));
         info.set_lig_props(0);
     }
 }

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -874,7 +874,7 @@ pub mod OT {
 
             if has_glyph_classes {
                 props &= GlyphPropsFlags::PRESERVE.bits();
-                cur.set_glyph_props(props | self.face.glyph_props(glyph_id));
+                cur.set_glyph_props(props | self.face.ot_tables.glyph_props(glyph_id));
             } else if !class_guess.is_empty() {
                 props &= GlyphPropsFlags::PRESERVE.bits();
                 cur.set_glyph_props(props | class_guess.bits());


### PR DESCRIPTION
The `cache.rs` changes need an expert to do properly.

```
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0211         -0.0216           118           115           117           115
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          -0.0058         -0.0054           131           130           130           129
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           -0.0123         -0.0129            53            52            53            52
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        -0.0040         -0.0035            32            32            32            32
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.0461         -0.0460            14            13            14            13
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    +0.0265         +0.0271            20            20            20            20
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        -0.0271         -0.0267           146           142           145           141
OVERALL_GEOMEAN                                                                      -0.0131         -0.0130             0             0             0             0
```