### PR TITLE
Check lookup digest before anything else

### DIFF
--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -271,9 +271,6 @@ impl LookupInfo {
         use_hot_subtable_cache: bool,
     ) -> Option<()> {
         let glyph = ctx.buffer.cur(0).as_glyph();
-        if !self.digest.may_have_glyph(glyph) {
-            return None;
-        }
         for (subtable_idx, subtable_info) in cache.subtables(self)?.iter().enumerate() {
             if !subtable_info.digest.may_have_glyph(glyph) {
                 continue;

--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -217,7 +217,8 @@ fn apply_forward(ctx: &mut OT::hb_ot_apply_context_t, lookup: &LookupInfo) -> bo
 
     while ctx.buffer.idx < ctx.buffer.len && ctx.buffer.successful {
         let cur = ctx.buffer.cur(0);
-        if (cur.mask & ctx.lookup_mask()) != 0
+        if lookup.digest.may_have_glyph(cur.as_glyph())
+            && (cur.mask & ctx.lookup_mask()) != 0
             && check_glyph_property(ctx.face, cur, ctx.lookup_props)
             && lookup
                 .apply(ctx, table_data, lookups, use_hot_subtable_cache)


### PR DESCRIPTION
This is the optimal order, and how HB does it.
```
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0406         -0.0396           110           105           109           105
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          -0.0164         -0.0162           123           121           122           120
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           -0.0497         -0.0494            47            45            47            44
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        -0.0191         -0.0188            29            28            29            28
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.0088         -0.0083            11            11            11            11
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    -0.0114         -0.0114            16            15            16            15
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        +0.0105         +0.0103           108           109           107           108
OVERALL_GEOMEAN                                                                      -0.0195         -0.0192             0             0             0             0
```