### PR TITLE
Err. Gate apply_backward with set-digest again

### DIFF
--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -245,7 +245,8 @@ fn apply_backward(ctx: &mut OT::hb_ot_apply_context_t, lookup: &LookupInfo) -> b
     };
     loop {
         let cur = ctx.buffer.cur(0);
-        ret |= (cur.mask & ctx.lookup_mask()) != 0
+        ret |= lookup.digest.may_have_glyph(cur.as_glyph())
+            && (cur.mask & ctx.lookup_mask()) != 0
             && check_glyph_property(ctx.face, cur, ctx.lookup_props)
             && lookup.apply(ctx, table_data, lookups, false).is_some();
 


### PR DESCRIPTION
Was dropped in d286ebc2a7307291cd48fd5bc3f64b26b2a5d178