### PR TITLE
Add UnicodeBuffer::ensure() to pre-allocate buffer

### DIFF
--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -1694,6 +1694,11 @@ impl UnicodeBuffer {
         self.0.len
     }
 
+    /// Ensures that the buffer can hold at least `size` codepoints.
+    pub fn ensure(&mut self, size: usize) -> bool {
+        self.0.ensure(size)
+    }
+
     /// Returns `true` if the buffer contains no elements.
     #[inline]
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
I measure 1% speedup by calling this from hb-harfrust.