### PR TITLE
Ligature seconds digest

### DIFF
--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -17,8 +17,8 @@ impl Apply for PairPosFormat1<'_> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
 
         let first_glyph_coverage_index =
-            if let SubtableExternalCache::MappingCache(cache) = external_cache {
-                coverage_index_cached(|gid| self.coverage().ok()?.get(gid), first_glyph, cache)?
+            if let SubtableExternalCache::PairPosFormat1Cache(cache) = external_cache {
+                coverage_index_cached(|gid| self.coverage().ok()?.get(gid), first_glyph, &cache.coverage)?
             } else {
                 coverage_index(self.coverage(), first_glyph)?
             };

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -5,6 +5,7 @@ use crate::hb::ot_layout_gsubgpos::{
     ligate_input, match_always, match_glyph, match_input, may_skip_t, skipping_iterator_t, Apply,
     LigatureSubstFormat1Cache, SubtableExternalCache, WouldApply, WouldApplyContext,
 };
+use crate::hb::set_digest::hb_set_digest_t;
 use alloc::boxed::Box;
 use read_fonts::tables::gsub::{Ligature, LigatureSet, LigatureSubstFormat1};
 use read_fonts::types::GlyphId;
@@ -74,9 +75,13 @@ impl WouldApply for LigatureSet<'_> {
     }
 }
 
-impl Apply for LigatureSet<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let mut first = GlyphId::new(u32::MAX);
+pub trait ApplyLigatureSet {
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, seconds: &hb_set_digest_t) -> Option<()>;
+}
+
+impl ApplyLigatureSet for LigatureSet<'_> {
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, seconds: &hb_set_digest_t) -> Option<()> {
+        let mut second = GlyphId::new(u32::MAX);
         let mut unsafe_to = 0;
         let ligatures = self.ligatures();
         let slow_path = if ligatures.len() <= 1 {
@@ -88,7 +93,7 @@ impl Apply for LigatureSet<'_> {
             if !matched {
                 true
             } else {
-                first = iter.buffer.info[iter.index()].glyph_id.into();
+                second = iter.buffer.info[iter.index()].glyph_id.into();
                 unsafe_to = iter.index() + 1;
 
                 // Can't use the fast path if eg. the next char is a default-ignorable
@@ -106,10 +111,13 @@ impl Apply for LigatureSet<'_> {
             }
         } else {
             // Fast path
+            if !seconds.may_have_glyph(second) {
+                return None;
+            }
             let mut unsafe_to_concat = false;
             for lig in ligatures.iter().filter_map(|lig| lig.ok()) {
                 let components = lig.component_glyph_ids();
-                if components.is_empty() || components[0].get() == first {
+                if components.is_empty() || components[0].get() == second {
                     if lig.apply(ctx).is_some() {
                         if unsafe_to_concat {
                             ctx.buffer
@@ -154,13 +162,38 @@ impl Apply for LigatureSubstFormat1<'_> {
         } else {
             coverage_index(self.coverage(), glyph)?
         };
+        let seconds =
+            if let SubtableExternalCache::LigatureSubstFormat1Cache(cache) = external_cache {
+                &cache.seconds
+            } else {
+                &hb_set_digest_t::full()
+            };
         self.ligature_sets()
             .get(index as usize)
             .ok()
-            .and_then(|set| set.apply(ctx))
+            .and_then(|set| set.apply(ctx, seconds))
     }
 
     fn external_cache_create(&self) -> SubtableExternalCache {
-        SubtableExternalCache::LigatureSubstFormat1Cache(Box::new(LigatureSubstFormat1Cache::new()))
+        let mut seconds = hb_set_digest_t::new();
+        self.ligature_sets()
+            .iter()
+            .filter_map(Result::ok)
+            .for_each(|lig_set| {
+                lig_set
+                    .ligatures()
+                    .iter()
+                    .filter_map(Result::ok)
+                    .for_each(|lig| {
+                        seconds.add(if let Some(gid) = lig.component_glyph_ids().first() {
+                            gid.get().into()
+                        } else {
+                            GlyphId::new(0)
+                        });
+                    });
+            });
+        SubtableExternalCache::LigatureSubstFormat1Cache(Box::new(LigatureSubstFormat1Cache::new(
+            seconds,
+        )))
     }
 }

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -147,8 +147,8 @@ impl Apply for LigatureSubstFormat1<'_> {
     ) -> Option<()> {
         let glyph = ctx.buffer.cur(0).as_glyph();
 
-        let index = if let SubtableExternalCache::MappingCache(cache) = external_cache {
-            coverage_index_cached(|gid| self.coverage().ok()?.get(gid), glyph, cache)?
+        let index = if let SubtableExternalCache::LigatureSubstFormat1Cache(cache) = external_cache {
+            coverage_index_cached(|gid| self.coverage().ok()?.get(gid), glyph, &cache.coverage)?
         } else {
             coverage_index(self.coverage(), glyph)?
         };

--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -3,7 +3,7 @@ use alloc::boxed::Box;
 use crate::hb::{
     hb_font_t, hb_glyph_info_t,
     ot_layout_gsubgpos::{
-        Apply, MappingCache, PairPosFormat2Cache, SubtableExternalCache, WouldApply,
+        Apply, LigatureSubstFormat1Cache, PairPosFormat1Cache, PairPosFormat2Cache, SubtableExternalCache, WouldApply,
         WouldApplyContext, OT::hb_ot_apply_context_t,
     },
     set_digest::hb_set_digest_t,
@@ -664,8 +664,11 @@ impl SubtableInfo {
         let mut digest = hb_set_digest_t::new();
         digest.add_coverage(&coverage);
         let external_cache = match kind {
-            SubtableKind::LigatureSubst1 | SubtableKind::PairPos1 => {
-                SubtableExternalCache::MappingCache(Box::new(MappingCache::new()))
+            SubtableKind::LigatureSubst1 => {
+                SubtableExternalCache::LigatureSubstFormat1Cache(Box::new(LigatureSubstFormat1Cache::new()))
+            }
+            SubtableKind::PairPos1 => {
+                SubtableExternalCache::PairPosFormat1Cache(Box::new(PairPosFormat1Cache::new()))
             }
             SubtableKind::PairPos2 => {
                 SubtableExternalCache::PairPosFormat2Cache(Box::new(PairPosFormat2Cache::new()))

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -7,6 +7,7 @@ use super::hb_font_t;
 use super::hb_mask_t;
 use super::ot_layout::*;
 use super::ot_layout_common::*;
+use super::set_digest::hb_set_digest_t;
 use super::unicode::hb_unicode_general_category_t;
 use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use alloc::boxed::Box;
@@ -625,12 +626,14 @@ pub(crate) type MappingCache = hb_cache_t<
 
 pub(crate) struct LigatureSubstFormat1Cache {
     pub coverage: MappingCache,
+    pub seconds: hb_set_digest_t,
 }
 
 impl LigatureSubstFormat1Cache {
-    pub fn new() -> Self {
+    pub fn new(seconds: hb_set_digest_t) -> Self {
         LigatureSubstFormat1Cache {
             coverage: MappingCache::new(),
+            seconds,
         }
     }
 }

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -623,6 +623,30 @@ pub(crate) type MappingCache = hb_cache_t<
     16,  // STORAGE_BITS
 >;
 
+pub(crate) struct LigatureSubstFormat1Cache {
+    pub coverage: MappingCache,
+}
+
+impl LigatureSubstFormat1Cache {
+    pub fn new() -> Self {
+        LigatureSubstFormat1Cache {
+            coverage: MappingCache::new(),
+        }
+    }
+}
+
+pub(crate) struct PairPosFormat1Cache {
+    pub coverage: MappingCache,
+}
+
+impl PairPosFormat1Cache {
+    pub fn new() -> Self {
+        PairPosFormat1Cache {
+            coverage: MappingCache::new(),
+        }
+    }
+}
+
 pub(crate) struct PairPosFormat2Cache {
     pub coverage: MappingCache,
     pub first: MappingCache,
@@ -641,7 +665,8 @@ impl PairPosFormat2Cache {
 
 pub(crate) enum SubtableExternalCache {
     None,
-    MappingCache(Box<MappingCache>),
+    LigatureSubstFormat1Cache(Box<LigatureSubstFormat1Cache>),
+    PairPosFormat1Cache(Box<PairPosFormat1Cache>),
     PairPosFormat2Cache(Box<PairPosFormat2Cache>),
 }
 

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -703,6 +703,12 @@ pub trait Apply {
         // This is used to determine the cost of caching the subtable.
         0
     }
+
+    fn external_cache_create(&self) -> SubtableExternalCache {
+        // Default implementation returns None, meaning no external cache.
+        // This is used to create an external cache for the subtable.
+        SubtableExternalCache::None
+    }
 }
 
 pub struct WouldApplyContext<'a> {

--- a/src/hb/set_digest.rs
+++ b/src/hb/set_digest.rs
@@ -35,7 +35,7 @@ impl hb_set_digest_t {
         self.masks = [0; N];
     }
 
-    pub fn _full() -> Self {
+    pub fn full() -> Self {
         Self { masks: [ALL; N] }
     }
 


### PR DESCRIPTION
From https://github.com/harfbuzz/harfbuzz/pull/5464
```
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0046         -0.0036           109           109           109           108
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          -0.0083         -0.0084           129           128           128           127
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           -0.0091         -0.0089            46            45            45            45
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        +0.0024         +0.0023            28            28            28            28
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.0895         -0.0892            10             9            10             9
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    -0.0919         -0.0919            15            13            15            13
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        +0.0225         +0.0226           102           104           101           104
OVERALL_GEOMEAN                                                                      -0.0264         -0.0262             0             0             0             0
```