### PR TITLE
Inline matcher_t::may_skip

### DIFF
--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -269,7 +269,7 @@ impl matcher_t {
 
         may_match_t::MATCH_MAYBE
     }
-    
+
     #[inline(always)]
     fn may_skip(&self, info: &hb_glyph_info_t, face: &hb_font_t, lookup_props: u32) -> may_skip_t {
         if !check_glyph_property(face, info, lookup_props) {

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -269,7 +269,8 @@ impl matcher_t {
 
         may_match_t::MATCH_MAYBE
     }
-
+    
+    #[inline(always)]
     fn may_skip(&self, info: &hb_glyph_info_t, face: &hb_font_t, lookup_props: u32) -> may_skip_t {
         if !check_glyph_property(face, info, lookup_props) {
             return may_skip_t::SKIP_YES;


### PR DESCRIPTION
Shows consistent improvements on HR benchmarks.