### PR TITLE
chore: add pre-commit CI: `cargo fmt` only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: Rust Format
+        description: "Automatically format Rust code with cargo fmt"
+        entry: sh -c "cargo fmt --all"
+        language: rust
+        pass_filenames: false


### PR DESCRIPTION
This is a subset of #90 - only adding `cargo fmt` as the automatic step. It should be merged before the #90.

Once enabled, pre-commit CI will keep all PRs clean by automatically doing `cargo fmt` and other minor linting, without requiring users to re-submit their changes. Note that this is done by CI on the server, and not by user's own git hook.

# Maintainer TODO

sign-in into https://pre-commit.ci/ and enable this repo for automatic PR validation (we had tons of success with this at MapLibre, and many other projects)