### PR TITLE
Stop converting between u32 and enum for general category

### DIFF
--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -5,7 +5,7 @@ use read_fonts::types::{GlyphId, GlyphId16};
 
 use super::buffer::glyph_flag::{SAFE_TO_INSERT_TATWEEL, UNSAFE_TO_BREAK, UNSAFE_TO_CONCAT};
 use super::face::hb_glyph_extents_t;
-use super::unicode::{CharExt, GeneralCategoryExt};
+use super::unicode::CharExt;
 use super::{hb_font_t, hb_mask_t};
 use crate::hb::set_digest::hb_set_digest_t;
 use crate::{script, BufferClusterLevel, BufferFlags, Direction, Language, Script, SerializeFlags};
@@ -329,7 +329,7 @@ impl hb_glyph_info_t {
     pub(crate) fn init_unicode_props(&mut self, scratch_flags: &mut hb_buffer_scratch_flags_t) {
         let u = self.as_char();
         let gc = u.general_category();
-        let mut props = gc.to_u32() as u16;
+        let mut props = gc.0 as u16;
 
         if u as u32 >= 0x80 {
             *scratch_flags |= HB_BUFFER_SCRATCH_FLAG_HAS_NON_ASCII;

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -8,8 +8,8 @@ use super::hb_mask_t;
 use super::ot_layout::*;
 use super::ot_layout_common::*;
 use super::set_digest::hb_set_digest_t;
-use super::unicode::hb_unicode_general_category_t;
 use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
+use crate::hb::unicode::GeneralCategory;
 use alloc::boxed::Box;
 use read_fonts::tables::layout::SequenceLookupRecord;
 use read_fonts::types::GlyphId;
@@ -1027,10 +1027,8 @@ pub fn ligate_input(
 
     if is_ligature {
         _hb_glyph_info_set_lig_props_for_ligature(first, lig_id, total_component_count);
-        if _hb_glyph_info_get_general_category(first)
-            == hb_unicode_general_category_t::NonspacingMark
-        {
-            _hb_glyph_info_set_general_category(first, hb_unicode_general_category_t::OtherLetter);
+        if _hb_glyph_info_get_general_category(first) == GeneralCategory::NON_SPACING_MARK {
+            _hb_glyph_info_set_general_category(first, GeneralCategory::OTHER_LETTER);
         }
     }
 

--- a/src/hb/ot_shape_fallback.rs
+++ b/src/hb/ot_shape_fallback.rs
@@ -94,9 +94,7 @@ pub fn _hb_ot_shape_fallback_mark_position_recategorize_marks(
 ) {
     let len = buffer.len;
     for info in &mut buffer.info[..len] {
-        if _hb_glyph_info_get_general_category(info)
-            == hb_unicode_general_category_t::NonspacingMark
-        {
+        if _hb_glyph_info_get_general_category(info) == GeneralCategory::NON_SPACING_MARK {
             let mut class = _hb_glyph_info_get_modified_combining_class(info);
             class = recategorize_combining_class(info.glyph_id, class);
             _hb_glyph_info_set_modified_combining_class(info, class);
@@ -114,9 +112,7 @@ fn zero_mark_advances(
         .iter()
         .zip(&mut buffer.pos[start..end])
     {
-        if _hb_glyph_info_get_general_category(info)
-            == hb_unicode_general_category_t::NonspacingMark
-        {
+        if _hb_glyph_info_get_general_category(info) == GeneralCategory::NON_SPACING_MARK {
             if adjust_offsets_when_zeroing {
                 pos.x_offset -= pos.x_advance;
                 pos.y_offset -= pos.y_advance;

--- a/src/hb/ot_shaper_arabic.rs
+++ b/src/hb/ot_shaper_arabic.rs
@@ -17,8 +17,8 @@ const HB_BUFFER_SCRATCH_FLAG_ARABIC_HAS_STCH: hb_buffer_scratch_flags_t =
 
 // See:
 // https://github.com/harfbuzz/harfbuzz/commit/6e6f82b6f3dde0fc6c3c7d991d9ec6cfff57823d#commitcomment-14248516
-fn is_word_category(gc: hb_unicode_general_category_t) -> bool {
-    (rb_flag_unsafe(gc.to_u32())
+fn is_word_category(gc: GeneralCategory) -> bool {
+    (rb_flag_unsafe(gc.to_u8() as u32)
         & (rb_flag(hb_gc::HB_UNICODE_GENERAL_CATEGORY_UNASSIGNED)
             | rb_flag(hb_gc::HB_UNICODE_GENERAL_CATEGORY_PRIVATE_USE)
             | rb_flag(hb_gc::HB_UNICODE_GENERAL_CATEGORY_MODIFIER_LETTER)
@@ -49,13 +49,13 @@ pub enum hb_arabic_joining_type_t {
     X = 8, // means: use general-category to choose between U or T.
 }
 
-fn get_joining_type(u: char, gc: hb_unicode_general_category_t) -> hb_arabic_joining_type_t {
+fn get_joining_type(u: char, gc: GeneralCategory) -> hb_arabic_joining_type_t {
     let j_type = super::ot_shaper_arabic_table::joining_type(u);
     if j_type != hb_arabic_joining_type_t::X {
         return j_type;
     }
 
-    let ok = rb_flag_unsafe(gc.to_u32())
+    let ok = rb_flag_unsafe(gc.to_u8() as u32)
         & (rb_flag(hb_gc::HB_UNICODE_GENERAL_CATEGORY_NON_SPACING_MARK)
             | rb_flag(hb_gc::HB_UNICODE_GENERAL_CATEGORY_ENCLOSING_MARK)
             | rb_flag(hb_gc::HB_UNICODE_GENERAL_CATEGORY_FORMAT));

--- a/src/hb/ot_shaper_indic.rs
+++ b/src/hb/ot_shaper_indic.rs
@@ -15,7 +15,7 @@ use super::ot_shape_normalize::*;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::*;
 use super::ot_shaper_syllabic::*;
-use super::unicode::{hb_gc, CharExt, GeneralCategoryExt};
+use super::unicode::{hb_gc, CharExt};
 use super::{hb_font_t, hb_glyph_info_t, hb_mask_t, hb_tag_t, script, Script};
 
 pub const INDIC_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {
@@ -1836,7 +1836,7 @@ fn final_reordering_impl(
     if buffer.info[start].indic_position() == ot_position_t::POS_PRE_M {
         if start == 0
             || (rb_flag_unsafe(
-                _hb_glyph_info_get_general_category(&buffer.info[start - 1]).to_u32(),
+                _hb_glyph_info_get_general_category(&buffer.info[start - 1]).to_u8() as u32,
             ) & rb_flag_range(
                 hb_gc::HB_UNICODE_GENERAL_CATEGORY_FORMAT,
                 hb_gc::HB_UNICODE_GENERAL_CATEGORY_NON_SPACING_MARK,

--- a/src/hb/ot_shaper_khmer.rs
+++ b/src/hb/ot_shaper_khmer.rs
@@ -8,7 +8,7 @@ use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::*;
 use super::ot_shaper_indic::ot_category_t;
 use super::ot_shaper_syllabic::*;
-use super::unicode::{CharExt, GeneralCategoryExt};
+use super::unicode::CharExt;
 use super::{hb_font_t, hb_glyph_info_t, hb_mask_t, hb_tag_t};
 
 pub const KHMER_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {

--- a/src/hb/ot_shaper_thai.rs
+++ b/src/hb/ot_shaper_thai.rs
@@ -3,7 +3,7 @@ use super::ot_layout::*;
 use super::ot_shape_normalize::HB_OT_SHAPE_NORMALIZATION_MODE_AUTO;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::*;
-use super::unicode::hb_unicode_general_category_t;
+use super::unicode::GeneralCategory;
 use super::{hb_font_t, script};
 
 pub const THAI_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {
@@ -393,7 +393,7 @@ fn preprocess_text(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_
         let end = buffer.out_len;
         _hb_glyph_info_set_general_category(
             &mut buffer.out_info_mut()[end - 2],
-            hb_unicode_general_category_t::NonspacingMark,
+            GeneralCategory::NON_SPACING_MARK,
         );
 
         // Ok, let's see...

--- a/src/hb/ot_shaper_use.rs
+++ b/src/hb/ot_shaper_use.rs
@@ -10,7 +10,7 @@ use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::*;
 use super::ot_shaper_arabic::arabic_shape_plan_t;
 use super::ot_shaper_syllabic::*;
-use super::unicode::{CharExt, GeneralCategoryExt};
+use super::unicode::CharExt;
 use super::{hb_font_t, hb_glyph_info_t, hb_mask_t, hb_tag_t, script, Script};
 
 pub const UNIVERSAL_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {

--- a/src/hb/unicode.rs
+++ b/src/hb/unicode.rs
@@ -24,38 +24,77 @@ pub mod hb_unicode_funcs_t {
     pub const SPACE_NARROW: u8 = 21;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum hb_unicode_general_category_t {
-    ClosePunctuation,
-    ConnectorPunctuation,
-    Control,
-    CurrencySymbol,
-    DashPunctuation,
-    DecimalNumber,
-    EnclosingMark,
-    FinalPunctuation,
-    Format,
-    InitialPunctuation,
-    LetterNumber,
-    LineSeparator,
-    LowercaseLetter,
-    MathSymbol,
-    ModifierLetter,
-    ModifierSymbol,
-    NonspacingMark,
-    OpenPunctuation,
-    OtherLetter,
-    OtherNumber,
-    OtherPunctuation,
-    OtherSymbol,
-    ParagraphSeparator,
-    PrivateUse,
-    SpaceSeparator,
-    SpacingMark,
-    Surrogate,
-    TitlecaseLetter,
-    Unassigned,
-    UppercaseLetter,
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct GeneralCategory(pub u8);
+
+#[allow(unused)]
+impl GeneralCategory {
+    pub const CONTROL: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_CONTROL as _);
+    pub const FORMAT: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_FORMAT as _);
+    pub const UNASSIGNED: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_UNASSIGNED as _);
+    pub const PRIVATE_USE: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_PRIVATE_USE as _);
+    pub const SURROGATE: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_SURROGATE as _);
+    pub const LOWERCASE_LETTER: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_LOWERCASE_LETTER as _);
+    pub const MODIFIER_LETTER: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_MODIFIER_LETTER as _);
+    pub const OTHER_LETTER: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_LETTER as _);
+    pub const TITLECASE_LETTER: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_TITLECASE_LETTER as _);
+    pub const UPPERCASE_LETTER: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_UPPERCASE_LETTER as _);
+    pub const SPACING_MARK: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_SPACING_MARK as _);
+    pub const ENCLOSING_MARK: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_ENCLOSING_MARK as _);
+    pub const NON_SPACING_MARK: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_NON_SPACING_MARK as _);
+    pub const DECIMAL_NUMBER: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_DECIMAL_NUMBER as _);
+    pub const LETTER_NUMBER: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_LETTER_NUMBER as _);
+    pub const OTHER_NUMBER: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_NUMBER as _);
+    pub const CONNECT_PUNCTUATION: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_CONNECT_PUNCTUATION as _);
+    pub const DASH_PUNCTUATION: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_DASH_PUNCTUATION as _);
+    pub const CLOSE_PUNCTUATION: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_CLOSE_PUNCTUATION as _);
+    pub const FINAL_PUNCTUATION: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_FINAL_PUNCTUATION as _);
+    pub const INITIAL_PUNCTUATION: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_INITIAL_PUNCTUATION as _);
+    pub const OTHER_PUNCTUATION: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_PUNCTUATION as _);
+    pub const OPEN_PUNCTUATION: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_OPEN_PUNCTUATION as _);
+    pub const CURRENCY_SYMBOL: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_CURRENCY_SYMBOL as _);
+    pub const MODIFIER_SYMBOL: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_MODIFIER_SYMBOL as _);
+    pub const MATH_SYMBOL: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_MATH_SYMBOL as _);
+    pub const OTHER_SYMBOL: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_SYMBOL as _);
+    pub const LINE_SEPARATOR: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_LINE_SEPARATOR as _);
+    pub const PARAGRAPH_SEPARATOR: Self =
+        Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_PARAGRAPH_SEPARATOR as _);
+    pub const SPACE_SEPARATOR: Self = Self(hb_gc::HB_UNICODE_GENERAL_CATEGORY_SPACE_SEPARATOR as _);
+}
+
+impl GeneralCategory {
+    pub fn to_u8(self) -> u8 {
+        self.0
+    }
+
+    pub fn is_mark(&self) -> bool {
+        matches!(
+            *self,
+            Self::SPACING_MARK | Self::ENCLOSING_MARK | Self::NON_SPACING_MARK
+        )
+    }
+
+    pub fn is_letter(&self) -> bool {
+        matches!(
+            *self,
+            Self::LOWERCASE_LETTER
+                | Self::MODIFIER_LETTER
+                | Self::OTHER_LETTER
+                | Self::TITLECASE_LETTER
+                | Self::UPPERCASE_LETTER
+        )
+    }
 }
 
 #[allow(dead_code)]
@@ -327,106 +366,9 @@ const MODIFIED_COMBINING_CLASS: &[u8; 256] = &[
     combining_class::Invalid,
 ];
 
-pub trait GeneralCategoryExt {
-    fn to_u32(&self) -> u32;
-    fn from_u32(gc: u32) -> Self;
-    fn is_mark(&self) -> bool;
-    fn is_letter(&self) -> bool;
-}
-
-#[rustfmt::skip]
-impl GeneralCategoryExt for hb_unicode_general_category_t {
-    fn to_u32(&self) -> u32 {
-        match *self {
-            hb_unicode_general_category_t::ClosePunctuation => hb_gc::HB_UNICODE_GENERAL_CATEGORY_CLOSE_PUNCTUATION,
-            hb_unicode_general_category_t::ConnectorPunctuation => hb_gc::HB_UNICODE_GENERAL_CATEGORY_CONNECT_PUNCTUATION,
-            hb_unicode_general_category_t::Control => hb_gc::HB_UNICODE_GENERAL_CATEGORY_CONTROL,
-            hb_unicode_general_category_t::CurrencySymbol => hb_gc::HB_UNICODE_GENERAL_CATEGORY_CURRENCY_SYMBOL,
-            hb_unicode_general_category_t::DashPunctuation => hb_gc::HB_UNICODE_GENERAL_CATEGORY_DASH_PUNCTUATION,
-            hb_unicode_general_category_t::DecimalNumber => hb_gc::HB_UNICODE_GENERAL_CATEGORY_DECIMAL_NUMBER,
-            hb_unicode_general_category_t::EnclosingMark => hb_gc::HB_UNICODE_GENERAL_CATEGORY_ENCLOSING_MARK,
-            hb_unicode_general_category_t::FinalPunctuation => hb_gc::HB_UNICODE_GENERAL_CATEGORY_FINAL_PUNCTUATION,
-            hb_unicode_general_category_t::Format => hb_gc::HB_UNICODE_GENERAL_CATEGORY_FORMAT,
-            hb_unicode_general_category_t::InitialPunctuation => hb_gc::HB_UNICODE_GENERAL_CATEGORY_INITIAL_PUNCTUATION,
-            hb_unicode_general_category_t::LetterNumber => hb_gc::HB_UNICODE_GENERAL_CATEGORY_LETTER_NUMBER,
-            hb_unicode_general_category_t::LineSeparator => hb_gc::HB_UNICODE_GENERAL_CATEGORY_LINE_SEPARATOR,
-            hb_unicode_general_category_t::LowercaseLetter => hb_gc::HB_UNICODE_GENERAL_CATEGORY_LOWERCASE_LETTER,
-            hb_unicode_general_category_t::MathSymbol => hb_gc::HB_UNICODE_GENERAL_CATEGORY_MATH_SYMBOL,
-            hb_unicode_general_category_t::ModifierLetter => hb_gc::HB_UNICODE_GENERAL_CATEGORY_MODIFIER_LETTER,
-            hb_unicode_general_category_t::ModifierSymbol => hb_gc::HB_UNICODE_GENERAL_CATEGORY_MODIFIER_SYMBOL,
-            hb_unicode_general_category_t::NonspacingMark => hb_gc::HB_UNICODE_GENERAL_CATEGORY_NON_SPACING_MARK,
-            hb_unicode_general_category_t::OpenPunctuation => hb_gc::HB_UNICODE_GENERAL_CATEGORY_OPEN_PUNCTUATION,
-            hb_unicode_general_category_t::OtherLetter => hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_LETTER,
-            hb_unicode_general_category_t::OtherNumber => hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_NUMBER,
-            hb_unicode_general_category_t::OtherPunctuation => hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_PUNCTUATION,
-            hb_unicode_general_category_t::OtherSymbol => hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_SYMBOL,
-            hb_unicode_general_category_t::ParagraphSeparator => hb_gc::HB_UNICODE_GENERAL_CATEGORY_PARAGRAPH_SEPARATOR,
-            hb_unicode_general_category_t::PrivateUse => hb_gc::HB_UNICODE_GENERAL_CATEGORY_PRIVATE_USE,
-            hb_unicode_general_category_t::SpaceSeparator => hb_gc::HB_UNICODE_GENERAL_CATEGORY_SPACE_SEPARATOR,
-            hb_unicode_general_category_t::SpacingMark => hb_gc::HB_UNICODE_GENERAL_CATEGORY_SPACING_MARK,
-            hb_unicode_general_category_t::Surrogate => hb_gc::HB_UNICODE_GENERAL_CATEGORY_SURROGATE,
-            hb_unicode_general_category_t::TitlecaseLetter => hb_gc::HB_UNICODE_GENERAL_CATEGORY_TITLECASE_LETTER,
-            hb_unicode_general_category_t::Unassigned => hb_gc::HB_UNICODE_GENERAL_CATEGORY_UNASSIGNED,
-            hb_unicode_general_category_t::UppercaseLetter => hb_gc::HB_UNICODE_GENERAL_CATEGORY_UPPERCASE_LETTER
-        }
-    }
-
-    fn from_u32(gc: u32) -> Self {
-        match gc {
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_CLOSE_PUNCTUATION => hb_unicode_general_category_t::ClosePunctuation,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_CONNECT_PUNCTUATION => hb_unicode_general_category_t::ConnectorPunctuation,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_CONTROL => hb_unicode_general_category_t::Control,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_CURRENCY_SYMBOL => hb_unicode_general_category_t::CurrencySymbol,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_DASH_PUNCTUATION => hb_unicode_general_category_t::DashPunctuation,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_DECIMAL_NUMBER => hb_unicode_general_category_t::DecimalNumber,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_ENCLOSING_MARK => hb_unicode_general_category_t::EnclosingMark,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_FINAL_PUNCTUATION => hb_unicode_general_category_t::FinalPunctuation,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_FORMAT => hb_unicode_general_category_t::Format,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_INITIAL_PUNCTUATION => hb_unicode_general_category_t::InitialPunctuation,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_LETTER_NUMBER => hb_unicode_general_category_t::LetterNumber,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_LINE_SEPARATOR => hb_unicode_general_category_t::LineSeparator,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_LOWERCASE_LETTER => hb_unicode_general_category_t::LowercaseLetter,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_MATH_SYMBOL => hb_unicode_general_category_t::MathSymbol,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_MODIFIER_LETTER => hb_unicode_general_category_t::ModifierLetter,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_MODIFIER_SYMBOL => hb_unicode_general_category_t::ModifierSymbol,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_NON_SPACING_MARK => hb_unicode_general_category_t::NonspacingMark,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_OPEN_PUNCTUATION => hb_unicode_general_category_t::OpenPunctuation,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_LETTER => hb_unicode_general_category_t::OtherLetter,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_NUMBER => hb_unicode_general_category_t::OtherNumber,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_PUNCTUATION => hb_unicode_general_category_t::OtherPunctuation,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_OTHER_SYMBOL => hb_unicode_general_category_t::OtherSymbol,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_PARAGRAPH_SEPARATOR => hb_unicode_general_category_t::ParagraphSeparator,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_PRIVATE_USE => hb_unicode_general_category_t::PrivateUse,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_SPACE_SEPARATOR => hb_unicode_general_category_t::SpaceSeparator,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_SPACING_MARK => hb_unicode_general_category_t::SpacingMark,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_SURROGATE => hb_unicode_general_category_t::Surrogate,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_TITLECASE_LETTER => hb_unicode_general_category_t::TitlecaseLetter,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_UNASSIGNED => hb_unicode_general_category_t::Unassigned,
-            hb_gc::HB_UNICODE_GENERAL_CATEGORY_UPPERCASE_LETTER => hb_unicode_general_category_t::UppercaseLetter,
-            _ => unreachable!()
-        }
-    }
-
-    fn is_mark(&self) -> bool {
-        matches!(*self, 
-            hb_unicode_general_category_t::SpacingMark |
-            hb_unicode_general_category_t::EnclosingMark |
-            hb_unicode_general_category_t::NonspacingMark)
-    }
-
-    fn is_letter(&self) -> bool {
-        matches!(*self, 
-            hb_unicode_general_category_t::LowercaseLetter |
-            hb_unicode_general_category_t::ModifierLetter |
-            hb_unicode_general_category_t::OtherLetter |
-            hb_unicode_general_category_t::TitlecaseLetter |
-            hb_unicode_general_category_t::UppercaseLetter)
-    }
-}
-
 pub trait CharExt {
     fn script(self) -> Script;
-    fn general_category(self) -> hb_unicode_general_category_t;
+    fn general_category(self) -> GeneralCategory;
     fn space_fallback(self) -> hb_unicode_funcs_t::space_t;
     fn combining_class(self) -> u8;
     fn modified_combining_class(self) -> u8;
@@ -442,8 +384,8 @@ impl CharExt for char {
         _hb_ucd_sc_map[_hb_ucd_sc(self as usize) as usize]
     }
 
-    fn general_category(self) -> hb_unicode_general_category_t {
-        hb_unicode_general_category_t::from_u32(_hb_ucd_gc(self as usize) as u32)
+    fn general_category(self) -> GeneralCategory {
+        GeneralCategory(_hb_ucd_gc(self as usize))
     }
 
     fn space_fallback(self) -> hb_unicode_funcs_t::space_t {


### PR DESCRIPTION
This was more pervasive than I thought. Seems to offer a minor perf boost as well?