### PR TITLE
Statically allocate MatchPositions to MAX_CONTEXT_LENGTH

### DIFF
--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -14,7 +14,7 @@ use alloc::boxed::Box;
 use read_fonts::tables::layout::SequenceLookupRecord;
 use read_fonts::types::GlyphId;
 
-pub(crate) type MatchPositions = smallvec::SmallVec<[usize; 8]>;
+pub(crate) type MatchPositions = smallvec::SmallVec<[usize; MAX_CONTEXT_LENGTH]>;
 
 /// Value represents glyph id.
 pub fn match_glyph(info: &mut hb_glyph_info_t, value: u16) -> bool {


### PR DESCRIPTION
Doesn't seem like has a perf impact.