### PR TITLE
Revert "Branchfree set_digest (#179)"

### DIFF
--- a/src/hb/set_digest.rs
+++ b/src/hb/set_digest.rs
@@ -98,24 +98,25 @@ impl hb_set_digest_t {
         }
     }
 
-    #[inline(always)]
     pub fn may_have_glyph(&self, g: GlyphId) -> bool {
         let gid = g.to_u32();
-        let mut have = true;
         for i in 0..N {
             let shift = HB_SET_DIGEST_SHIFTS[i];
             let bit = (gid >> shift) & MB1;
-            have &= (self.masks[i] & (ONE << bit)) != 0;
+            if self.masks[i] & (ONE << bit) == 0 {
+                return false;
+            }
         }
-        have
+        true
     }
 
     pub fn may_intersect(&self, other: &Self) -> bool {
-        let mut have = true;
         for i in 0..N {
-            have &= (self.masks[i] & other.masks[i]) != 0;
+            if self.masks[i] & other.masks[i] == 0 {
+                return false;
+            }
         }
-        have
+        true
     }
 }
 


### PR DESCRIPTION
This reverts commit 304eae0f24c99fc7c241d7b405578449d76d3c62.

Revert, as this was borderline on slowdown. Let compiler decide. HB reverted as well: https://github.com/harfbuzz/harfbuzz/pull/5470