### PR TITLE
[aat] Fix matching for kerx

### DIFF
--- a/src/hb/aat/layout_kerx_table.rs
+++ b/src/hb/aat/layout_kerx_table.rs
@@ -39,7 +39,9 @@ pub(crate) fn apply(
             continue;
         };
 
-        if subtable.is_variable() {
+        // We don't properly handle variations _or_ subtables with a non-zero
+        // tuple count
+        if subtable.is_variable() || subtable.tuple_count() != 0 {
             continue;
         }
 
@@ -160,7 +162,8 @@ fn apply_simple_kerning<T: SimpleKerning>(
 ) {
     let mut ctx = hb_ot_apply_context_t::new(TableIndex::GPOS, face, buffer);
     ctx.set_lookup_mask(plan.kern_mask);
-    ctx.lookup_props = u32::from(lookup_flags::IGNORE_FLAGS);
+    ctx.lookup_props = u32::from(lookup_flags::IGNORE_MARKS);
+    ctx.update_matchers();
 
     let horizontal = ctx.buffer.direction.is_horizontal();
     let cross_stream = subtable.is_cross_stream();


### PR DESCRIPTION
And prevent application of subtables with non-zero tuple counts.