### PR TITLE
Implement lazy lookup loading

### DIFF
--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -146,7 +146,7 @@ mod cache {
         }
 
         pub fn get<'a>(&self, _host: &impl LookupHost<'a>, index: u16) -> Option<&LookupInfo> {
-            self.lookups.get(index as usize).as_ref()
+            self.lookups.get(index as usize)?.as_ref()
         }
     }
 }

--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -124,7 +124,7 @@ mod cache {
 
 #[cfg(not(feature = "std"))]
 mod cache {
-    use super::{LookupHost, LookupInfo};
+    use super::{LookupHost, LookupInfo, Vec};
 
     #[derive(Default)]
     pub(crate) struct LookupCache {
@@ -187,7 +187,7 @@ impl LookupInfo {
         };
         let lookup_data = data.table_data.split_off(data.offset)?;
         let lookup: Lookup<()> = Lookup::read(lookup_data).ok()?;
-        let kind = lookup.lookup_type();
+        let lookup_type = lookup.lookup_type();
         let lookup_flag = lookup.lookup_flag();
         info.props = u32::from(lookup.lookup_flag().to_bits());
         if lookup_flag.to_bits() & LookupFlag::USE_MARK_FILTERING_SET.to_bits() != 0 {
@@ -205,7 +205,7 @@ impl LookupInfo {
                 data.table_data,
                 subtable_offset as u32,
                 data.is_subst,
-                kind as u8,
+                lookup_type as u8,
             ) {
                 info.digest.union(&subtable_info.digest);
                 if cache_cost > subtable_cache_user_cost {

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -889,14 +889,11 @@ pub mod OT {
             let applied = self
                 .face
                 .ot_tables
-                .table_data_and_lookups(self.table_index)
-                .and_then(|(table_data, lookups)| {
-                    Some((table_data, lookups.get(sub_lookup_index)?, lookups))
-                })
-                .and_then(|(table_data, lookup, lookups)| {
+                .table_data_and_lookup(self.table_index, sub_lookup_index)
+                .and_then(|(table_data, lookup)| {
                     self.lookup_props = lookup.props();
                     self.update_matchers();
-                    lookup.apply(self, table_data, lookups, false)
+                    lookup.apply(self, table_data, false)
                 });
             self.lookup_props = saved_props;
             self.lookup_index = saved_index;


### PR DESCRIPTION
Use a `Vec` of `OnceLock`s so that we can cache lookup metadata on demand rather than preloading all of them.

On `no_std` builds, just precaches everything since we don't have the primitives available to do this safely and thread safely.