### PR TITLE
Add smaller, secondary subtable caches

### DIFF
--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -1,4 +1,4 @@
-use crate::hb::ot::coverage_index_cached;
+use crate::hb::ot::{coverage_index, coverage_index_cached};
 use crate::hb::ot::{glyph_class, glyph_class_cached};
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
@@ -23,7 +23,7 @@ impl Apply for PairPosFormat1<'_> {
                     &cache.coverage,
                 )?
             } else {
-                panic!(""); // Tell compiler this can't happen.
+                coverage_index(self.coverage(), first_glyph)?
             };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
@@ -139,7 +139,7 @@ impl Apply for PairPosFormat2<'_> {
                 &cache.coverage,
             )?
         } else {
-            panic!(""); // Tell compiler this can't happen.
+            coverage_index(self.coverage(), first_glyph)?
         };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
@@ -193,7 +193,7 @@ impl Apply for PairPosFormat2<'_> {
                 &cache.first,
             )
         } else {
-            panic!(""); // Tell compiler this can't happen.
+            glyph_class(self.class_def1(), first_glyph)
         };
         let class2 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
             glyph_class_cached(
@@ -202,7 +202,7 @@ impl Apply for PairPosFormat2<'_> {
                 &cache.second,
             )
         } else {
-            panic!(""); // Tell compiler this can't happen.
+            glyph_class(self.class_def2(), second_glyph)
         };
         let mut buf_idx = iter.buf_idx;
         let format1 = self.value_format1();

--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -23,7 +23,7 @@ impl Apply for PairPosFormat1<'_> {
                     &cache.coverage,
                 )?
             } else {
-                unreachable!();
+                return None; // This can't actually happen.
             };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
@@ -139,7 +139,7 @@ impl Apply for PairPosFormat2<'_> {
                 &cache.coverage,
             )?
         } else {
-            unreachable!();
+            return None; // This can't actually happen.
         };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
@@ -193,7 +193,7 @@ impl Apply for PairPosFormat2<'_> {
                 &cache.first,
             )
         } else {
-            unreachable!();
+            return None; // This can't actually happen.
         };
         let class2 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
             glyph_class_cached(
@@ -202,7 +202,7 @@ impl Apply for PairPosFormat2<'_> {
                 &cache.second,
             )
         } else {
-            unreachable!();
+            return None; // This can't actually happen.
         };
         let mut buf_idx = iter.buf_idx;
         let format1 = self.value_format1();

--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -23,7 +23,7 @@ impl Apply for PairPosFormat1<'_> {
                     &cache.coverage,
                 )?
             } else {
-                return None; // This can't actually happen.
+                panic!(""); // Tell compiler this can't happen.
             };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
@@ -139,7 +139,7 @@ impl Apply for PairPosFormat2<'_> {
                 &cache.coverage,
             )?
         } else {
-            return None; // This can't actually happen.
+            panic!(""); // Tell compiler this can't happen.
         };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
@@ -193,7 +193,7 @@ impl Apply for PairPosFormat2<'_> {
                 &cache.first,
             )
         } else {
-            return None; // This can't actually happen.
+            panic!(""); // Tell compiler this can't happen.
         };
         let class2 = if let SubtableExternalCache::PairPosFormat2Cache(cache) = external_cache {
             glyph_class_cached(
@@ -202,7 +202,7 @@ impl Apply for PairPosFormat2<'_> {
                 &cache.second,
             )
         } else {
-            return None; // This can't actually happen.
+            panic!(""); // Tell compiler this can't happen.
         };
         let mut buf_idx = iter.buf_idx;
         let format1 = self.value_format1();

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -1,5 +1,5 @@
 use crate::hb::buffer::GlyphInfo;
-use crate::hb::ot::coverage_index_cached;
+use crate::hb::ot::{coverage_index, coverage_index_cached};
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
     ligate_input, match_always, match_glyph, match_input, may_skip_t, skipping_iterator_t, Apply,
@@ -157,13 +157,13 @@ impl Apply for LigatureSubstFormat1<'_> {
         {
             coverage_index_cached(|gid| self.coverage().ok()?.get(gid), glyph, &cache.coverage)?
         } else {
-            panic!(""); // Tell compiler this can't happen.
+            coverage_index(self.coverage(), glyph)?
         };
         let seconds =
             if let SubtableExternalCache::LigatureSubstFormat1Cache(cache) = external_cache {
                 &cache.seconds
             } else {
-                panic!(""); // Tell compiler this can't happen.
+                &hb_set_digest_t::full()
             };
         self.ligature_sets()
             .get(index as usize)

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -157,13 +157,13 @@ impl Apply for LigatureSubstFormat1<'_> {
         {
             coverage_index_cached(|gid| self.coverage().ok()?.get(gid), glyph, &cache.coverage)?
         } else {
-            unreachable!();
+            return None; // This can't actually happen.
         };
         let seconds =
             if let SubtableExternalCache::LigatureSubstFormat1Cache(cache) = external_cache {
                 &cache.seconds
             } else {
-                unreachable!();
+                return None; // This can't actually happen.
             };
         self.ligature_sets()
             .get(index as usize)

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -157,13 +157,13 @@ impl Apply for LigatureSubstFormat1<'_> {
         {
             coverage_index_cached(|gid| self.coverage().ok()?.get(gid), glyph, &cache.coverage)?
         } else {
-            return None; // This can't actually happen.
+            panic!(""); // Tell compiler this can't happen.
         };
         let seconds =
             if let SubtableExternalCache::LigatureSubstFormat1Cache(cache) = external_cache {
                 &cache.seconds
             } else {
-                return None; // This can't actually happen.
+                panic!(""); // Tell compiler this can't happen.
             };
         self.ligature_sets()
             .get(index as usize)

--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -2,7 +2,7 @@ use crate::hb::{
     hb_font_t,
     ot_layout::TableIndex,
     ot_layout_gsubgpos::{
-        Apply, SubtableCacheMode, SubtableExternalCache, WouldApply, WouldApplyContext,
+        Apply, SubtableExternalCache, SubtableExternalCacheMode, WouldApply, WouldApplyContext,
         OT::hb_ot_apply_context_t,
     },
     set_digest::hb_set_digest_t,
@@ -201,14 +201,18 @@ impl LookupInfo {
         let mut subtable_cache_user_cost = 0;
         info.subtables.reserve(lookup.sub_table_count() as usize);
         for (idx, subtable_offset) in lookup.subtable_offsets().iter().enumerate() {
-            let use_full_external_cache = idx < 8;
+            let cache_mode = if idx < 8 {
+                SubtableExternalCacheMode::Full
+            } else {
+                SubtableExternalCacheMode::Small
+            };
             let subtable_offset = subtable_offset.get().to_usize() + data.offset;
             if let Some((subtable_info, cache_cost)) = SubtableInfo::new(
                 data.table_data,
                 subtable_offset as u32,
                 data.is_subst,
                 lookup_type as u8,
-                use_full_external_cache,
+                cache_mode,
             ) {
                 info.digest.union(&subtable_info.digest);
                 if cache_cost > subtable_cache_user_cost {
@@ -486,16 +490,10 @@ impl SubtableInfo {
         subtable_offset: u32,
         is_subst: bool,
         lookup_type: u8,
-        use_full_external_cache: bool,
+        cache_mode: SubtableExternalCacheMode,
     ) -> Option<(Self, u32)> {
         let data = table_data.split_off(subtable_offset as usize)?;
-        let maybe_external_cache = |s: &dyn Apply| {
-            if use_full_external_cache {
-                s.external_cache_create(SubtableCacheMode::Full)
-            } else {
-                s.external_cache_create(SubtableCacheMode::Small)
-            }
-        };
+        let maybe_external_cache = |s: &dyn Apply| s.external_cache_create(cache_mode);
         let (kind, (external_cache, cache_cost, coverage), apply_fns): (
             SubtableKind,
             (SubtableExternalCache, u32, CoverageTable),
@@ -638,7 +636,7 @@ impl SubtableInfo {
                     subtable_offset.checked_add(ext_offset)?,
                     is_subst,
                     ext_type,
-                    use_full_external_cache,
+                    cache_mode,
                 );
             }
             (false, 6) => (

--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -199,13 +199,15 @@ impl LookupInfo {
         }
         let mut subtable_cache_user_cost = 0;
         info.subtables.reserve(lookup.sub_table_count() as usize);
-        for subtable_offset in lookup.subtable_offsets() {
+        for (idx, subtable_offset) in lookup.subtable_offsets().into_iter().enumerate() {
+            let use_external_cache = idx < 8;
             let subtable_offset = subtable_offset.get().to_usize() + data.offset;
             if let Some((subtable_info, cache_cost)) = SubtableInfo::new(
                 data.table_data,
                 subtable_offset as u32,
                 data.is_subst,
                 lookup_type as u8,
+                use_external_cache,
             ) {
                 info.digest.union(&subtable_info.digest);
                 if cache_cost > subtable_cache_user_cost {
@@ -483,6 +485,7 @@ impl SubtableInfo {
         subtable_offset: u32,
         is_subst: bool,
         lookup_type: u8,
+        use_external_cache: bool,
     ) -> Option<(Self, u32)> {
         let data = table_data.split_off(subtable_offset as usize)?;
         let (kind, (external_cache, cache_cost, coverage), apply_fns): (
@@ -494,7 +497,11 @@ impl SubtableInfo {
                 SingleSubst::Format1(s) => (
                     SubtableKind::SingleSubst1,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -503,7 +510,11 @@ impl SubtableInfo {
                 SingleSubst::Format2(s) => (
                     SubtableKind::SingleSubst2,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -514,7 +525,11 @@ impl SubtableInfo {
                 SinglePos::Format1(s) => (
                     SubtableKind::SinglePos1,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -523,7 +538,11 @@ impl SubtableInfo {
                 SinglePos::Format2(s) => (
                     SubtableKind::SinglePos2,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -534,7 +553,11 @@ impl SubtableInfo {
                 SubtableKind::MultipleSubst1,
                 MultipleSubstFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        t.external_cache_create(),
+                        if use_external_cache {
+                            t.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         t.cache_cost(),
                         t.coverage().ok()?,
                     ))
@@ -545,7 +568,11 @@ impl SubtableInfo {
                 PairPos::Format1(s) => (
                     SubtableKind::PairPos1,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -554,7 +581,11 @@ impl SubtableInfo {
                 PairPos::Format2(s) => (
                     SubtableKind::PairPos2,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -565,7 +596,11 @@ impl SubtableInfo {
                 SubtableKind::AlternateSubst1,
                 AlternateSubstFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        t.external_cache_create(),
+                        if use_external_cache {
+                            t.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         t.cache_cost(),
                         t.coverage().ok()?,
                     ))
@@ -576,7 +611,11 @@ impl SubtableInfo {
                 SubtableKind::CursivePos1,
                 CursivePosFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        t.external_cache_create(),
+                        if use_external_cache {
+                            t.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         t.cache_cost(),
                         t.coverage().ok()?,
                     ))
@@ -587,7 +626,11 @@ impl SubtableInfo {
                 SubtableKind::LigatureSubst1,
                 LigatureSubstFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        t.external_cache_create(),
+                        if use_external_cache {
+                            t.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         t.cache_cost(),
                         t.coverage().ok()?,
                     ))
@@ -598,7 +641,11 @@ impl SubtableInfo {
                 SubtableKind::MarkBasePos1,
                 MarkBasePosFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        t.external_cache_create(),
+                        if use_external_cache {
+                            t.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         t.cache_cost(),
                         t.mark_coverage().ok()?,
                     ))
@@ -609,7 +656,11 @@ impl SubtableInfo {
                 SequenceContext::Format1(s) => (
                     SubtableKind::ContextFormat1,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -618,7 +669,11 @@ impl SubtableInfo {
                 SequenceContext::Format2(s) => (
                     SubtableKind::ContextFormat2,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -627,7 +682,11 @@ impl SubtableInfo {
                 SequenceContext::Format3(s) => (
                     SubtableKind::ContextFormat3,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverages().get(0).ok()?,
                     ),
@@ -638,7 +697,11 @@ impl SubtableInfo {
                 SubtableKind::MarkLigPos1,
                 MarkLigPosFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        t.external_cache_create(),
+                        if use_external_cache {
+                            t.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         t.cache_cost(),
                         t.mark_coverage().ok()?,
                     ))
@@ -649,7 +712,11 @@ impl SubtableInfo {
                 ChainedSequenceContext::Format1(s) => (
                     SubtableKind::ChainedContextFormat1,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -658,7 +725,11 @@ impl SubtableInfo {
                 ChainedSequenceContext::Format2(s) => (
                     SubtableKind::ChainedContextFormat2,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.coverage().ok()?,
                     ),
@@ -667,7 +738,11 @@ impl SubtableInfo {
                 ChainedSequenceContext::Format3(s) => (
                     SubtableKind::ChainedContextFormat3,
                     (
-                        s.external_cache_create(),
+                        if use_external_cache {
+                            s.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         s.cache_cost(),
                         s.input_coverages().get(0).ok()?,
                     ),
@@ -683,13 +758,18 @@ impl SubtableInfo {
                     subtable_offset.checked_add(ext_offset)?,
                     is_subst,
                     ext_type,
+                    use_external_cache,
                 );
             }
             (false, 6) => (
                 SubtableKind::MarkMarkPos1,
                 MarkMarkPosFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        t.external_cache_create(),
+                        if use_external_cache {
+                            t.external_cache_create()
+                        } else {
+                            SubtableExternalCache::None
+                        },
                         t.cache_cost(),
                         t.mark1_coverage().ok()?,
                     ))
@@ -702,7 +782,11 @@ impl SubtableInfo {
                     .ok()
                     .and_then(|t| {
                         Some((
-                            t.external_cache_create(),
+                            if use_external_cache {
+                                t.external_cache_create()
+                            } else {
+                                SubtableExternalCache::None
+                            },
                             t.cache_cost(),
                             t.coverage().ok()?,
                         ))

--- a/src/hb/ot/lookup.rs
+++ b/src/hb/ot/lookup.rs
@@ -199,7 +199,7 @@ impl LookupInfo {
         }
         let mut subtable_cache_user_cost = 0;
         info.subtables.reserve(lookup.sub_table_count() as usize);
-        for (idx, subtable_offset) in lookup.subtable_offsets().into_iter().enumerate() {
+        for (idx, subtable_offset) in lookup.subtable_offsets().iter().enumerate() {
             let use_external_cache = idx < 8;
             let subtable_offset = subtable_offset.get().to_usize() + data.offset;
             if let Some((subtable_info, cache_cost)) = SubtableInfo::new(
@@ -488,6 +488,13 @@ impl SubtableInfo {
         use_external_cache: bool,
     ) -> Option<(Self, u32)> {
         let data = table_data.split_off(subtable_offset as usize)?;
+        let maybe_external_cache = |s: &dyn Apply| {
+            if use_external_cache {
+                s.external_cache_create()
+            } else {
+                SubtableExternalCache::None
+            }
+        };
         let (kind, (external_cache, cache_cost, coverage), apply_fns): (
             SubtableKind,
             (SubtableExternalCache, u32, CoverageTable),
@@ -496,144 +503,64 @@ impl SubtableInfo {
             (true, 1) => match SingleSubst::read(data).ok()? {
                 SingleSubst::Format1(s) => (
                     SubtableKind::SingleSubst1,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [single_subst1, single_subst1_cached as _],
                 ),
                 SingleSubst::Format2(s) => (
                     SubtableKind::SingleSubst2,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [single_subst2, single_subst2_cached as _],
                 ),
             },
             (false, 1) => match SinglePos::read(data).ok()? {
                 SinglePos::Format1(s) => (
                     SubtableKind::SinglePos1,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [single_pos1, single_pos1_cached as _],
                 ),
                 SinglePos::Format2(s) => (
                     SubtableKind::SinglePos2,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [single_pos2, single_pos2_cached as _],
                 ),
             },
             (true, 2) => (
                 SubtableKind::MultipleSubst1,
                 MultipleSubstFormat1::read(data).ok().and_then(|t| {
-                    Some((
-                        if use_external_cache {
-                            t.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        t.cache_cost(),
-                        t.coverage().ok()?,
-                    ))
+                    Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
                 })?,
                 [multiple_subst1, multiple_subst1_cached as _],
             ),
             (false, 2) => match PairPos::read(data).ok()? {
                 PairPos::Format1(s) => (
                     SubtableKind::PairPos1,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [pair_pos1, pair_pos1_cached as _],
                 ),
                 PairPos::Format2(s) => (
                     SubtableKind::PairPos2,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [pair_pos2, pair_pos2_cached as _],
                 ),
             },
             (true, 3) => (
                 SubtableKind::AlternateSubst1,
                 AlternateSubstFormat1::read(data).ok().and_then(|t| {
-                    Some((
-                        if use_external_cache {
-                            t.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        t.cache_cost(),
-                        t.coverage().ok()?,
-                    ))
+                    Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
                 })?,
                 [alternate_subst1, alternate_subst1_cached as _],
             ),
             (false, 3) => (
                 SubtableKind::CursivePos1,
                 CursivePosFormat1::read(data).ok().and_then(|t| {
-                    Some((
-                        if use_external_cache {
-                            t.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        t.cache_cost(),
-                        t.coverage().ok()?,
-                    ))
+                    Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
                 })?,
                 [cursive_pos1, cursive_pos1_cached as _],
             ),
             (true, 4) => (
                 SubtableKind::LigatureSubst1,
                 LigatureSubstFormat1::read(data).ok().and_then(|t| {
-                    Some((
-                        if use_external_cache {
-                            t.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        t.cache_cost(),
-                        t.coverage().ok()?,
-                    ))
+                    Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
                 })?,
                 [ligature_subst1, ligature_subst1_cached as _],
             ),
@@ -641,11 +568,7 @@ impl SubtableInfo {
                 SubtableKind::MarkBasePos1,
                 MarkBasePosFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        if use_external_cache {
-                            t.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
+                        maybe_external_cache(&t),
                         t.cache_cost(),
                         t.mark_coverage().ok()?,
                     ))
@@ -655,38 +578,18 @@ impl SubtableInfo {
             (true, 5) | (false, 7) => match SequenceContext::read(data).ok()? {
                 SequenceContext::Format1(s) => (
                     SubtableKind::ContextFormat1,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [context1, context1_cached as _],
                 ),
                 SequenceContext::Format2(s) => (
                     SubtableKind::ContextFormat2,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [context2, context2_cached as _],
                 ),
                 SequenceContext::Format3(s) => (
                     SubtableKind::ContextFormat3,
                     (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
+                        maybe_external_cache(&s),
                         s.cache_cost(),
                         s.coverages().get(0).ok()?,
                     ),
@@ -697,11 +600,7 @@ impl SubtableInfo {
                 SubtableKind::MarkLigPos1,
                 MarkLigPosFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        if use_external_cache {
-                            t.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
+                        maybe_external_cache(&t),
                         t.cache_cost(),
                         t.mark_coverage().ok()?,
                     ))
@@ -711,38 +610,18 @@ impl SubtableInfo {
             (true, 6) | (false, 8) => match ChainedSequenceContext::read(data).ok()? {
                 ChainedSequenceContext::Format1(s) => (
                     SubtableKind::ChainedContextFormat1,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [chained_context1, chained_context1_cached as _],
                 ),
                 ChainedSequenceContext::Format2(s) => (
                     SubtableKind::ChainedContextFormat2,
-                    (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
-                        s.cache_cost(),
-                        s.coverage().ok()?,
-                    ),
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [chained_context2, chained_context2_cached as _],
                 ),
                 ChainedSequenceContext::Format3(s) => (
                     SubtableKind::ChainedContextFormat3,
                     (
-                        if use_external_cache {
-                            s.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
+                        maybe_external_cache(&s),
                         s.cache_cost(),
                         s.input_coverages().get(0).ok()?,
                     ),
@@ -765,11 +644,7 @@ impl SubtableInfo {
                 SubtableKind::MarkMarkPos1,
                 MarkMarkPosFormat1::read(data).ok().and_then(|t| {
                     Some((
-                        if use_external_cache {
-                            t.external_cache_create()
-                        } else {
-                            SubtableExternalCache::None
-                        },
+                        maybe_external_cache(&t),
                         t.cache_cost(),
                         t.mark1_coverage().ok()?,
                     ))
@@ -781,15 +656,7 @@ impl SubtableInfo {
                 ReverseChainSingleSubstFormat1::read(data)
                     .ok()
                     .and_then(|t| {
-                        Some((
-                            if use_external_cache {
-                                t.external_cache_create()
-                            } else {
-                                SubtableExternalCache::None
-                            },
-                            t.cache_cost(),
-                            t.coverage().ok()?,
-                        ))
+                        Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
                     })?,
                 [rev_chain_single_subst1, rev_chain_single_subst1_cached as _],
             ),

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -620,6 +620,7 @@ impl CoverageInfo {
 pub(crate) struct ClassDefInfo {
     pub offset: u16,
     pub format: u16,
+    // For format 1 only
     pub start_glyph_id: u16,
     pub count: u16,
 }

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -8,6 +8,7 @@ use super::hb_mask_t;
 use super::ot_layout::*;
 use super::ot_layout_common::*;
 use super::set_digest::hb_set_digest_t;
+use crate::hb::ot::{ClassDefInfo, CoverageInfo};
 use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use crate::hb::unicode::GeneralCategory;
 use alloc::boxed::Box;
@@ -637,6 +638,14 @@ pub(crate) type MappingCache = hb_cache_t<
     16,  // STORAGE_BITS
 >;
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub(crate) enum SubtableCacheMode {
+    #[allow(unused)]
+    None,
+    Small,
+    Full,
+}
+
 pub(crate) struct LigatureSubstFormat1Cache {
     pub seconds: hb_set_digest_t,
     pub coverage: MappingCache,
@@ -679,11 +688,18 @@ impl PairPosFormat2Cache {
     }
 }
 
+pub(crate) struct PairPosFormat2SmallCache {
+    pub coverage: CoverageInfo,
+    pub first: ClassDefInfo,
+    pub second: ClassDefInfo,
+}
+
 pub(crate) enum SubtableExternalCache {
     None,
     LigatureSubstFormat1Cache(Box<LigatureSubstFormat1Cache>),
     PairPosFormat1Cache(Box<PairPosFormat1Cache>),
     PairPosFormat2Cache(Box<PairPosFormat2Cache>),
+    PairPosFormat2SmallCache(PairPosFormat2SmallCache),
 }
 
 /// Apply a lookup.
@@ -720,7 +736,7 @@ pub trait Apply {
         0
     }
 
-    fn external_cache_create(&self) -> SubtableExternalCache {
+    fn external_cache_create(&self, mode: SubtableCacheMode) -> SubtableExternalCache {
         // Default implementation returns None, meaning no external cache.
         // This is used to create an external cache for the subtable.
         SubtableExternalCache::None

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -639,7 +639,7 @@ pub(crate) type MappingCache = hb_cache_t<
 >;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub(crate) enum SubtableCacheMode {
+pub(crate) enum SubtableExternalCacheMode {
     #[allow(unused)]
     None,
     Small,
@@ -660,6 +660,11 @@ impl LigatureSubstFormat1Cache {
     }
 }
 
+pub(crate) struct LigatureSubstFormat1SmallCache {
+    pub coverage: CoverageInfo,
+    pub seconds: hb_set_digest_t,
+}
+
 pub(crate) struct PairPosFormat1Cache {
     pub coverage: MappingCache,
 }
@@ -670,6 +675,10 @@ impl PairPosFormat1Cache {
             coverage: MappingCache::new(),
         }
     }
+}
+
+pub(crate) struct PairPosFormat1SmallCache {
+    pub coverage: CoverageInfo,
 }
 
 pub(crate) struct PairPosFormat2Cache {
@@ -697,7 +706,9 @@ pub(crate) struct PairPosFormat2SmallCache {
 pub(crate) enum SubtableExternalCache {
     None,
     LigatureSubstFormat1Cache(Box<LigatureSubstFormat1Cache>),
+    LigatureSubstFormat1SmallCache(LigatureSubstFormat1SmallCache),
     PairPosFormat1Cache(Box<PairPosFormat1Cache>),
+    PairPosFormat1SmallCache(PairPosFormat1SmallCache),
     PairPosFormat2Cache(Box<PairPosFormat2Cache>),
     PairPosFormat2SmallCache(PairPosFormat2SmallCache),
 }
@@ -736,9 +747,10 @@ pub trait Apply {
         0
     }
 
-    fn external_cache_create(&self, mode: SubtableCacheMode) -> SubtableExternalCache {
+    fn external_cache_create(&self, mode: SubtableExternalCacheMode) -> SubtableExternalCache {
         // Default implementation returns None, meaning no external cache.
         // This is used to create an external cache for the subtable.
+        let _ = mode;
         SubtableExternalCache::None
     }
 }

--- a/src/hb/set_digest.rs
+++ b/src/hb/set_digest.rs
@@ -35,7 +35,7 @@ impl hb_set_digest_t {
         self.masks = [0; N];
     }
 
-    pub fn _full() -> Self {
+    pub fn full() -> Self {
         Self { masks: [ALL; N] }
     }
 


### PR DESCRIPTION
This adds a secondary set of smaller "caches" for the PairPos and Ligature subtables. This is basically just storing small metadata from Coverage and ClassDef tables so we can avoid a bunch of reads and bounds checks. For ligature subtables, this keeps the "seconds" set digest in the smaller cache but that could be removed.

Based on #192