### PR TITLE
Add a key for shape plans to assist with caching

### DIFF
--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -132,6 +132,7 @@ pub struct OtTables<'a> {
     pub gdef_mark_set_digests: &'a [hb_set_digest_t],
     pub coords: &'a [F2Dot14],
     pub var_store: Option<ItemVariationStore<'a>>,
+    pub feature_variations: [Option<u32>; 2],
 }
 
 impl<'a> OtTables<'a> {
@@ -140,6 +141,7 @@ impl<'a> OtTables<'a> {
         cache: &'a OtCache,
         table_offsets: &TableOffsets,
         coords: &'a [F2Dot14],
+        feature_variations: [Option<u32>; 2],
     ) -> Self {
         let gsub = table_offsets
             .gsub
@@ -176,6 +178,7 @@ impl<'a> OtTables<'a> {
             gdef_mark_set_digests: &cache.gdef_mark_set_digests,
             var_store,
             coords,
+            feature_variations,
         }
     }
 

--- a/src/hb/ot_map.rs
+++ b/src/hb/ot_map.rs
@@ -18,6 +18,7 @@ pub struct hb_ot_map_t {
     features: Vec<feature_map_t>,
     lookups: [Vec<lookup_map_t>; 2],
     stages: [Vec<StageMap>; 2],
+    feature_variations: [Option<u32>; 2],
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -151,6 +152,10 @@ impl hb_ot_map_t {
             .get(stage)
             .map_or(lookups.len(), |curr| curr.last_lookup);
         start..end
+    }
+
+    pub fn feature_variations(&self) -> &[Option<u32>; 2] {
+        &self.feature_variations
     }
 }
 
@@ -338,6 +343,7 @@ impl<'a> hb_ot_map_builder_t<'a> {
             features,
             lookups,
             stages,
+            feature_variations: self.face.ot_tables.feature_variations,
         }
     }
 
@@ -486,10 +492,7 @@ impl<'a> hb_ot_map_builder_t<'a> {
             let mut stage_index = 0;
             let mut last_lookup = 0;
 
-            let variation_index = self
-                .face
-                .layout_table(table_index)
-                .and_then(|t| t.feature_variation_index(self.face.ot_tables.coords));
+            let variation_index = self.face.ot_tables.feature_variations[table_index as usize];
 
             for stage in 0..self.current_stage[table_index] {
                 if let Some(feature_index) = required_feature_index[table_index] {

--- a/src/hb/ot_shape.rs
+++ b/src/hb/ot_shape.rs
@@ -26,6 +26,7 @@ pub struct hb_ot_shape_planner_t<'a> {
     pub face: &'a hb_font_t<'a>,
     pub direction: Direction,
     pub script: Option<Script>,
+    pub language: Option<Language>,
     pub ot_map: hb_ot_map_builder_t<'a>,
     pub apply_morx: bool,
     pub script_zero_marks: bool,
@@ -67,6 +68,7 @@ impl<'a> hb_ot_shape_planner_t<'a> {
             face,
             direction,
             script,
+            language: language.cloned(),
             ot_map,
             apply_morx,
             script_zero_marks,
@@ -176,7 +178,7 @@ impl<'a> hb_ot_shape_planner_t<'a> {
         }
     }
 
-    pub fn compile(mut self) -> hb_ot_shape_plan_t {
+    pub fn compile(mut self, features: &[Feature]) -> hb_ot_shape_plan_t {
         let ot_map = self.ot_map.compile();
 
         let frac_mask = ot_map.get_1_mask(hb_tag_t::new(b"frac"));
@@ -268,6 +270,7 @@ impl<'a> hb_ot_shape_planner_t<'a> {
         let mut plan = hb_ot_shape_plan_t {
             direction: self.direction,
             script: self.script,
+            language: self.language,
             shaper: self.shaper,
             ot_map,
             data: None,
@@ -290,6 +293,7 @@ impl<'a> hb_ot_shape_planner_t<'a> {
             apply_kerx,
             apply_morx,
             apply_trak,
+            user_features: features.into(),
         };
 
         if let Some(func) = self.shaper.create_data {

--- a/src/hb/ot_shape_plan.rs
+++ b/src/hb/ot_shape_plan.rs
@@ -1,5 +1,10 @@
 use alloc::boxed::Box;
 use core::any::Any;
+use smallvec::SmallVec;
+
+use crate::hb::common::HB_FEATURE_GLOBAL_END;
+use crate::hb::common::HB_FEATURE_GLOBAL_START;
+use crate::ShaperInstance;
 
 use super::ot_map::*;
 use super::ot_shape::*;
@@ -10,6 +15,7 @@ use super::{hb_font_t, hb_mask_t, Direction, Feature, Language, Script};
 pub struct hb_ot_shape_plan_t {
     pub(crate) direction: Direction,
     pub(crate) script: Option<Script>,
+    pub(crate) language: Option<Language>,
     pub(crate) shaper: &'static hb_ot_shaper_t,
     pub(crate) ot_map: hb_ot_map_t,
     pub(crate) data: Option<Box<dyn Any + Send + Sync>>,
@@ -35,6 +41,8 @@ pub struct hb_ot_shape_plan_t {
     pub(crate) apply_kerx: bool,
     pub(crate) apply_morx: bool,
     pub(crate) apply_trak: bool,
+
+    pub(crate) user_features: SmallVec<[Feature; 4]>,
 }
 
 impl hb_ot_shape_plan_t {
@@ -50,12 +58,79 @@ impl hb_ot_shape_plan_t {
         assert_ne!(direction, Direction::Invalid);
         let mut planner = hb_ot_shape_planner_t::new(face, direction, script, language);
         planner.collect_features(user_features);
-        planner.compile()
+        planner.compile(user_features)
     }
 
     pub(crate) fn data<T: 'static>(&self) -> &T {
         self.data.as_ref().unwrap().downcast_ref().unwrap()
     }
+}
+
+/// A key used for selecting a shape plan.
+pub struct ShapePlanKey<'a> {
+    script: Option<Script>,
+    direction: Direction,
+    language: Option<&'a Language>,
+    feature_variations: [Option<u32>; 2],
+    features: &'a [Feature],
+}
+
+impl<'a> ShapePlanKey<'a> {
+    /// Creates a new shape plan key with the given script and direction.
+    pub fn new(script: Option<Script>, direction: Direction) -> Self {
+        Self {
+            script,
+            direction,
+            language: None,
+            feature_variations: [None; 2],
+            features: &[],
+        }
+    }
+
+    /// Sets the language to use for this shape plan key.
+    pub fn language(mut self, language: Option<&'a Language>) -> Self {
+        self.language = language;
+        self
+    }
+
+    /// Sets the instance to use for this shape plan key.
+    pub fn instance(mut self, instance: Option<&ShaperInstance>) -> Self {
+        self.feature_variations = instance
+            .map(|instance| instance.feature_variations)
+            .unwrap_or_default();
+        self
+    }
+
+    /// Sets the features to use for this shape plan key.
+    pub fn features(mut self, features: &'a [Feature]) -> Self {
+        self.features = features;
+        self
+    }
+
+    /// Returns true if this key is a match for the given shape plan.
+    pub fn matches(&self, plan: &hb_ot_shape_plan_t) -> bool {
+        self.script == plan.script
+            && self.direction == plan.direction
+            && self.language == plan.language.as_ref()
+            && self.feature_variations == *plan.ot_map.feature_variations()
+            && features_equivalent(self.features, &plan.user_features)
+    }
+}
+
+fn features_equivalent(features_a: &[Feature], features_b: &[Feature]) -> bool {
+    if features_a.len() != features_b.len() {
+        return false;
+    }
+    for (a, b) in features_a.iter().zip(features_b) {
+        if a.tag != b.tag
+            || a.value != b.value
+            || (a.start == HB_FEATURE_GLOBAL_START && a.end == HB_FEATURE_GLOBAL_END)
+                != (b.start == HB_FEATURE_GLOBAL_START && b.end == HB_FEATURE_GLOBAL_END)
+        {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use read_fonts::{types::Tag, FontRef};
 pub use hb::buffer::{GlyphBuffer, GlyphInfo, GlyphPosition, UnicodeBuffer};
 pub use hb::common::{script, Direction, Feature, Language, Script, Variation};
 pub use hb::face::{hb_font_t as Shaper, ShaperBuilder, ShaperData, ShaperInstance};
-pub use hb::ot_shape_plan::hb_ot_shape_plan_t as ShapePlan;
+pub use hb::ot_shape_plan::{hb_ot_shape_plan_t as ShapePlan, ShapePlanKey};
 
 /// Type alias for a normalized variation coordinate.
 pub type NormalizedCoord = read_fonts::types::F2Dot14;


### PR DESCRIPTION
Basic usage looks like...

```rust
let key = ShapePlanKey::new(Some(script), Direction::LeftToRight)
    .instance(Some(&instance))
    .features(my_features);

if key.matches(&some_plan) {
   // use me!
}
```