### PR TITLE
[ligature-cache] Handle case of ligature with no components

### DIFF
--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -214,11 +214,11 @@ fn collect_seconds(lig_subst: &LigatureSubstFormat1) -> hb_set_digest_t {
                 .iter()
                 .filter_map(Result::ok)
                 .for_each(|lig| {
-                    seconds.add(if let Some(gid) = lig.component_glyph_ids().first() {
-                        gid.get().into()
+                    if let Some(gid) = lig.component_glyph_ids().first() {
+                        seconds.add(gid.get().into());
                     } else {
-                        GlyphId::new(0)
-                    });
+                        seconds = hb_set_digest_t::full();
+                    };
                 });
         });
     seconds


### PR DESCRIPTION
In the cache with "seconds" set-digest.

From HB https://github.com/harfbuzz/harfbuzz/pull/5500