### PR TITLE
Minor optimizations for (Chain)ContextFormat2

### DIFF
--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -557,7 +557,7 @@ fn glyph_class_cached(
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Default, Debug)]
 pub(crate) struct CoverageInfo {
     pub offset: u16,
     pub format: u16,
@@ -582,6 +582,9 @@ impl CoverageInfo {
     }
 
     pub fn index(&self, parent_data: &FontData, gid: GlyphId) -> Option<u16> {
+        if self.offset == 0 {
+            return None;
+        }
         let gid = gid.to_u32();
         let data_offset = self.offset as usize + 4;
         let len = self.count as usize;
@@ -619,7 +622,7 @@ impl CoverageInfo {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Default, Debug)]
 pub(crate) struct ClassDefInfo {
     pub offset: u16,
     pub format: u16,
@@ -657,12 +660,15 @@ impl ClassDefInfo {
 
     pub fn class(&self, parent_data: &FontData, gid: GlyphId) -> u16 {
         let offset = self.offset as usize;
+        if offset == 0 {
+            return 0;
+        }
         let gid = gid.to_u32();
         if self.format == 1 {
             let Some(idx) = gid.checked_sub(self.start_glyph_id as u32) else {
                 return 0;
             };
-            if idx > self.count as u32 {
+            if idx >= self.count as u32 {
                 return 0;
             }
             parent_data

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -700,6 +700,18 @@ pub(crate) struct PairPosFormat2SmallCache {
     pub second: ClassDefInfo,
 }
 
+pub(crate) struct ContextFormat2Cache {
+    pub coverage: CoverageInfo,
+    pub input: ClassDefInfo,
+}
+
+pub(crate) struct ChainContextFormat2Cache {
+    pub coverage: CoverageInfo,
+    pub backtrack: ClassDefInfo,
+    pub input: ClassDefInfo,
+    pub lookahead: ClassDefInfo,
+}
+
 pub(crate) enum SubtableExternalCache {
     None,
     LigatureSubstFormat1Cache(Box<LigatureSubstFormat1Cache>),
@@ -708,6 +720,8 @@ pub(crate) enum SubtableExternalCache {
     PairPosFormat1SmallCache(PairPosFormat1SmallCache),
     PairPosFormat2Cache(Box<PairPosFormat2Cache>),
     PairPosFormat2SmallCache(PairPosFormat2SmallCache),
+    ContextFormat2Cache(ContextFormat2Cache),
+    ChainContextFormat2Cache(ChainContextFormat2Cache),
 }
 
 /// Apply a lookup.


### PR DESCRIPTION
We have some unused space in the external subtable cache so use it for these tables to avoid some fontations overhead. Seems to buy a little bit on Nastaliq according to HR benches.