### PR TITLE
Fix copy/pasta error in porting code for contextual

### DIFF
--- a/src/hb/ot/contextual.rs
+++ b/src/hb/ot/contextual.rs
@@ -171,7 +171,7 @@ impl Apply for SequenceContextFormat3<'_> {
             None,
         ) {
             ctx.buffer
-                .unsafe_to_break_from_outbuffer(Some(ctx.buffer.idx), Some(match_end));
+                .unsafe_to_break(Some(ctx.buffer.idx), Some(match_end));
             apply_lookup(
                 ctx,
                 input_coverages.len() - 1,


### PR DESCRIPTION
HB has unsafe_to_break here.