### PR TITLE
[buffer] Retain digest in the buffer

### DIFF
--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -430,6 +430,9 @@ pub struct hb_buffer_t {
     pub context: [[Codepoint; CONTEXT_LENGTH]; 2],
     pub context_len: [usize; 2],
 
+    pub(crate) digest: hb_set_digest_t,
+    pub(crate) glyph_set: U32Set,
+
     // Managed by enter / leave
     pub allocated_var_bits: u8,
     pub serial: u8,
@@ -438,8 +441,6 @@ pub struct hb_buffer_t {
     pub max_len: usize,
     /// Maximum allowed operations.
     pub max_ops: i32,
-
-    pub(crate) glyph_set: U32Set,
 }
 
 impl hb_buffer_t {
@@ -479,6 +480,7 @@ impl hb_buffer_t {
             serial: 0,
             context: Default::default(),
             context_len: [0, 0],
+            digest: hb_set_digest_t::new(),
             glyph_set: U32Set::default(),
         }
     }
@@ -582,10 +584,9 @@ impl hb_buffer_t {
         &mut self.out_info_mut()[idx]
     }
 
-    pub fn digest(&self) -> hb_set_digest_t {
-        let mut digest = hb_set_digest_t::new();
-        digest.add_array(self.info.iter().map(|i| i.glyph_id));
-        digest
+    pub fn update_digest(&mut self) {
+        self.digest = hb_set_digest_t::new();
+        self.digest.add_array(self.info.iter().map(|i| i.glyph_id));
     }
     pub fn update_glyph_set(&mut self) {
         self.glyph_set.clear();

--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -160,7 +160,7 @@ pub fn apply_layout_table<T: LayoutTable>(
                     continue;
                 };
 
-                if lookup.digest().may_intersect(&ctx.digest) {
+                if lookup.digest().may_intersect(&ctx.buffer.digest) {
                     ctx.lookup_index = lookup_map.index;
                     ctx.set_lookup_mask(lookup_map.mask);
                     ctx.auto_zwj = lookup_map.auto_zwj;
@@ -176,7 +176,7 @@ pub fn apply_layout_table<T: LayoutTable>(
 
         if let Some(func) = stage.pause_func {
             if func(plan, face, ctx.buffer) {
-                ctx.digest = ctx.buffer.digest();
+                ctx.buffer.update_digest();
             }
         }
     }

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -773,7 +773,6 @@ pub struct WouldApplyContext<'a> {
 
 pub mod OT {
     use super::*;
-    use crate::hb::set_digest::hb_set_digest_t;
 
     fn match_properties_mark(
         face: &hb_font_t,
@@ -845,7 +844,6 @@ pub mod OT {
         pub new_syllables: Option<u8>,
         pub last_base: i32,
         pub last_base_until: u32,
-        pub digest: hb_set_digest_t,
         pub(crate) matcher: matcher_t,
         pub(crate) context_matcher: matcher_t,
         pub(crate) match_positions_len: usize,
@@ -858,7 +856,6 @@ pub mod OT {
             face: &'a hb_font_t<'a>,
             buffer: &'a mut hb_buffer_t,
         ) -> Self {
-            let buffer_digest = buffer.digest();
             Self {
                 table_index,
                 face,
@@ -876,7 +873,6 @@ pub mod OT {
                 new_syllables: None,
                 last_base: -1,
                 last_base_until: 0,
-                digest: buffer_digest,
                 matcher: matcher_t::default(),
                 context_matcher: matcher_t::default(),
                 match_positions_len: 0,
@@ -951,7 +947,7 @@ pub mod OT {
             ligature: bool,
             component: bool,
         ) {
-            self.digest.add(glyph_id.into());
+            self.buffer.digest.add(glyph_id.into());
 
             if let Some(syllable) = self.new_syllables {
                 self.buffer.cur_mut(0).set_syllable(syllable);

--- a/src/hb/ot_shape.rs
+++ b/src/hb/ot_shape.rs
@@ -406,7 +406,9 @@ fn hb_ot_substitute_plan(ctx: &mut hb_ot_shape_context_t) {
 
     if ctx.plan.apply_morx {
         aat::layout::substitute(ctx.plan, ctx.face, ctx.buffer, ctx.features);
+        ctx.buffer.update_digest();
     } else {
+        ctx.buffer.update_digest();
         ot_layout_gsub_table::substitute(ctx.plan, ctx.face, ctx.buffer);
     }
 }


### PR DESCRIPTION
We don't have to reinitialize it for GPOS now, showing some 1.5% speedup on Roboto-Regular benchmark.

Over time we can change the various gsub_pauses to update the digest in-place instead of returning true.

From HB https://github.com/harfbuzz/harfbuzz/pull/5576 and b2a6375b8138d1189d6d719a92e9d88b92a0b669