### PR TITLE
[shape] Use a buffer scratch flag for continuations (#5586)

### DIFF
--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -374,6 +374,7 @@ impl GlyphInfo {
             }
 
             if gc.is_mark() {
+                *scratch_flags |= HB_BUFFER_SCRATCH_FLAG_HAS_CONTINUATIONS;
                 props |= UnicodeProps::CONTINUATION.bits();
                 props |= (u.modified_combining_class() as u16) << 8;
             }
@@ -1696,6 +1697,7 @@ pub const HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_ATTACHMENT: u32 = 0x0000_0008;
 pub const HB_BUFFER_SCRATCH_FLAG_HAS_CGJ: u32 = 0x0000_0010;
 pub const HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE: u32 = 0x0000_0020;
 pub const HB_BUFFER_SCRATCH_FLAG_HAS_VARIATION_SELECTOR_FALLBACK: u32 = 0x0000_0040;
+pub const HB_BUFFER_SCRATCH_FLAG_HAS_CONTINUATIONS: u32 = 0x0000_0080;
 
 /* Reserved for shapers' internal use. */
 pub const HB_BUFFER_SCRATCH_FLAG_SHAPER0: u32 = 0x0100_0000;

--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -554,7 +554,8 @@ impl GlyphInfo {
     /// See <https://github.com/harfbuzz/harfbuzz/blob/368598b5bd9c37a15cb0fd5438b8e617e254609b/src/hb-ot-layout.hh#L365>
     #[doc(alias = "_hb_glyph_info_set_continuation")]
     #[inline]
-    pub(crate) fn set_continuation(&mut self) {
+    pub(crate) fn set_continuation(&mut self, scratch_flags: &mut hb_buffer_scratch_flags_t) {
+        *scratch_flags |= HB_BUFFER_SCRATCH_FLAG_HAS_CONTINUATIONS;
         let mut n = self.unicode_props();
         n |= UnicodeProps::CONTINUATION.bits();
         self.set_unicode_props(n);

--- a/src/hb/ot_shaper_thai.rs
+++ b/src/hb/ot_shaper_thai.rs
@@ -385,7 +385,8 @@ fn preprocess_text(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_
         buffer.output_glyph(nikhahit_from_sara_am(u));
         {
             let out_idx = buffer.out_len - 1;
-            buffer.out_info_mut()[out_idx].set_continuation();
+            let mut info = buffer.out_info_mut()[out_idx];
+            info.set_continuation(&mut buffer.scratch_flags);
         }
         buffer.replace_glyph(sara_aa_from_sara_am(u));
 


### PR DESCRIPTION
Use it in form_clusters instead of ascii flag, for speedup.

From HB.