### PR TITLE
Use a single Buffer type

### DIFF
--- a/benches/shaping.rs
+++ b/benches/shaping.rs
@@ -41,7 +41,7 @@ impl ShapePlanCache {
     fn get(
         &mut self,
         shaper: &harfrust::Shaper,
-        buffer: &harfrust::UnicodeBuffer,
+        buffer: &harfrust::Buffer,
     ) -> &harfrust::ShapePlan {
         let key = harfrust::ShapePlanKey::new(Some(buffer.script()), buffer.direction());
         if let Some(plan_idx) = self.plans.iter().position(|plan| key.matches(plan)) {
@@ -80,14 +80,14 @@ fn bench(c: &mut Criterion) {
             let state = HrTestState::new(&font);
             let shaper = state.shaper();
             let mut plan_cache = ShapePlanCache::default();
-            let mut shared_buffer = Some(harfrust::UnicodeBuffer::new());
+            let mut buffer = harfrust::Buffer::new();
             b.iter(|| {
                 for line in &lines {
-                    let mut buffer = shared_buffer.take().unwrap();
+                    buffer.clear();
                     buffer.push_str(line);
                     buffer.guess_segment_properties();
                     let plan = plan_cache.get(&shaper, &buffer);
-                    shared_buffer = Some(shaper.shape_with_plan(plan, buffer, &[]).clear());
+                    shaper.shape_with_plan(plan, &mut buffer, &[]);
                 }
             });
         });

--- a/examples/shape.rs
+++ b/examples/shape.rs
@@ -182,7 +182,7 @@ fn main() {
     };
 
     for text in lines {
-        let mut buffer = harfrust::UnicodeBuffer::new();
+        let mut buffer = harfrust::Buffer::new();
         buffer.push_str(text);
 
         if let Some(d) = args.direction {
@@ -207,7 +207,7 @@ fn main() {
 
         buffer.guess_segment_properties();
 
-        let glyph_buffer = shaper.shape(buffer, &args.features);
+        shaper.shape(&mut buffer, &args.features);
 
         let mut format_flags = harfrust::SerializeFlags::default();
         if args.no_glyph_names {
@@ -234,7 +234,7 @@ fn main() {
             format_flags |= harfrust::SerializeFlags::GLYPH_FLAGS;
         }
 
-        println!("{}", glyph_buffer.serialize(&shaper, format_flags));
+        println!("{}", buffer.serialize(&shaper, format_flags));
     }
 }
 

--- a/src/hb/aat/layout.rs
+++ b/src/hb/aat/layout.rs
@@ -4,7 +4,7 @@ use super::map;
 use super::{layout_kerx_table, layout_morx_table, layout_trak_table};
 use crate::hb::aat::layout_common::{AatApplyContext, HB_BUFFER_SCRATCH_FLAG_AAT_HAS_DELETED};
 use crate::hb::{
-    buffer::hb_buffer_t, hb_font_t, hb_tag_t, ot_shape_plan::hb_ot_shape_plan_t, GlyphInfo,
+    buffer::Buffer, hb_font_t, hb_tag_t, ot_shape_plan::hb_ot_shape_plan_t, GlyphInfo,
 };
 use crate::Feature;
 
@@ -502,7 +502,7 @@ pub const DELETED_GLYPH: u32 = 0xFFFF;
 pub fn substitute(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     features: &[Feature],
 ) {
     let mut aat_map = map::AatMap::default();
@@ -533,7 +533,7 @@ fn is_deleted_glyph(info: &GlyphInfo) -> bool {
 ///
 /// See <https://github.com/harfbuzz/harfbuzz/blob/2c22a65f0cb99544c36580b9703a43b5dc97a9e1/src/hb-aat-layout.cc#L337>
 #[doc(alias = "hb_aat_layout_remove_deleted_glyphs")]
-pub fn remove_deleted_glyphs(buffer: &mut hb_buffer_t) {
+pub fn remove_deleted_glyphs(buffer: &mut Buffer) {
     if (buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_AAT_HAS_DELETED) != 0 {
         buffer.delete_glyphs_inplace(is_deleted_glyph);
     }
@@ -543,7 +543,7 @@ pub fn remove_deleted_glyphs(buffer: &mut hb_buffer_t) {
 ///
 /// See <https://github.com/harfbuzz/harfbuzz/blob/2c22a65f0cb99544c36580b9703a43b5dc97a9e1/src/hb-aat-layout.cc#L363>
 #[doc(alias = "hb_aat_layout_position")]
-pub fn position(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+pub fn position(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) {
     let mut c = AatApplyContext::new(plan, face, buffer);
     layout_kerx_table::apply(&mut c);
 }
@@ -552,6 +552,6 @@ pub fn position(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buf
 ///
 /// See <https://github.com/harfbuzz/harfbuzz/blob/2c22a65f0cb99544c36580b9703a43b5dc97a9e1/src/hb-aat-layout.cc#L398>
 #[doc(alias = "hb_aat_layout_track")]
-pub fn track(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+pub fn track(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) {
     layout_trak_table::apply(plan, face, buffer);
 }

--- a/src/hb/aat/layout_common.rs
+++ b/src/hb/aat/layout_common.rs
@@ -1,6 +1,6 @@
 use super::layout::DELETED_GLYPH;
 use super::map::RangeFlags;
-use crate::hb::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_SHAPER0};
+use crate::hb::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_SHAPER0};
 use crate::hb::face::hb_font_t;
 use crate::hb::hb_mask_t;
 use crate::hb::ot_layout_gsubgpos::MappingCache;
@@ -37,7 +37,7 @@ pub(crate) fn get_class<T: bytemuck::AnyBitPattern + FixedSize>(
 pub struct AatApplyContext<'a> {
     pub plan: &'a hb_ot_shape_plan_t,
     pub face: &'a hb_font_t<'a>,
-    pub buffer: &'a mut hb_buffer_t,
+    pub buffer: &'a mut Buffer,
     pub has_glyph_classes: bool,
     pub range_flags: Option<&'a [RangeFlags]>,
     pub subtable_flags: hb_mask_t,
@@ -54,7 +54,7 @@ impl<'a> AatApplyContext<'a> {
     pub fn new(
         plan: &'a hb_ot_shape_plan_t,
         face: &'a hb_font_t<'a>,
-        buffer: &'a mut hb_buffer_t,
+        buffer: &'a mut Buffer,
     ) -> Self {
         Self {
             plan,

--- a/src/hb/aat/layout_trak_table.rs
+++ b/src/hb/aat/layout_trak_table.rs
@@ -6,9 +6,9 @@ use read_fonts::tables::trak::TrackTableEntry;
 use read_fonts::types::{BigEndian, Fixed};
 use read_fonts::FontData;
 
-use crate::hb::{buffer::hb_buffer_t, hb_font_t, ot_shape_plan::hb_ot_shape_plan_t};
+use crate::hb::{buffer::Buffer, hb_font_t, ot_shape_plan::hb_ot_shape_plan_t};
 
-pub fn apply(_plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) -> Option<()> {
+pub fn apply(_plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) -> Option<()> {
     let trak = face.aat_tables.trak.as_ref()?;
     let mut ptem = face.points_per_em.unwrap_or(0.0);
     if ptem <= 0.0 {

--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -6,8 +6,8 @@ use read_fonts::types::{GlyphId, GlyphId16};
 
 use super::buffer::glyph_flag::{SAFE_TO_INSERT_TATWEEL, UNSAFE_TO_BREAK, UNSAFE_TO_CONCAT};
 use super::face::hb_glyph_extents_t;
+use super::hb_mask_t;
 use super::unicode::CharExt;
-use super::{hb_font_t, hb_mask_t};
 use crate::hb::set_digest::hb_set_digest_t;
 use crate::hb::unicode::Codepoint;
 use crate::{script, BufferClusterLevel, BufferFlags, Direction, Language, Script, SerializeFlags};
@@ -389,6 +389,17 @@ impl GlyphInfo {
     }
 }
 
+/// The type of [`Buffer`] contents.
+///
+/// HarfBuzz calls this `hb_buffer_content_type_t`.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum BufferContentType {
+    /// The buffer contains input characters (before shaping).
+    Unicode,
+    /// The buffer contains output glyphs (after shaping).
+    Glyphs,
+}
+
 pub type hb_buffer_cluster_level_t = u32;
 pub const HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES: u32 = 0;
 pub const HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS: u32 = 1;
@@ -396,66 +407,59 @@ pub const HB_BUFFER_CLUSTER_LEVEL_CHARACTERS: u32 = 2;
 pub const HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES: u32 = 3;
 pub const HB_BUFFER_CLUSTER_LEVEL_DEFAULT: u32 = HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES;
 
-pub struct hb_buffer_t {
+/// The main structure holding the input text and its properties before
+/// shaping, and output glyphs and their information after shaping.
+pub struct Buffer {
     // Information about how the text in the buffer should be treated.
-    pub flags: BufferFlags,
-    pub cluster_level: hb_buffer_cluster_level_t,
-    pub invisible: Option<GlyphId>,
-    pub not_found_variation_selector: Option<u32>,
+    pub(crate) flags: BufferFlags,
+    pub(crate) cluster_level: hb_buffer_cluster_level_t,
+    pub(crate) invisible: Option<GlyphId>,
+    pub(crate) not_found_variation_selector: Option<u32>,
 
     // Buffer contents.
-    pub direction: Direction,
-    pub script: Option<Script>,
-    pub language: Option<Language>,
+    pub(crate) content_type: Option<BufferContentType>,
+    pub(crate) direction: Direction,
+    pub(crate) script: Option<Script>,
+    pub(crate) language: Option<Language>,
 
     /// Allocations successful.
-    pub successful: bool,
+    pub(crate) successful: bool,
     /// Whether we have an output buffer going on.
     pub(crate) have_output: bool,
-    pub have_separate_output: bool,
+    pub(crate) have_separate_output: bool,
     /// Whether we have positions
-    pub have_positions: bool,
+    pub(crate) have_positions: bool,
 
-    pub idx: usize,
-    pub len: usize,
-    pub out_len: usize,
+    pub(crate) idx: usize,
+    pub(crate) len: usize,
+    pub(crate) out_len: usize,
 
-    pub info: Vec<GlyphInfo>,
-    pub pos: Vec<GlyphPosition>,
+    pub(crate) info: Vec<GlyphInfo>,
+    pub(crate) pos: Vec<GlyphPosition>,
 
     // Text before / after the main buffer contents.
     // Always in Unicode, and ordered outward.
     // Index 0 is for "pre-context", 1 for "post-context".
-    pub context: [[Codepoint; CONTEXT_LENGTH]; 2],
-    pub context_len: [usize; 2],
+    pub(crate) context: [[Codepoint; CONTEXT_LENGTH]; 2],
+    pub(crate) context_len: [usize; 2],
 
     pub(crate) digest: hb_set_digest_t,
     pub(crate) glyph_set: U32Set,
 
     // Managed by enter / leave
-    pub allocated_var_bits: u8,
-    pub serial: u8,
-    pub scratch_flags: hb_buffer_scratch_flags_t,
+    pub(crate) allocated_var_bits: u8,
+    pub(crate) serial: u8,
+    pub(crate) scratch_flags: hb_buffer_scratch_flags_t,
     /// Maximum allowed len.
-    pub max_len: usize,
+    pub(crate) max_len: usize,
     /// Maximum allowed operations.
-    pub max_ops: i32,
+    pub(crate) max_ops: i32,
 }
 
-impl hb_buffer_t {
-    pub const MAX_LEN_FACTOR: usize = 256;
-    pub const MAX_LEN_MIN: usize = 65536;
-    // Shaping more than a billion chars? Let us know!
-    pub const MAX_LEN_DEFAULT: usize = 0x3FFF_FFFF;
-
-    pub const MAX_OPS_FACTOR: i32 = 4096;
-    pub const MAX_OPS_MIN: i32 = 65536;
-    // Shaping more than a billion operations? Let us know!
-    pub const MAX_OPS_DEFAULT: i32 = 0x1FFF_FFFF;
-
+impl Buffer {
     /// Creates a new `Buffer`.
     pub fn new() -> Self {
-        hb_buffer_t {
+        Buffer {
             flags: BufferFlags::empty(),
             cluster_level: HB_BUFFER_CLUSTER_LEVEL_DEFAULT,
             invisible: None,
@@ -463,6 +467,7 @@ impl hb_buffer_t {
             not_found_variation_selector: None,
             max_len: Self::MAX_LEN_DEFAULT,
             max_ops: Self::MAX_OPS_DEFAULT,
+            content_type: None,
             direction: Direction::Invalid,
             script: None,
             language: None,
@@ -484,116 +489,21 @@ impl hb_buffer_t {
         }
     }
 
+    /// Returns the length of the data of the buffer.
     #[inline]
-    pub fn allocate_var(&mut self, shape: buffer_var_shape) {
-        let bits = shape.bits();
-        debug_assert_eq!(
-            self.allocated_var_bits & bits,
-            0,
-            "Variable already allocated"
-        );
-        self.allocated_var_bits |= bits;
+    pub fn len(&self) -> usize {
+        self.len
     }
 
+    /// Returns `true` if the buffer contains no elements.
     #[inline]
-    pub fn try_allocate_var(&mut self, shape: buffer_var_shape) -> bool {
-        let bits = shape.bits();
-        if self.allocated_var_bits & bits != 0 {
-            return false;
-        }
-        self.allocated_var_bits |= bits;
-        true
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
-    #[inline]
-    pub fn deallocate_var(&mut self, shape: buffer_var_shape) {
-        let bits = shape.bits();
-        debug_assert_eq!(
-            self.allocated_var_bits & bits,
-            bits,
-            "Deallocating unallocated var"
-        );
-        self.allocated_var_bits &= !bits;
-    }
-
-    #[inline]
-    pub fn assert_var(&self, shape: buffer_var_shape) {
-        let bits = shape.bits();
-        debug_assert_eq!(
-            self.allocated_var_bits & bits,
-            bits,
-            "Variable not allocated"
-        );
-    }
-
-    #[inline]
-    pub fn info_slice_mut(&mut self) -> &mut [GlyphInfo] {
-        &mut self.info[..self.len]
-    }
-
-    #[inline]
-    pub fn out_info(&self) -> &[GlyphInfo] {
-        if self.have_separate_output {
-            bytemuck::cast_slice(self.pos.as_slice())
-        } else {
-            &self.info
-        }
-    }
-
-    #[inline]
-    pub fn out_info_mut(&mut self) -> &mut [GlyphInfo] {
-        if self.have_separate_output {
-            bytemuck::cast_slice_mut(self.pos.as_mut_slice())
-        } else {
-            &mut self.info
-        }
-    }
-
-    #[inline]
-    fn set_out_info(&mut self, i: usize, info: GlyphInfo) {
-        self.out_info_mut()[i] = info;
-    }
-
-    #[inline]
-    pub fn cur(&self, i: usize) -> &GlyphInfo {
-        &self.info[self.idx + i]
-    }
-
-    #[inline]
-    pub fn cur_mut(&mut self, i: usize) -> &mut GlyphInfo {
-        let idx = self.idx + i;
-        &mut self.info[idx]
-    }
-
-    #[inline]
-    pub fn cur_pos_mut(&mut self) -> &mut GlyphPosition {
-        let i = self.idx;
-        &mut self.pos[i]
-    }
-
-    #[inline]
-    pub fn prev(&self) -> &GlyphInfo {
-        let idx = self.out_len.saturating_sub(1);
-        &self.out_info()[idx]
-    }
-
-    #[inline]
-    pub fn prev_mut(&mut self) -> &mut GlyphInfo {
-        let idx = self.out_len.saturating_sub(1);
-        &mut self.out_info_mut()[idx]
-    }
-
-    pub fn update_digest(&mut self) {
-        self.digest = hb_set_digest_t::new();
-        self.digest.add_array(self.info.iter().map(|i| i.glyph_id));
-    }
-    pub fn update_glyph_set(&mut self) {
-        self.glyph_set.clear();
-        self.glyph_set
-            .extend_unsorted(self.info.iter().map(|i| i.glyph_id));
-    }
-
-    fn clear(&mut self) {
+    /// Clears the contents of the buffer.
+    pub fn clear(&mut self) {
+        self.content_type = None;
         self.direction = Direction::Invalid;
         self.script = None;
         self.language = None;
@@ -618,8 +528,439 @@ impl hb_buffer_t {
         self.not_found_variation_selector = None;
     }
 
+    /// Ensures that the buffer has capacity to hold at least `size` elements.
+    #[must_use]
+    #[inline(always)]
+    pub fn reserve(&mut self, size: usize) -> bool {
+        if size <= self.info.len() {
+            true
+        } else {
+            self.enlarge(size)
+        }
+    }
+
+    /// Returns the type of the buffer contents.
+    ///
+    /// Buffers are either empty, contain characters (before shaping), or
+    /// contain glyphs (the result of shaping).
+    pub fn content_type(&self) -> Option<BufferContentType> {
+        self.content_type
+    }
+
+    /// Pushes a string to the buffer.
+    pub fn push_str(&mut self, text: &str) {
+        if self.content_type == Some(BufferContentType::Glyphs) {
+            // TODO: return an error
+            return;
+        }
+        if !self.reserve(self.len + text.chars().count()) {
+            return;
+        }
+        if !text.is_empty() {
+            self.content_type = Some(BufferContentType::Unicode);
+        }
+        for (i, c) in text.char_indices() {
+            self.info[self.len] = GlyphInfo {
+                glyph_id: c as u32,
+                cluster: i as u32,
+                ..GlyphInfo::default()
+            };
+            self.len += 1;
+        }
+    }
+
+    /// Appends a character to a buffer with the given cluster value.
     #[inline]
-    pub fn backtrack_len(&self) -> usize {
+    pub fn push(&mut self, codepoint: char, cluster: u32) {
+        if self.content_type == Some(BufferContentType::Glyphs) {
+            // TODO: return an error
+            return;
+        }
+        self.add(codepoint as u32, cluster);
+        self.context_len[1] = 0;
+        self.content_type = Some(BufferContentType::Unicode);
+    }
+
+    /// Sets the pre-context for the buffer.
+    pub fn set_pre_context(&mut self, text: &str) {
+        self.clear_context(0);
+        for (i, c) in text.chars().rev().enumerate().take(CONTEXT_LENGTH) {
+            self.context[0][i] = c as Codepoint;
+            self.context_len[0] += 1;
+        }
+    }
+
+    /// Sets the post-context for the buffer.
+    pub fn set_post_context(&mut self, text: &str) {
+        self.clear_context(1);
+        for (i, c) in text.chars().enumerate().take(CONTEXT_LENGTH) {
+            self.context[1][i] = c as Codepoint;
+            self.context_len[1] += 1;
+        }
+    }
+
+    /// Set the text direction of the `Buffer`'s contents.
+    #[inline]
+    pub fn set_direction(&mut self, direction: Direction) {
+        self.direction = direction;
+    }
+
+    /// Returns the `Buffer`'s text direction.
+    #[inline]
+    pub fn direction(&self) -> Direction {
+        self.direction
+    }
+
+    /// Set the script from an ISO15924 tag.
+    #[inline]
+    pub fn set_script(&mut self, script: Script) {
+        self.script = Some(script);
+    }
+
+    /// Get the ISO15924 script tag.
+    pub fn script(&self) -> Script {
+        self.script.unwrap_or(script::UNKNOWN)
+    }
+
+    /// Set the buffer language.
+    #[inline]
+    pub fn set_language(&mut self, lang: Language) {
+        self.language = Some(lang);
+    }
+
+    /// Get the buffer language.
+    #[inline]
+    pub fn language(&self) -> Option<&Language> {
+        self.language.as_ref()
+    }
+
+    /// Set the glyph value to replace not-found variation-selector characters with.
+    #[inline]
+    pub fn set_not_found_variation_selector_glyph(&mut self, glyph: u32) {
+        self.not_found_variation_selector = Some(glyph);
+    }
+
+    /// Sets unset buffer segment properties based on buffer Unicode contents.
+    ///
+    /// If the buffer is not empty, it must have content type [`BufferContentType::Unicode`].
+    ///
+    /// If buffer script is not set, it will be set to the Unicode script of
+    /// the first character in the buffer that has a script other than common,
+    /// inherited, and unknown.
+    ///
+    /// Next, if the buffer direction is not set, it will be set to the natural
+    /// horizontal direction of the buffer script as returned by
+    /// `Direction::from_script`. If that returns `None` then
+    /// [`Direction::LeftToRight`] is used.
+    ///
+    /// Unlike HarfBuzz, we do not set the language to the process's default
+    /// language if unset.
+    pub fn guess_segment_properties(&mut self) {
+        if self.script.is_none() {
+            for info in &self.info {
+                match info.as_codepoint().script() {
+                    script::COMMON | script::INHERITED | script::UNKNOWN => {}
+                    s => {
+                        self.script = Some(s);
+                        break;
+                    }
+                }
+            }
+        }
+        if self.direction == Direction::Invalid {
+            if let Some(script) = self.script {
+                self.direction = Direction::from_script(script).unwrap_or_default();
+            }
+
+            if self.direction == Direction::Invalid {
+                self.direction = Direction::LeftToRight;
+            }
+        }
+        // TODO: language must be set
+    }
+
+    /// Set the flags for this buffer.
+    #[inline]
+    pub fn set_flags(&mut self, flags: BufferFlags) {
+        self.flags = flags;
+    }
+
+    /// Get the flags for this buffer.
+    #[inline]
+    pub fn flags(&self) -> BufferFlags {
+        self.flags
+    }
+
+    /// Set the cluster level of the buffer.
+    #[inline]
+    pub fn set_cluster_level(&mut self, cluster_level: BufferClusterLevel) {
+        self.cluster_level = match cluster_level {
+            BufferClusterLevel::MonotoneGraphemes => HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES,
+            BufferClusterLevel::MonotoneCharacters => HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS,
+            BufferClusterLevel::Characters => HB_BUFFER_CLUSTER_LEVEL_CHARACTERS,
+            BufferClusterLevel::Graphemes => HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES,
+        }
+    }
+
+    /// Retrieve the cluster level of the buffer.
+    #[inline]
+    pub fn cluster_level(&self) -> BufferClusterLevel {
+        match self.cluster_level {
+            HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES => BufferClusterLevel::MonotoneGraphemes,
+            HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS => BufferClusterLevel::MonotoneCharacters,
+            HB_BUFFER_CLUSTER_LEVEL_CHARACTERS => BufferClusterLevel::Characters,
+            HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES => BufferClusterLevel::Graphemes,
+            _ => BufferClusterLevel::MonotoneGraphemes,
+        }
+    }
+
+    /// Resets clusters.
+    #[inline]
+    pub fn reset_clusters(&mut self) {
+        for (i, info) in self.info.iter_mut().enumerate() {
+            info.cluster = i as u32;
+        }
+    }
+
+    /// Reverses the buffer contents.
+    #[inline]
+    pub fn reverse(&mut self) {
+        if self.is_empty() {
+            return;
+        }
+
+        self.reverse_range(0, self.len);
+    }
+
+    /// Reverses the buffer contents between `start` and `end`.
+    pub fn reverse_range(&mut self, start: usize, end: usize) {
+        if end - start < 2 {
+            return;
+        }
+
+        self.info[start..end].reverse();
+        if self.have_positions {
+            self.pos[start..end].reverse();
+        }
+    }
+
+    /// Get the glyph infos.
+    #[inline]
+    pub fn glyph_infos(&self) -> &[GlyphInfo] {
+        &self.info[0..self.len]
+    }
+
+    /// Get the glyph positions.
+    #[inline]
+    pub fn glyph_positions(&self) -> &[GlyphPosition] {
+        if self.have_positions {
+            &self.pos[0..self.len]
+        } else {
+            &[]
+        }
+    }
+
+    /// Converts the glyph buffer content into a string.
+    pub fn serialize(&self, shaper: &crate::Shaper, flags: SerializeFlags) -> String {
+        self.serialize_impl(shaper, flags).unwrap_or_default()
+    }
+
+    fn serialize_impl(
+        &self,
+        shaper: &crate::Shaper,
+        flags: SerializeFlags,
+    ) -> Result<String, core::fmt::Error> {
+        use core::fmt::Write;
+
+        let mut s = String::with_capacity(64);
+
+        let info = self.glyph_infos();
+        let pos = self.glyph_positions();
+        let mut x = 0;
+        let mut y = 0;
+        let names = shaper.glyph_names();
+        for (info, pos) in info.iter().zip(pos) {
+            s.push(if s.is_empty() { '[' } else { '|' });
+
+            if !flags.contains(SerializeFlags::NO_GLYPH_NAMES) {
+                match names.get(info.as_glyph().to_u32()) {
+                    Some(name) => s.push_str(name),
+                    None => write!(&mut s, "gid{}", info.glyph_id)?,
+                }
+            } else {
+                write!(&mut s, "{}", info.glyph_id)?;
+            }
+
+            if !flags.contains(SerializeFlags::NO_CLUSTERS) {
+                write!(&mut s, "={}", info.cluster)?;
+            }
+
+            if !flags.contains(SerializeFlags::NO_POSITIONS) {
+                if x + pos.x_offset != 0 || y + pos.y_offset != 0 {
+                    write!(&mut s, "@{},{}", x + pos.x_offset, y + pos.y_offset)?;
+                }
+
+                if !flags.contains(SerializeFlags::NO_ADVANCES) {
+                    write!(&mut s, "+{}", pos.x_advance)?;
+                    if pos.y_advance != 0 {
+                        write!(&mut s, ",{}", pos.y_advance)?;
+                    }
+                }
+            }
+
+            if flags.contains(SerializeFlags::GLYPH_FLAGS) {
+                if info.mask & glyph_flag::DEFINED != 0 {
+                    write!(&mut s, "#{:X}", info.mask & glyph_flag::DEFINED)?;
+                }
+            }
+
+            if flags.contains(SerializeFlags::GLYPH_EXTENTS) {
+                let mut extents = hb_glyph_extents_t::default();
+                shaper.glyph_extents(info.as_glyph(), &mut extents);
+                write!(
+                    &mut s,
+                    "<{},{},{},{}>",
+                    extents.x_bearing, extents.y_bearing, extents.width, extents.height
+                )?;
+            }
+
+            if flags.contains(SerializeFlags::NO_ADVANCES) {
+                x += pos.x_advance;
+                y += pos.y_advance;
+            }
+        }
+
+        if !s.is_empty() {
+            s.push(']');
+        }
+
+        Ok(s)
+    }
+}
+
+impl Buffer {
+    pub(crate) const MAX_LEN_FACTOR: usize = 256;
+    pub(crate) const MAX_LEN_MIN: usize = 65536;
+    // Shaping more than a billion chars? Let us know!
+    pub(crate) const MAX_LEN_DEFAULT: usize = 0x3FFF_FFFF;
+
+    pub(crate) const MAX_OPS_FACTOR: i32 = 4096;
+    pub(crate) const MAX_OPS_MIN: i32 = 65536;
+    // Shaping more than a billion operations? Let us know!
+    pub(crate) const MAX_OPS_DEFAULT: i32 = 0x1FFF_FFFF;
+
+    #[inline]
+    pub(crate) fn allocate_var(&mut self, shape: buffer_var_shape) {
+        let bits = shape.bits();
+        debug_assert_eq!(
+            self.allocated_var_bits & bits,
+            0,
+            "Variable already allocated"
+        );
+        self.allocated_var_bits |= bits;
+    }
+
+    #[inline]
+    pub(crate) fn try_allocate_var(&mut self, shape: buffer_var_shape) -> bool {
+        let bits = shape.bits();
+        if self.allocated_var_bits & bits != 0 {
+            return false;
+        }
+        self.allocated_var_bits |= bits;
+        true
+    }
+
+    #[inline]
+    pub(crate) fn deallocate_var(&mut self, shape: buffer_var_shape) {
+        let bits = shape.bits();
+        debug_assert_eq!(
+            self.allocated_var_bits & bits,
+            bits,
+            "Deallocating unallocated var"
+        );
+        self.allocated_var_bits &= !bits;
+    }
+
+    #[inline]
+    pub(crate) fn assert_var(&self, shape: buffer_var_shape) {
+        let bits = shape.bits();
+        debug_assert_eq!(
+            self.allocated_var_bits & bits,
+            bits,
+            "Variable not allocated"
+        );
+    }
+
+    #[inline]
+    pub(crate) fn info_slice_mut(&mut self) -> &mut [GlyphInfo] {
+        &mut self.info[..self.len]
+    }
+
+    #[inline]
+    pub(crate) fn out_info(&self) -> &[GlyphInfo] {
+        if self.have_separate_output {
+            bytemuck::cast_slice(self.pos.as_slice())
+        } else {
+            &self.info
+        }
+    }
+
+    #[inline]
+    pub(crate) fn out_info_mut(&mut self) -> &mut [GlyphInfo] {
+        if self.have_separate_output {
+            bytemuck::cast_slice_mut(self.pos.as_mut_slice())
+        } else {
+            &mut self.info
+        }
+    }
+
+    #[inline]
+    fn set_out_info(&mut self, i: usize, info: GlyphInfo) {
+        self.out_info_mut()[i] = info;
+    }
+
+    #[inline]
+    pub(crate) fn cur(&self, i: usize) -> &GlyphInfo {
+        &self.info[self.idx + i]
+    }
+
+    #[inline]
+    pub(crate) fn cur_mut(&mut self, i: usize) -> &mut GlyphInfo {
+        let idx = self.idx + i;
+        &mut self.info[idx]
+    }
+
+    #[inline]
+    pub(crate) fn cur_pos_mut(&mut self) -> &mut GlyphPosition {
+        let i = self.idx;
+        &mut self.pos[i]
+    }
+
+    #[inline]
+    pub(crate) fn prev(&self) -> &GlyphInfo {
+        let idx = self.out_len.saturating_sub(1);
+        &self.out_info()[idx]
+    }
+
+    #[inline]
+    pub(crate) fn prev_mut(&mut self) -> &mut GlyphInfo {
+        let idx = self.out_len.saturating_sub(1);
+        &mut self.out_info_mut()[idx]
+    }
+
+    pub(crate) fn update_digest(&mut self) {
+        self.digest = hb_set_digest_t::new();
+        self.digest.add_array(self.info.iter().map(|i| i.glyph_id));
+    }
+
+    pub(crate) fn update_glyph_set(&mut self) {
+        self.glyph_set.clear();
+        self.glyph_set
+            .extend_unsorted(self.info.iter().map(|i| i.glyph_id));
+    }
+
+    #[inline]
+    pub(crate) fn backtrack_len(&self) -> usize {
         if self.have_output {
             self.out_len
         } else {
@@ -628,7 +969,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn lookahead_len(&self) -> usize {
+    pub(crate) fn lookahead_len(&self) -> usize {
         self.len - self.idx
     }
 
@@ -645,7 +986,7 @@ impl hb_buffer_t {
     }
 
     fn add(&mut self, codepoint: u32, cluster: u32) {
-        if !self.ensure(self.len + 1) {
+        if !self.reserve(self.len + 1) {
             return;
         }
         self.info[self.len] = GlyphInfo {
@@ -656,27 +997,7 @@ impl hb_buffer_t {
         self.len += 1;
     }
 
-    #[inline]
-    pub fn reverse(&mut self) {
-        if self.is_empty() {
-            return;
-        }
-
-        self.reverse_range(0, self.len);
-    }
-
-    pub fn reverse_range(&mut self, start: usize, end: usize) {
-        if end - start < 2 {
-            return;
-        }
-
-        self.info[start..end].reverse();
-        if self.have_positions {
-            self.pos[start..end].reverse();
-        }
-    }
-
-    pub fn reverse_groups<F>(&mut self, group: F, merge_clusters: bool)
+    pub(crate) fn reverse_groups<F>(&mut self, group: F, merge_clusters: bool)
     where
         F: Fn(&GlyphInfo, &GlyphInfo) -> bool,
     {
@@ -709,7 +1030,7 @@ impl hb_buffer_t {
         self.reverse();
     }
 
-    pub fn group_end<F>(&self, mut start: usize, group: F) -> usize
+    pub(crate) fn group_end<F>(&self, mut start: usize, group: F) -> usize
     where
         F: Fn(&GlyphInfo, &GlyphInfo) -> bool,
     {
@@ -722,40 +1043,7 @@ impl hb_buffer_t {
         start
     }
 
-    #[inline]
-    fn reset_clusters(&mut self) {
-        for (i, info) in self.info.iter_mut().enumerate() {
-            info.cluster = i as u32;
-        }
-    }
-
-    pub fn guess_segment_properties(&mut self) {
-        if self.script.is_none() {
-            for info in &self.info {
-                match info.as_codepoint().script() {
-                    script::COMMON | script::INHERITED | script::UNKNOWN => {}
-                    s => {
-                        self.script = Some(s);
-                        break;
-                    }
-                }
-            }
-        }
-
-        if self.direction == Direction::Invalid {
-            if let Some(script) = self.script {
-                self.direction = Direction::from_script(script).unwrap_or_default();
-            }
-
-            if self.direction == Direction::Invalid {
-                self.direction = Direction::LeftToRight;
-            }
-        }
-
-        // TODO: language must be set
-    }
-
-    pub fn sync(&mut self) -> bool {
+    pub(crate) fn sync(&mut self) -> bool {
         debug_assert!(self.have_output);
         debug_assert!(self.idx <= self.len);
 
@@ -785,7 +1073,7 @@ impl hb_buffer_t {
         true
     }
 
-    pub fn clear_output(&mut self) {
+    pub(crate) fn clear_output(&mut self) {
         self.have_output = true;
         self.have_positions = false;
 
@@ -794,7 +1082,7 @@ impl hb_buffer_t {
         self.have_separate_output = false;
     }
 
-    pub fn clear_positions(&mut self) {
+    pub(crate) fn clear_positions(&mut self) {
         self.have_output = false;
         self.have_positions = true;
 
@@ -806,7 +1094,7 @@ impl hb_buffer_t {
         }
     }
 
-    pub fn replace_glyphs(&mut self, num_in: usize, num_out: usize, glyph_data: &[u32]) {
+    pub(crate) fn replace_glyphs(&mut self, num_in: usize, num_out: usize, glyph_data: &[u32]) {
         if !self.make_room_for(num_in, num_out) {
             return;
         }
@@ -826,7 +1114,7 @@ impl hb_buffer_t {
         self.out_len += num_out;
     }
 
-    pub fn replace_glyph(&mut self, glyph_index: u32) {
+    pub(crate) fn replace_glyph(&mut self, glyph_index: u32) {
         if self.have_separate_output || self.out_len != self.idx {
             if !self.make_room_for(1, 1) {
                 return;
@@ -842,7 +1130,7 @@ impl hb_buffer_t {
         self.out_len += 1;
     }
 
-    pub fn output_glyph(&mut self, glyph_index: u32) {
+    pub(crate) fn output_glyph(&mut self, glyph_index: u32) {
         if !self.make_room_for(0, 1) {
             return;
         }
@@ -864,7 +1152,7 @@ impl hb_buffer_t {
         self.out_len += 1;
     }
 
-    pub fn output_info(&mut self, glyph_info: GlyphInfo) {
+    pub(crate) fn output_info(&mut self, glyph_info: GlyphInfo) {
         if !self.make_room_for(0, 1) {
             return;
         }
@@ -874,7 +1162,7 @@ impl hb_buffer_t {
     }
 
     /// Copies glyph at idx to output but doesn't advance idx.
-    pub fn copy_glyph(&mut self) {
+    pub(crate) fn copy_glyph(&mut self) {
         if !self.make_room_for(0, 1) {
             return;
         }
@@ -887,10 +1175,10 @@ impl hb_buffer_t {
     ///
     /// If there's no output, just advance idx.
     #[inline(always)]
-    pub fn next_glyph(&mut self) {
+    pub(crate) fn next_glyph(&mut self) {
         if self.have_output {
             if self.have_separate_output || self.out_len != self.idx {
-                if !self.ensure(self.out_len + 1) {
+                if !self.reserve(self.out_len + 1) {
                     return;
                 }
 
@@ -907,10 +1195,10 @@ impl hb_buffer_t {
     /// Copies n glyphs at idx to output and advance idx.
     ///
     /// If there's no output, just advance idx.
-    pub fn next_glyphs(&mut self, n: usize) {
+    pub(crate) fn next_glyphs(&mut self, n: usize) {
         if self.have_output {
             if self.have_separate_output || self.out_len != self.idx {
-                if !self.ensure(self.out_len + n) {
+                if !self.reserve(self.out_len + n) {
                     return;
                 }
 
@@ -926,17 +1214,17 @@ impl hb_buffer_t {
     }
 
     /// Advance idx without copying to output.
-    pub fn skip_glyph(&mut self) {
+    pub(crate) fn skip_glyph(&mut self) {
         self.idx += 1;
     }
 
-    pub fn reset_masks(&mut self, mask: hb_mask_t) {
+    pub(crate) fn reset_masks(&mut self, mask: hb_mask_t) {
         for info in &mut self.info[..self.len] {
             info.mask = mask;
         }
     }
 
-    pub fn set_masks(
+    pub(crate) fn set_masks(
         &mut self,
         mut value: hb_mask_t,
         mask: hb_mask_t,
@@ -971,7 +1259,7 @@ impl hb_buffer_t {
     }
 
     #[inline(always)]
-    pub fn merge_clusters(&mut self, start: usize, end: usize) {
+    pub(crate) fn merge_clusters(&mut self, start: usize, end: usize) {
         if end - start < 2 {
             return;
         }
@@ -1024,7 +1312,7 @@ impl hb_buffer_t {
         }
     }
 
-    pub fn merge_out_clusters(&mut self, mut start: usize, mut end: usize) {
+    pub(crate) fn merge_out_clusters(&mut self, mut start: usize, mut end: usize) {
         if !BufferClusterLevel::new(self.cluster_level).is_monotone() {
             return;
         }
@@ -1070,7 +1358,7 @@ impl hb_buffer_t {
     }
 
     /// Merge clusters for deleting current glyph, and skip it.
-    pub fn delete_glyph(&mut self) {
+    pub(crate) fn delete_glyph(&mut self) {
         let cluster = self.info[self.idx].cluster;
 
         if (self.idx + 1 < self.len && cluster == self.info[self.idx + 1].cluster)
@@ -1106,7 +1394,7 @@ impl hb_buffer_t {
         self.skip_glyph();
     }
 
-    pub fn delete_glyphs_inplace(&mut self, filter: impl Fn(&GlyphInfo) -> bool) {
+    pub(crate) fn delete_glyphs_inplace(&mut self, filter: impl Fn(&GlyphInfo) -> bool) {
         // Merge clusters and delete filtered glyphs.
         // NOTE! We can't use out-buffer as we have positioning data.
         let mut j = 0;
@@ -1156,7 +1444,7 @@ impl hb_buffer_t {
         self.len = j;
     }
 
-    pub fn unsafe_to_break(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn unsafe_to_break(&mut self, start: Option<usize>, end: Option<usize>) {
         self._set_glyph_flags(
             UNSAFE_TO_BREAK | UNSAFE_TO_CONCAT,
             start,
@@ -1166,7 +1454,7 @@ impl hb_buffer_t {
         );
     }
 
-    pub fn safe_to_insert_tatweel(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn safe_to_insert_tatweel(&mut self, start: Option<usize>, end: Option<usize>) {
         if !self
             .flags
             .contains(BufferFlags::PRODUCE_SAFE_TO_INSERT_TATWEEL)
@@ -1255,7 +1543,7 @@ impl hb_buffer_t {
         self._set_glyph_flags_impl(mask, start, end, interior, from_out_buffer);
     }
 
-    pub fn unsafe_to_concat(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn unsafe_to_concat(&mut self, start: Option<usize>, end: Option<usize>) {
         if !self.flags.contains(BufferFlags::PRODUCE_UNSAFE_TO_CONCAT) {
             return;
         }
@@ -1263,7 +1551,11 @@ impl hb_buffer_t {
         self._set_glyph_flags(UNSAFE_TO_CONCAT, start, end, Some(false), None);
     }
 
-    pub fn unsafe_to_break_from_outbuffer(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn unsafe_to_break_from_outbuffer(
+        &mut self,
+        start: Option<usize>,
+        end: Option<usize>,
+    ) {
         self._set_glyph_flags(
             UNSAFE_TO_BREAK | UNSAFE_TO_CONCAT,
             start,
@@ -1273,7 +1565,11 @@ impl hb_buffer_t {
         );
     }
 
-    pub fn unsafe_to_concat_from_outbuffer(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn unsafe_to_concat_from_outbuffer(
+        &mut self,
+        start: Option<usize>,
+        end: Option<usize>,
+    ) {
         if !self.flags.contains(BufferFlags::PRODUCE_UNSAFE_TO_CONCAT) {
             return;
         }
@@ -1281,7 +1577,7 @@ impl hb_buffer_t {
         self._set_glyph_flags(UNSAFE_TO_CONCAT, start, end, Some(false), Some(true));
     }
 
-    pub fn move_to(&mut self, i: usize) -> bool {
+    pub(crate) fn move_to(&mut self, i: usize) -> bool {
         if !self.have_output {
             debug_assert!(i <= self.len);
             self.idx = i;
@@ -1335,16 +1631,6 @@ impl hb_buffer_t {
     }
 
     #[must_use]
-    #[inline(always)]
-    pub fn ensure(&mut self, size: usize) -> bool {
-        if size <= self.info.len() {
-            true
-        } else {
-            self.enlarge(size)
-        }
-    }
-
-    #[must_use]
     fn enlarge(&mut self, size: usize) -> bool {
         if size > self.max_len {
             self.successful = false;
@@ -1358,7 +1644,7 @@ impl hb_buffer_t {
 
     #[must_use]
     fn make_room_for(&mut self, num_in: usize, num_out: usize) -> bool {
-        if !self.ensure(self.out_len + num_out) {
+        if !self.reserve(self.out_len + num_out) {
             return false;
         }
 
@@ -1376,7 +1662,7 @@ impl hb_buffer_t {
 
     fn shift_forward(&mut self, count: usize) -> bool {
         debug_assert!(self.have_output);
-        if !self.ensure(self.len + count) {
+        if !self.reserve(self.len + count) {
             return false;
         }
 
@@ -1406,7 +1692,12 @@ impl hb_buffer_t {
         self.context_len[side] = 0;
     }
 
-    pub fn sort(&mut self, start: usize, end: usize, cmp: impl Fn(&GlyphInfo, &GlyphInfo) -> bool) {
+    pub(crate) fn sort(
+        &mut self,
+        start: usize,
+        end: usize,
+        cmp: impl Fn(&GlyphInfo, &GlyphInfo) -> bool,
+    ) {
         debug_assert!(!self.have_positions);
 
         for i in start + 1..end {
@@ -1433,7 +1724,7 @@ impl hb_buffer_t {
         }
     }
 
-    pub fn set_cluster(info: &mut GlyphInfo, cluster: u32, mask: hb_mask_t) {
+    pub(crate) fn set_cluster(info: &mut GlyphInfo, cluster: u32, mask: hb_mask_t) {
         if info.cluster != cluster {
             info.mask = (info.mask & !glyph_flag::DEFINED) | (mask & glyph_flag::DEFINED);
         }
@@ -1446,21 +1737,21 @@ impl hb_buffer_t {
         self.serial = 0;
         self.scratch_flags = HB_BUFFER_SCRATCH_FLAG_DEFAULT;
 
-        if let Some(len) = self.len.checked_mul(hb_buffer_t::MAX_LEN_FACTOR) {
-            self.max_len = len.max(hb_buffer_t::MAX_LEN_MIN);
+        if let Some(len) = self.len.checked_mul(Buffer::MAX_LEN_FACTOR) {
+            self.max_len = len.max(Buffer::MAX_LEN_MIN);
         }
 
         if let Ok(len) = i32::try_from(self.len) {
-            if let Some(ops) = len.checked_mul(hb_buffer_t::MAX_OPS_FACTOR) {
-                self.max_ops = ops.max(hb_buffer_t::MAX_OPS_MIN);
+            if let Some(ops) = len.checked_mul(Buffer::MAX_OPS_FACTOR) {
+                self.max_ops = ops.max(Buffer::MAX_OPS_MIN);
             }
         }
     }
 
     // Called around shape()
     pub(crate) fn leave(&mut self) {
-        self.max_len = hb_buffer_t::MAX_LEN_DEFAULT;
-        self.max_ops = hb_buffer_t::MAX_OPS_DEFAULT;
+        self.max_len = Buffer::MAX_LEN_DEFAULT;
+        self.max_ops = Buffer::MAX_OPS_DEFAULT;
         self.serial = 0;
     }
 
@@ -1544,43 +1835,7 @@ impl hb_buffer_t {
         }
     }
 
-    /// Checks that buffer contains no elements.
-    pub fn is_empty(&self) -> bool {
-        self.len == 0
-    }
-
-    fn push_str(&mut self, text: &str) {
-        if !self.ensure(self.len + text.chars().count()) {
-            return;
-        }
-
-        for (i, c) in text.char_indices() {
-            self.info[self.len] = GlyphInfo {
-                glyph_id: c as u32,
-                cluster: i as u32,
-                ..GlyphInfo::default()
-            };
-            self.len += 1;
-        }
-    }
-
-    fn set_pre_context(&mut self, text: &str) {
-        self.clear_context(0);
-        for (i, c) in text.chars().rev().enumerate().take(CONTEXT_LENGTH) {
-            self.context[0][i] = c as Codepoint;
-            self.context_len[0] += 1;
-        }
-    }
-
-    fn set_post_context(&mut self, text: &str) {
-        self.clear_context(1);
-        for (i, c) in text.chars().enumerate().take(CONTEXT_LENGTH) {
-            self.context[1][i] = c as Codepoint;
-            self.context_len[1] += 1;
-        }
-    }
-
-    pub fn next_syllable(&self, mut start: usize) -> usize {
+    pub(crate) fn next_syllable(&self, mut start: usize) -> usize {
         if start >= self.len {
             return start;
         }
@@ -1595,7 +1850,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn allocate_lig_id(&mut self) -> u8 {
+    pub(crate) fn allocate_lig_id(&mut self) -> u8 {
         let mut lig_id = self.next_serial() & 0x07;
 
         if lig_id == 0 {
@@ -1603,6 +1858,12 @@ impl hb_buffer_t {
         }
 
         lig_id
+    }
+}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -1702,298 +1963,3 @@ pub const HB_BUFFER_SCRATCH_FLAG_SHAPER0: u32 = 0x0100_0000;
 // pub const HB_BUFFER_SCRATCH_FLAG_SHAPER1: u32 = 0x02000000;
 // pub const HB_BUFFER_SCRATCH_FLAG_SHAPER2: u32 = 0x04000000;
 // pub const HB_BUFFER_SCRATCH_FLAG_SHAPER3: u32 = 0x08000000;
-
-/// A buffer that contains an input string ready for shaping.
-pub struct UnicodeBuffer(pub(crate) hb_buffer_t);
-
-impl UnicodeBuffer {
-    /// Create a new `UnicodeBuffer`.
-    #[inline]
-    pub fn new() -> UnicodeBuffer {
-        UnicodeBuffer(hb_buffer_t::new())
-    }
-
-    /// Returns the length of the data of the buffer.
-    ///
-    /// This corresponds to the number of unicode codepoints contained in the
-    /// buffer.
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.0.len
-    }
-
-    /// Ensures that the buffer can hold at least `size` codepoints.
-    pub fn reserve(&mut self, size: usize) -> bool {
-        self.0.ensure(size)
-    }
-
-    /// Returns `true` if the buffer contains no elements.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Pushes a string to a buffer.
-    #[inline]
-    pub fn push_str(&mut self, str: &str) {
-        self.0.push_str(str);
-    }
-
-    /// Sets the pre-context for this buffer.
-    #[inline]
-    pub fn set_pre_context(&mut self, str: &str) {
-        self.0.set_pre_context(str);
-    }
-
-    /// Sets the post-context for this buffer.
-    #[inline]
-    pub fn set_post_context(&mut self, str: &str) {
-        self.0.set_post_context(str);
-    }
-
-    /// Appends a character to a buffer with the given cluster value.
-    #[inline]
-    pub fn add(&mut self, codepoint: char, cluster: u32) {
-        self.0.add(codepoint as u32, cluster);
-        self.0.context_len[1] = 0;
-    }
-
-    /// Set the text direction of the `Buffer`'s contents.
-    #[inline]
-    pub fn set_direction(&mut self, direction: Direction) {
-        self.0.direction = direction;
-    }
-
-    /// Returns the `Buffer`'s text direction.
-    #[inline]
-    pub fn direction(&self) -> Direction {
-        self.0.direction
-    }
-
-    /// Set the script from an ISO15924 tag.
-    #[inline]
-    pub fn set_script(&mut self, script: Script) {
-        self.0.script = Some(script);
-    }
-
-    /// Get the ISO15924 script tag.
-    pub fn script(&self) -> Script {
-        self.0.script.unwrap_or(script::UNKNOWN)
-    }
-
-    /// Set the buffer language.
-    #[inline]
-    pub fn set_language(&mut self, lang: Language) {
-        self.0.language = Some(lang);
-    }
-
-    /// Set the glyph value to replace not-found variation-selector characters with.
-    #[inline]
-    pub fn set_not_found_variation_selector_glyph(&mut self, glyph: u32) {
-        self.0.not_found_variation_selector = Some(glyph);
-    }
-
-    /// Get the buffer language.
-    #[inline]
-    pub fn language(&self) -> Option<Language> {
-        self.0.language.clone()
-    }
-
-    /// Guess the segment properties (direction, language, script) for the
-    /// current buffer.
-    #[inline]
-    pub fn guess_segment_properties(&mut self) {
-        self.0.guess_segment_properties();
-    }
-
-    /// Set the flags for this buffer.
-    #[inline]
-    pub fn set_flags(&mut self, flags: BufferFlags) {
-        self.0.flags = flags;
-    }
-
-    /// Get the flags for this buffer.
-    #[inline]
-    pub fn flags(&self) -> BufferFlags {
-        self.0.flags
-    }
-
-    /// Set the cluster level of the buffer.
-    #[inline]
-    pub fn set_cluster_level(&mut self, cluster_level: BufferClusterLevel) {
-        self.0.cluster_level = match cluster_level {
-            BufferClusterLevel::MonotoneGraphemes => HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES,
-            BufferClusterLevel::MonotoneCharacters => HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS,
-            BufferClusterLevel::Characters => HB_BUFFER_CLUSTER_LEVEL_CHARACTERS,
-            BufferClusterLevel::Graphemes => HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES,
-        }
-    }
-
-    /// Retrieve the cluster level of the buffer.
-    #[inline]
-    pub fn cluster_level(&self) -> BufferClusterLevel {
-        match self.0.cluster_level {
-            HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES => BufferClusterLevel::MonotoneGraphemes,
-            HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS => BufferClusterLevel::MonotoneCharacters,
-            HB_BUFFER_CLUSTER_LEVEL_CHARACTERS => BufferClusterLevel::Characters,
-            HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES => BufferClusterLevel::Graphemes,
-            _ => BufferClusterLevel::MonotoneGraphemes,
-        }
-    }
-
-    /// Resets clusters.
-    #[inline]
-    pub fn reset_clusters(&mut self) {
-        self.0.reset_clusters();
-    }
-
-    /// Clear the contents of the buffer.
-    #[inline]
-    pub fn clear(&mut self) {
-        self.0.clear();
-    }
-}
-
-impl core::fmt::Debug for UnicodeBuffer {
-    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        fmt.debug_struct("UnicodeBuffer")
-            .field("direction", &self.direction())
-            .field("language", &self.language())
-            .field("script", &self.script())
-            .field("cluster_level", &self.cluster_level())
-            .finish()
-    }
-}
-
-impl Default for UnicodeBuffer {
-    fn default() -> UnicodeBuffer {
-        UnicodeBuffer::new()
-    }
-}
-
-/// A buffer that contains the results of the shaping process.
-pub struct GlyphBuffer(pub(crate) hb_buffer_t);
-
-impl GlyphBuffer {
-    /// Returns the length of the data of the buffer.
-    ///
-    /// When called before shaping this is the number of unicode codepoints
-    /// contained in the buffer. When called after shaping it returns the number
-    /// of glyphs stored.
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.0.len
-    }
-
-    /// Returns `true` if the buffer contains no elements.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Get the glyph infos.
-    #[inline]
-    pub fn glyph_infos(&self) -> &[GlyphInfo] {
-        &self.0.info[0..self.0.len]
-    }
-
-    /// Get the glyph positions.
-    #[inline]
-    pub fn glyph_positions(&self) -> &[GlyphPosition] {
-        &self.0.pos[0..self.0.len]
-    }
-
-    /// Clears the content of the glyph buffer and returns an empty
-    /// `UnicodeBuffer` reusing the existing allocation.
-    #[inline]
-    pub fn clear(mut self) -> UnicodeBuffer {
-        self.0.clear();
-        UnicodeBuffer(self.0)
-    }
-
-    /// Converts the glyph buffer content into a string.
-    pub fn serialize(&self, face: &crate::Shaper, flags: SerializeFlags) -> String {
-        self.serialize_impl(face, flags).unwrap_or_default()
-    }
-
-    fn serialize_impl(
-        &self,
-        face: &hb_font_t,
-        flags: SerializeFlags,
-    ) -> Result<String, core::fmt::Error> {
-        use core::fmt::Write;
-
-        let mut s = String::with_capacity(64);
-
-        let info = self.glyph_infos();
-        let pos = self.glyph_positions();
-        let mut x = 0;
-        let mut y = 0;
-        let names = face.glyph_names();
-        for (info, pos) in info.iter().zip(pos) {
-            s.push(if s.is_empty() { '[' } else { '|' });
-
-            if !flags.contains(SerializeFlags::NO_GLYPH_NAMES) {
-                match names.get(info.as_glyph().to_u32()) {
-                    Some(name) => s.push_str(name),
-                    None => write!(&mut s, "gid{}", info.glyph_id)?,
-                }
-            } else {
-                write!(&mut s, "{}", info.glyph_id)?;
-            }
-
-            if !flags.contains(SerializeFlags::NO_CLUSTERS) {
-                write!(&mut s, "={}", info.cluster)?;
-            }
-
-            if !flags.contains(SerializeFlags::NO_POSITIONS) {
-                if x + pos.x_offset != 0 || y + pos.y_offset != 0 {
-                    write!(&mut s, "@{},{}", x + pos.x_offset, y + pos.y_offset)?;
-                }
-
-                if !flags.contains(SerializeFlags::NO_ADVANCES) {
-                    write!(&mut s, "+{}", pos.x_advance)?;
-                    if pos.y_advance != 0 {
-                        write!(&mut s, ",{}", pos.y_advance)?;
-                    }
-                }
-            }
-
-            if flags.contains(SerializeFlags::GLYPH_FLAGS) {
-                if info.mask & glyph_flag::DEFINED != 0 {
-                    write!(&mut s, "#{:X}", info.mask & glyph_flag::DEFINED)?;
-                }
-            }
-
-            if flags.contains(SerializeFlags::GLYPH_EXTENTS) {
-                let mut extents = hb_glyph_extents_t::default();
-                face.glyph_extents(info.as_glyph(), &mut extents);
-                write!(
-                    &mut s,
-                    "<{},{},{},{}>",
-                    extents.x_bearing, extents.y_bearing, extents.width, extents.height
-                )?;
-            }
-
-            if flags.contains(SerializeFlags::NO_ADVANCES) {
-                x += pos.x_advance;
-                y += pos.y_advance;
-            }
-        }
-
-        if !s.is_empty() {
-            s.push(']');
-        }
-
-        Ok(s)
-    }
-}
-
-impl core::fmt::Debug for GlyphBuffer {
-    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        fmt.debug_struct("GlyphBuffer")
-            .field("glyph_positions", &self.glyph_positions())
-            .field("glyph_infos", &self.glyph_infos())
-            .finish()
-    }
-}

--- a/src/hb/glyph_metrics.rs
+++ b/src/hb/glyph_metrics.rs
@@ -1,4 +1,4 @@
-use crate::hb::buffer::hb_buffer_t;
+use crate::hb::buffer::Buffer;
 use crate::{hb::tables::TableRanges, Tag};
 use read_fonts::{
     tables::{
@@ -111,7 +111,7 @@ impl<'a> GlyphMetrics<'a> {
         Some(advance)
     }
 
-    pub fn populate_advance_widths(&self, buf: &mut hb_buffer_t, coords: &[F2Dot14]) {
+    pub fn populate_advance_widths(&self, buf: &mut Buffer, coords: &[F2Dot14]) {
         for (info, pos) in buf.info.iter().zip(buf.pos.iter_mut()) {
             pos.x_advance = self
                 .h_metrics

--- a/src/hb/kerning.rs
+++ b/src/hb/kerning.rs
@@ -33,7 +33,7 @@ pub(crate) fn get_class(machine: &aat::StateTable, glyph_id: GlyphId, cache: &Cl
 pub fn hb_ot_layout_kern(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> Option<()> {
     let mut c = AatApplyContext::new(plan, face, buffer);
 
@@ -120,7 +120,7 @@ pub fn hb_ot_layout_kern(
 
 fn machine_kern<F>(
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     kern_mask: hb_mask_t,
     cross_stream: bool,
     get_kerning: F,

--- a/src/hb/ot/gpos/mark.rs
+++ b/src/hb/ot/gpos/mark.rs
@@ -1,4 +1,4 @@
-use crate::hb::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_ATTACHMENT};
+use crate::hb::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_ATTACHMENT};
 use crate::hb::ot_layout_common::lookup_flags;
 use crate::hb::ot_layout_gpos_table::attach_type;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
@@ -126,7 +126,7 @@ impl Apply for MarkBasePosFormat1<'_> {
     }
 }
 
-fn accept(buffer: &hb_buffer_t, idx: usize) -> bool {
+fn accept(buffer: &Buffer, idx: usize) -> bool {
     /* We only want to attach to the first of a MultipleSubst sequence.
      * https://github.com/harfbuzz/harfbuzz/issues/740
      * Reject others...

--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -26,7 +26,7 @@ impl GlyphInfo {
     );
 }
 
-impl hb_buffer_t {
+impl Buffer {
     pub(crate) fn allocate_unicode_vars(&mut self) {
         self.allocate_var(GlyphInfo::UNICODE_PROPS_VAR);
     }
@@ -84,7 +84,7 @@ pub fn hb_ot_layout_has_cross_kerning(face: &hb_font_t) -> bool {
 
 // OT::GDEF::is_blocklisted unsupported
 
-pub fn _hb_ot_layout_set_glyph_props(face: &hb_font_t, buffer: &mut hb_buffer_t) {
+pub fn _hb_ot_layout_set_glyph_props(face: &hb_font_t, buffer: &mut Buffer) {
     buffer.assert_gsubgpos_vars();
 
     let len = buffer.len;
@@ -140,7 +140,7 @@ pub trait LayoutTable {
 
 /// Called before substitution lookups are performed, to ensure that glyph
 /// class and other properties are set on the glyphs in the buffer.
-pub fn hb_ot_layout_substitute_start(face: &hb_font_t, buffer: &mut hb_buffer_t) {
+pub fn hb_ot_layout_substitute_start(face: &hb_font_t, buffer: &mut Buffer) {
     _hb_ot_layout_set_glyph_props(face, buffer);
 }
 
@@ -148,7 +148,7 @@ pub fn hb_ot_layout_substitute_start(face: &hb_font_t, buffer: &mut hb_buffer_t)
 pub fn apply_layout_table<T: LayoutTable>(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     table: Option<&T>,
 ) {
     let mut ctx = OT::hb_ot_apply_context_t::new(T::INDEX, face, buffer);
@@ -580,7 +580,7 @@ pub(crate) fn _hb_grapheme_group_func(_: &GlyphInfo, b: &GlyphInfo) -> bool {
     b.is_continuation()
 }
 
-pub fn _hb_ot_layout_reverse_graphemes(buffer: &mut hb_buffer_t) {
+pub fn _hb_ot_layout_reverse_graphemes(buffer: &mut Buffer) {
     // MONOTONE_GRAPHEMES was already applied and is taken care of by _hb_grapheme_group_func.
     // So we just check for MONOTONE_CHARACTERS here.
     buffer.reverse_groups(
@@ -869,7 +869,7 @@ impl GlyphInfo {
 pub fn _hb_clear_substitution_flags(
     _: &hb_ot_shape_plan_t,
     _: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     let len = buffer.len;
     for info in &mut buffer.info[..len] {

--- a/src/hb/ot_layout_gpos_table.rs
+++ b/src/hb/ot_layout_gpos_table.rs
@@ -8,7 +8,7 @@ use super::ot_layout::*;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use crate::Direction;
 
-pub fn position(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+pub fn position(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) {
     apply_layout_table(plan, face, buffer, face.ot_tables.gpos.as_ref());
 }
 
@@ -95,7 +95,7 @@ fn propagate_attachment_offsets(
 pub mod GPOS {
     use super::*;
 
-    pub fn position_start(_: &hb_font_t, buffer: &mut hb_buffer_t) {
+    pub fn position_start(_: &hb_font_t, buffer: &mut Buffer) {
         let len = buffer.len;
         for pos in &mut buffer.pos[..len] {
             pos.set_attach_chain(0);
@@ -103,11 +103,11 @@ pub mod GPOS {
         }
     }
 
-    pub fn position_finish_advances(_: &hb_font_t, _: &mut hb_buffer_t) {
+    pub fn position_finish_advances(_: &hb_font_t, _: &mut Buffer) {
         //buffer.assert_gsubgpos_vars();
     }
 
-    pub fn position_finish_offsets(_: &hb_font_t, buffer: &mut hb_buffer_t) {
+    pub fn position_finish_offsets(_: &hb_font_t, buffer: &mut Buffer) {
         buffer.assert_gsubgpos_vars();
 
         let len = buffer.len;

--- a/src/hb/ot_layout_gsub_table.rs
+++ b/src/hb/ot_layout_gsub_table.rs
@@ -1,8 +1,8 @@
-use super::buffer::hb_buffer_t;
+use super::buffer::Buffer;
 use super::hb_font_t;
 use super::ot_layout::*;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 
-pub fn substitute(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+pub fn substitute(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) {
     apply_layout_table(plan, face, buffer, face.ot_tables.gsub.as_ref());
 }

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -1,7 +1,7 @@
 //! Matching of glyph patterns.
 
 use super::buffer::GlyphInfo;
-use super::buffer::{hb_buffer_t, GlyphPropsFlags};
+use super::buffer::{Buffer, GlyphPropsFlags};
 use super::cache::hb_cache_t;
 use super::hb_font_t;
 use super::hb_mask_t;
@@ -296,7 +296,7 @@ impl matcher_t {
 // when needed, and we do not have `init` method that exist in harfbuzz. This has a performance
 // cost, and makes backporting related changes very hard, but it seems unavoidable, unfortunately.
 pub struct skipping_iterator_t<'f, 'c, F> {
-    pub(crate) buffer: &'c mut hb_buffer_t,
+    pub(crate) buffer: &'c mut Buffer,
     face: &'c hb_font_t<'f>,
     matcher: &'c matcher_t,
     match_positions: &'c mut MatchPositions,
@@ -833,7 +833,7 @@ pub mod OT {
     pub struct hb_ot_apply_context_t<'a> {
         pub table_index: TableIndex,
         pub face: &'a hb_font_t<'a>,
-        pub buffer: &'a mut hb_buffer_t,
+        pub buffer: &'a mut Buffer,
         lookup_mask: hb_mask_t,
         pub per_syllable: bool,
         pub lookup_index: u16,
@@ -857,7 +857,7 @@ pub mod OT {
         pub fn new(
             table_index: TableIndex,
             face: &'a hb_font_t<'a>,
-            buffer: &'a mut hb_buffer_t,
+            buffer: &'a mut Buffer,
         ) -> Self {
             Self {
                 table_index,

--- a/src/hb/ot_map.rs
+++ b/src/hb/ot_map.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::ops::Range;
 
-use super::buffer::{glyph_flag, hb_buffer_t};
+use super::buffer::{glyph_flag, Buffer};
 use super::common::TagExt;
 use super::ot_layout::TableIndex;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
@@ -69,7 +69,7 @@ pub struct StageMap {
 
 // Pause functions return true if new glyph indices might have been added to the buffer.
 // This is used to update buffer digest.
-pub type pause_func_t = fn(&hb_ot_shape_plan_t, &hb_font_t, &mut hb_buffer_t) -> bool;
+pub type pause_func_t = fn(&hb_ot_shape_plan_t, &hb_font_t, &mut Buffer) -> bool;
 
 impl hb_ot_map_t {
     pub const MAX_BITS: u32 = 8;

--- a/src/hb/ot_shape.rs
+++ b/src/hb/ot_shape.rs
@@ -316,7 +316,7 @@ impl<'a> hb_ot_shape_planner_t<'a> {
 pub struct hb_ot_shape_context_t<'a> {
     pub plan: &'a hb_ot_shape_plan_t,
     pub face: &'a hb_font_t<'a>,
-    pub buffer: &'a mut hb_buffer_t,
+    pub buffer: &'a mut Buffer,
     // Transient stuff
     pub target_direction: Direction,
     pub features: &'a [Feature],
@@ -494,7 +494,7 @@ fn position_complex(ctx: &mut hb_ot_shape_context_t) {
     }
 }
 
-fn position_by_plan(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn position_by_plan(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) {
     if plan.apply_gpos {
         ot_layout_gpos_table::position(plan, face, buffer);
     } else if plan.apply_kerx {
@@ -601,7 +601,7 @@ fn setup_masks_fraction(ctx: &mut hb_ot_shape_context_t) {
     }
 }
 
-fn set_unicode_props(buffer: &mut hb_buffer_t) {
+fn set_unicode_props(buffer: &mut Buffer) {
     // Implement enough of Unicode Graphemes here that shaping
     // in reverse-direction wouldn't break graphemes.  Namely,
     // we mark all marks and ZWJ and ZWJ,Extended_Pictographic
@@ -688,7 +688,7 @@ fn set_unicode_props(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn insert_dotted_circle(buffer: &mut hb_buffer_t, face: &hb_font_t) {
+fn insert_dotted_circle(buffer: &mut Buffer, face: &hb_font_t) {
     if !buffer
         .flags
         .contains(BufferFlags::DO_NOT_INSERT_DOTTED_CIRCLE)
@@ -711,7 +711,7 @@ fn insert_dotted_circle(buffer: &mut hb_buffer_t, face: &hb_font_t) {
     }
 }
 
-fn form_clusters(buffer: &mut hb_buffer_t) {
+fn form_clusters(buffer: &mut Buffer) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_CONTINUATIONS != 0 {
         if BufferClusterLevel::new(buffer.cluster_level).is_graphemes() {
             foreach_grapheme!(buffer, start, end, { buffer.merge_clusters(start, end) });
@@ -723,7 +723,7 @@ fn form_clusters(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn ensure_native_direction(buffer: &mut hb_buffer_t) {
+fn ensure_native_direction(buffer: &mut Buffer) {
     let dir = buffer.direction;
     let mut hor = buffer
         .script
@@ -807,7 +807,7 @@ fn rotate_chars(ctx: &mut hb_ot_shape_context_t) {
     }
 }
 
-fn map_glyphs_fast(buffer: &mut hb_buffer_t) {
+fn map_glyphs_fast(buffer: &mut Buffer) {
     // Normalization process sets up normalizer_glyph_index(), we just copy it.
     let len = buffer.len;
     for info in &mut buffer.info[..len] {
@@ -819,7 +819,7 @@ fn map_glyphs_fast(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn hb_synthesize_glyph_classes(buffer: &mut hb_buffer_t) {
+fn hb_synthesize_glyph_classes(buffer: &mut Buffer) {
     let len = buffer.len;
     for info in &mut buffer.info[..len] {
         // Never mark default-ignorables as marks.
@@ -842,7 +842,7 @@ fn hb_synthesize_glyph_classes(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn zero_width_default_ignorables(buffer: &mut hb_buffer_t) {
+fn zero_width_default_ignorables(buffer: &mut Buffer) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_DEFAULT_IGNORABLES != 0
         && !buffer
             .flags
@@ -866,7 +866,7 @@ fn zero_width_default_ignorables(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn deal_with_variation_selectors(buffer: &mut hb_buffer_t) {
+fn deal_with_variation_selectors(buffer: &mut Buffer) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_VARIATION_SELECTOR_FALLBACK == 0 {
         return;
     }
@@ -893,7 +893,7 @@ fn deal_with_variation_selectors(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn zero_mark_widths_by_gdef(buffer: &mut hb_buffer_t, adjust_offsets: bool) {
+fn zero_mark_widths_by_gdef(buffer: &mut Buffer, adjust_offsets: bool) {
     let len = buffer.len;
     for (info, pos) in buffer.info[..len].iter().zip(&mut buffer.pos[..len]) {
         if info.is_mark() {
@@ -908,7 +908,7 @@ fn zero_mark_widths_by_gdef(buffer: &mut hb_buffer_t, adjust_offsets: bool) {
     }
 }
 
-fn hide_default_ignorables(buffer: &mut hb_buffer_t, face: &hb_font_t) {
+fn hide_default_ignorables(buffer: &mut Buffer, face: &hb_font_t) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_DEFAULT_IGNORABLES != 0
         && !buffer
             .flags
@@ -936,7 +936,7 @@ fn hide_default_ignorables(buffer: &mut hb_buffer_t, face: &hb_font_t) {
     }
 }
 
-fn propagate_flags(buffer: &mut hb_buffer_t) {
+fn propagate_flags(buffer: &mut Buffer) {
     // Propagate cluster-level glyph flags to be the same on all cluster glyphs.
     // Simplifies using them.
 

--- a/src/hb/ot_shape_fallback.rs
+++ b/src/hb/ot_shape_fallback.rs
@@ -1,6 +1,6 @@
 use read_fonts::types::GlyphId;
 
-use super::buffer::{hb_buffer_t, GlyphPosition};
+use super::buffer::{Buffer, GlyphPosition};
 use super::face::hb_glyph_extents_t;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::unicode::*;
@@ -89,7 +89,7 @@ fn recategorize_combining_class(u: u32, mut class: u8) -> u8 {
 pub fn _hb_ot_shape_fallback_mark_position_recategorize_marks(
     _: &hb_ot_shape_plan_t,
     _: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     let len = buffer.len;
     for info in &mut buffer.info[..len] {
@@ -102,7 +102,7 @@ pub fn _hb_ot_shape_fallback_mark_position_recategorize_marks(
 }
 
 fn zero_mark_advances(
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     start: usize,
     end: usize,
     adjust_offsets_when_zeroing: bool,
@@ -249,7 +249,7 @@ fn position_mark(
 fn position_around_base(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     base: usize,
     end: usize,
     adjust_offsets_when_zeroing: bool,
@@ -366,7 +366,7 @@ fn position_around_base(
 fn position_cluster_impl(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     start: usize,
     end: usize,
     adjust_offsets_when_zeroing: bool,
@@ -396,7 +396,7 @@ fn position_cluster_impl(
 fn position_cluster(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     start: usize,
     end: usize,
     adjust_offsets_when_zeroing: bool,
@@ -411,7 +411,7 @@ fn position_cluster(
 pub fn position_marks(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     adjust_offsets_when_zeroing: bool,
 ) {
     buffer.assert_gsubgpos_vars();
@@ -431,15 +431,11 @@ pub fn position_marks(
     position_cluster(plan, face, buffer, start, len, adjust_offsets_when_zeroing);
 }
 
-pub fn _hb_ot_shape_fallback_kern(_: &hb_ot_shape_plan_t, _: &hb_font_t, _: &mut hb_buffer_t) {
+pub fn _hb_ot_shape_fallback_kern(_: &hb_ot_shape_plan_t, _: &hb_font_t, _: &mut Buffer) {
     // STUB: this is deprecated in HarfBuzz
 }
 
-pub fn _hb_ot_shape_fallback_spaces(
-    _: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
-) {
+pub fn _hb_ot_shape_fallback_spaces(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) {
     use super::unicode::hb_unicode_funcs_t as t;
 
     let len = buffer.len;

--- a/src/hb/ot_shape_normalize.rs
+++ b/src/hb/ot_shape_normalize.rs
@@ -19,7 +19,7 @@ impl GlyphInfo {
 
 pub struct hb_ot_shape_normalize_context_t<'a> {
     pub plan: &'a hb_ot_shape_plan_t,
-    pub buffer: &'a mut hb_buffer_t,
+    pub buffer: &'a mut Buffer,
     pub face: &'a hb_font_t<'a>,
     pub decompose: DecomposeFn,
     pub compose: ComposeFn,
@@ -110,7 +110,7 @@ fn set_glyph(info: &mut GlyphInfo, font: &hb_font_t) {
     }
 }
 
-fn output_char(buffer: &mut hb_buffer_t, unichar: u32, glyph: u32) {
+fn output_char(buffer: &mut Buffer, unichar: u32, glyph: u32) {
     // This is very confusing indeed.
     buffer.cur_mut(0).set_normalizer_glyph_index(glyph);
     buffer.output_glyph(unichar);
@@ -120,12 +120,12 @@ fn output_char(buffer: &mut hb_buffer_t, unichar: u32, glyph: u32) {
     buffer.scratch_flags = flags;
 }
 
-fn next_char(buffer: &mut hb_buffer_t, glyph: u32) {
+fn next_char(buffer: &mut Buffer, glyph: u32) {
     buffer.cur_mut(0).set_normalizer_glyph_index(glyph);
     buffer.next_glyph();
 }
 
-fn skip_char(buffer: &mut hb_buffer_t) {
+fn skip_char(buffer: &mut Buffer) {
     buffer.skip_glyph();
 }
 
@@ -295,11 +295,7 @@ fn compare_combining_class(pa: &GlyphInfo, pb: &GlyphInfo) -> bool {
     a > b
 }
 
-pub fn _hb_ot_shape_normalize(
-    plan: &hb_ot_shape_plan_t,
-    buffer: &mut hb_buffer_t,
-    face: &hb_font_t,
-) {
+pub fn _hb_ot_shape_normalize(plan: &hb_ot_shape_plan_t, buffer: &mut Buffer, face: &hb_font_t) {
     if buffer.is_empty() {
         return;
     }

--- a/src/hb/ot_shaper.rs
+++ b/src/hb/ot_shaper.rs
@@ -73,11 +73,11 @@ pub struct hb_ot_shaper_t {
 
     /// Called during `shape()`.
     /// Shapers can use to modify text before shaping starts.
-    pub preprocess_text: Option<fn(&hb_ot_shape_plan_t, &hb_font_t, &mut hb_buffer_t)>,
+    pub preprocess_text: Option<fn(&hb_ot_shape_plan_t, &hb_font_t, &mut Buffer)>,
 
     /// Called during `shape()`.
     /// Shapers can use to modify text before shaping starts.
-    pub postprocess_glyphs: Option<fn(&hb_ot_shape_plan_t, &hb_font_t, &mut hb_buffer_t)>,
+    pub postprocess_glyphs: Option<fn(&hb_ot_shape_plan_t, &hb_font_t, &mut Buffer)>,
 
     /// How to normalize.
     pub normalization_preference: hb_ot_shape_normalization_mode_t,
@@ -91,7 +91,7 @@ pub struct hb_ot_shaper_t {
     /// Called during `shape()`.
     /// Shapers should use map to get feature masks and set on buffer.
     /// Shapers may NOT modify characters.
-    pub setup_masks: Option<fn(&hb_ot_shape_plan_t, &hb_font_t, &mut hb_buffer_t)>,
+    pub setup_masks: Option<fn(&hb_ot_shape_plan_t, &hb_font_t, &mut Buffer)>,
 
     /// If not `None`, then must match found GPOS script tag for
     /// GPOS to be applied.  Otherwise, fallback positioning will be used.
@@ -99,7 +99,7 @@ pub struct hb_ot_shaper_t {
 
     /// Called during `shape()`.
     /// Shapers can use to modify ordering of combining marks.
-    pub reorder_marks: Option<fn(&hb_ot_shape_plan_t, &mut hb_buffer_t, usize, usize)>,
+    pub reorder_marks: Option<fn(&hb_ot_shape_plan_t, &mut Buffer, usize, usize)>,
 
     /// If and when to zero-width marks.
     pub zero_width_marks: hb_ot_shape_zero_width_marks_type_t,

--- a/src/hb/ot_shaper_hangul.rs
+++ b/src/hb/ot_shaper_hangul.rs
@@ -108,7 +108,7 @@ fn is_zero_width_char(face: &hb_font_t, c: Codepoint) -> bool {
     }
 }
 
-fn preprocess_text_hangul(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn preprocess_text_hangul(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) {
     buffer.allocate_var(GlyphInfo::HANGUL_SHAPING_FEATURE_VAR);
 
     // Hangul syllables come in two shapes: LV, and LVT.  Of those:
@@ -352,7 +352,7 @@ fn preprocess_text_hangul(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut
     buffer.sync();
 }
 
-fn setup_masks_hangul(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks_hangul(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) {
     let hangul_plan = plan.data::<hangul_shape_plan_t>();
     for info in buffer.info_slice_mut() {
         info.mask |= hangul_plan.mask_array[info.hangul_shaping_feature() as usize];

--- a/src/hb/ot_shaper_hebrew.rs
+++ b/src/hb/ot_shaper_hebrew.rs
@@ -1,7 +1,7 @@
 use super::ot_shape_normalize::*;
 use super::ot_shaper::*;
 use super::{hb_tag_t, unicode};
-use crate::hb::buffer::hb_buffer_t;
+use crate::hb::buffer::Buffer;
 use crate::hb::ot_shape_plan::hb_ot_shape_plan_t;
 use crate::hb::unicode::Codepoint;
 use crate::hb::unicode::{combining_class, modified_combining_class};
@@ -22,12 +22,7 @@ pub const HEBREW_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {
     fallback_position: true,
 };
 
-fn reorder_marks_hebrew(
-    _: &hb_ot_shape_plan_t,
-    buffer: &mut hb_buffer_t,
-    start: usize,
-    end: usize,
-) {
+fn reorder_marks_hebrew(_: &hb_ot_shape_plan_t, buffer: &mut Buffer, start: usize, end: usize) {
     for i in start + 2..end {
         let c0 = buffer.info[i - 2];
         let c1 = buffer.info[i - 1];

--- a/src/hb/ot_shaper_indic.rs
+++ b/src/hb/ot_shaper_indic.rs
@@ -577,7 +577,7 @@ fn override_features(planner: &mut hb_ot_shape_planner_t) {
     planner.ot_map.add_gsub_pause(Some(syllabic_clear_var)); // Don't need syllables anymore.
 }
 
-fn preprocess_text(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn preprocess_text(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) {
     super::ot_shaper_vowel_constraints::preprocess_text_vowel_constraints(buffer);
 }
 
@@ -609,7 +609,7 @@ fn compose(_: &hb_ot_shape_normalize_context_t, a: Codepoint, b: Codepoint) -> O
     crate::hb::unicode::compose(a, b)
 }
 
-fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) {
     buffer.allocate_var(GlyphInfo::INDIC_CATEGORY_VAR);
     buffer.allocate_var(GlyphInfo::INDIC_POSITION_VAR);
 
@@ -620,7 +620,7 @@ fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) 
     }
 }
 
-fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_indic_machine::find_syllables_indic(buffer);
@@ -636,11 +636,7 @@ fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer
     false
 }
 
-fn initial_reordering(
-    plan: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
-) -> bool {
+fn initial_reordering(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) -> bool {
     use super::ot_shaper_indic_machine::SyllableType;
 
     let mut ret = false;
@@ -674,7 +670,7 @@ fn update_consonant_positions(
     plan: &hb_ot_shape_plan_t,
     indic_plan: &IndicShapePlan,
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     let mut virama_glyph = None;
     if indic_plan.config.virama != 0 {
@@ -759,7 +755,7 @@ fn initial_reordering_syllable(
     face: &hb_font_t,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     use super::ot_shaper_indic_machine::SyllableType;
 
@@ -794,7 +790,7 @@ fn initial_reordering_consonant_syllable(
     face: &hb_font_t,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     // https://github.com/harfbuzz/harfbuzz/issues/435#issuecomment-335560167
     // For compatibility with legacy usage in Kannada,
@@ -1315,14 +1311,14 @@ fn initial_reordering_standalone_cluster(
     face: &hb_font_t,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     // We treat placeholder/dotted-circle as if they are consonants, so we
     // should just chain.  Only if not in compatibility mode that is...
     initial_reordering_consonant_syllable(plan, indic_plan, face, start, end, buffer);
 }
 
-fn final_reordering(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn final_reordering(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) -> bool {
     if buffer.is_empty() {
         return false;
     }
@@ -1342,7 +1338,7 @@ fn final_reordering_impl(
     face: &hb_font_t,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     let indic_plan = plan.data::<IndicShapePlan>();
 

--- a/src/hb/ot_shaper_indic_machine.rs
+++ b/src/hb/ot_shaper_indic_machine.rs
@@ -12,7 +12,7 @@
     clippy::never_loop
 )]
 
-use super::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
+use super::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
 
 static _indic_syllable_machine_trans_keys: [u8; 278] = [
     7, 19, 3, 19, 4, 19, 4, 19, 12, 12, 3, 19, 3, 19, 3, 19, 7, 19, 4, 19, 4, 19, 12, 12, 3, 19, 3,
@@ -201,7 +201,7 @@ pub enum SyllableType {
     NonIndicCluster,
 }
 
-pub fn find_syllables_indic(buffer: &mut hb_buffer_t) {
+pub fn find_syllables_indic(buffer: &mut Buffer) {
     let mut cs = 0;
     let mut ts = 0;
     let mut te = 0;
@@ -489,7 +489,7 @@ fn found_syllable(
     end: usize,
     syllable_serial: &mut u8,
     kind: SyllableType,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     for i in start..end {
         buffer.info[i].set_syllable((*syllable_serial << 4) | kind as u8);

--- a/src/hb/ot_shaper_khmer.rs
+++ b/src/hb/ot_shaper_khmer.rs
@@ -126,7 +126,7 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 }
 
-fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_khmer_machine::find_syllables_khmer(buffer);
@@ -142,7 +142,7 @@ fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer
     false
 }
 
-fn reorder_khmer(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn reorder_khmer(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) -> bool {
     use super::ot_shaper_khmer_machine::SyllableType;
 
     let mut ret = false;
@@ -177,7 +177,7 @@ fn reorder_syllable_khmer(
     khmer_plan: &KhmerShapePlan,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     use super::ot_shaper_khmer_machine::SyllableType;
 
@@ -202,7 +202,7 @@ fn reorder_consonant_syllable(
     plan: &KhmerShapePlan,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     // Setup masks.
     {
@@ -301,7 +301,7 @@ fn compose(_: &hb_ot_shape_normalize_context_t, a: Codepoint, b: Codepoint) -> O
     crate::hb::unicode::compose(a, b)
 }
 
-fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) {
     buffer.allocate_var(GlyphInfo::KHMER_CATEGORY_VAR);
 
     // We cannot setup masks here.  We save information about characters

--- a/src/hb/ot_shaper_khmer_machine.rs
+++ b/src/hb/ot_shaper_khmer_machine.rs
@@ -13,7 +13,7 @@
     clippy::never_loop
 )]
 
-use super::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
+use super::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
 
 static _khmer_syllable_machine_actions: [i8; 29] = [
     0, 1, 0, 1, 1, 1, 2, 1, 5, 1, 6, 1, 7, 1, 8, 1, 9, 1, 10, 1, 11, 2, 2, 3, 2, 2, 4, 0, 0,
@@ -97,7 +97,7 @@ pub enum SyllableType {
     NonKhmerCluster,
 }
 
-pub fn find_syllables_khmer(buffer: &mut hb_buffer_t) {
+pub fn find_syllables_khmer(buffer: &mut Buffer) {
     let mut cs = 0;
     let mut ts = 0;
     let mut te = 0;
@@ -348,7 +348,7 @@ fn found_syllable(
     end: usize,
     syllable_serial: &mut u8,
     kind: SyllableType,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     for i in start..end {
         buffer.info[i].set_syllable((*syllable_serial << 4) | kind as u8);

--- a/src/hb/ot_shaper_myanmar.rs
+++ b/src/hb/ot_shaper_myanmar.rs
@@ -115,7 +115,7 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 }
 
-fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_myanmar_machine::find_syllables_myanmar(buffer);
@@ -131,7 +131,7 @@ fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer
     false
 }
 
-fn reorder_myanmar(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn reorder_myanmar(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) -> bool {
     use super::ot_shaper_myanmar_machine::SyllableType;
 
     let mut ret = false;
@@ -161,7 +161,7 @@ fn reorder_myanmar(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buf
     ret
 }
 
-fn reorder_syllable_myanmar(start: usize, end: usize, buffer: &mut hb_buffer_t) {
+fn reorder_syllable_myanmar(start: usize, end: usize, buffer: &mut Buffer) {
     use super::ot_shaper_myanmar_machine::SyllableType;
 
     let syllable_type = match buffer.info[start].syllable() & 0x0F {
@@ -183,7 +183,7 @@ fn reorder_syllable_myanmar(start: usize, end: usize, buffer: &mut hb_buffer_t) 
 
 // Rules from:
 // https://docs.microsoft.com/en-us/typography/script-development/myanmar
-fn initial_reordering_consonant_syllable(start: usize, end: usize, buffer: &mut hb_buffer_t) {
+fn initial_reordering_consonant_syllable(start: usize, end: usize, buffer: &mut Buffer) {
     let mut base = end;
     let mut has_reph = false;
 
@@ -321,7 +321,7 @@ fn initial_reordering_consonant_syllable(start: usize, end: usize, buffer: &mut 
     }
 }
 
-fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) {
     buffer.allocate_var(GlyphInfo::MYANMAR_CATEGORY_VAR);
     buffer.allocate_var(GlyphInfo::MYANMAR_POSITION_VAR);
 

--- a/src/hb/ot_shaper_myanmar_machine.rs
+++ b/src/hb/ot_shaper_myanmar_machine.rs
@@ -13,7 +13,7 @@
     clippy::never_loop
 )]
 
-use super::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
+use super::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
 
 static _myanmar_syllable_machine_trans_keys: [u8; 108] = [
     0, 22, 1, 22, 3, 22, 3, 22, 1, 22, 3, 22, 1, 22, 1, 22, 1, 22, 1, 22, 1, 22, 3, 22, 0, 8, 1,
@@ -118,7 +118,7 @@ pub enum SyllableType {
     NonMyanmarCluster,
 }
 
-pub fn find_syllables_myanmar(buffer: &mut hb_buffer_t) {
+pub fn find_syllables_myanmar(buffer: &mut Buffer) {
     let mut cs = 0;
     let mut ts = 0;
     let mut te;
@@ -339,7 +339,7 @@ fn found_syllable(
     end: usize,
     syllable_serial: &mut u8,
     kind: SyllableType,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     for i in start..end {
         buffer.info[i].set_syllable((*syllable_serial << 4) | kind as u8);

--- a/src/hb/ot_shaper_syllabic.rs
+++ b/src/hb/ot_shaper_syllabic.rs
@@ -5,7 +5,7 @@ use crate::BufferFlags;
 
 pub fn insert_dotted_circles(
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     broken_syllable_type: u8,
     dottedcircle_category: u8,
     repha_category: Option<u8>,
@@ -75,7 +75,7 @@ pub fn insert_dotted_circles(
 pub(crate) fn syllabic_clear_var(
     _: &hb_ot_shape_plan_t,
     _: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     for info in &mut buffer.info {
         info.set_syllable(0);

--- a/src/hb/ot_shaper_thai.rs
+++ b/src/hb/ot_shaper_thai.rs
@@ -270,7 +270,7 @@ static BELOW_STATE_MACHINE: &[[BSME; 3]] = &[
     ],
 ];
 
-fn do_pua_shaping(face: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn do_pua_shaping(face: &hb_font_t, buffer: &mut Buffer) {
     let mut above_state = ABOVE_START_STATE[Consonant::NotConsonant as usize];
     let mut below_state = BELOW_START_STATE[Consonant::NotConsonant as usize];
     let mut base = 0;
@@ -308,7 +308,7 @@ fn do_pua_shaping(face: &hb_font_t, buffer: &mut hb_buffer_t) {
 }
 
 // TODO: more tests
-fn preprocess_text(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn preprocess_text(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) {
     // This function implements the shaping logic documented here:
     //
     //   https://linux.thai.net/~thep/th-otf/shaping.html

--- a/src/hb/ot_shaper_use.rs
+++ b/src/hb/ot_shaper_use.rs
@@ -237,7 +237,7 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 }
 
-fn setup_syllables(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_syllables(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_use_machine::find_syllables(buffer);
@@ -252,7 +252,7 @@ fn setup_syllables(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buf
     false
 }
 
-fn setup_rphf_mask(plan: &hb_ot_shape_plan_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_rphf_mask(plan: &hb_ot_shape_plan_t, buffer: &mut Buffer) -> bool {
     let universal_plan = plan.data::<UniversalShapePlan>();
 
     let mask = universal_plan.rphf_mask;
@@ -280,7 +280,7 @@ fn setup_rphf_mask(plan: &hb_ot_shape_plan_t, buffer: &mut hb_buffer_t) -> bool 
     false
 }
 
-fn setup_topographical_masks(plan: &hb_ot_shape_plan_t, buffer: &mut hb_buffer_t) {
+fn setup_topographical_masks(plan: &hb_ot_shape_plan_t, buffer: &mut Buffer) {
     use super::ot_shaper_use_machine::SyllableType;
 
     if plan.data::<UniversalShapePlan>().arabic_plan.is_some() {
@@ -350,7 +350,7 @@ fn setup_topographical_masks(plan: &hb_ot_shape_plan_t, buffer: &mut hb_buffer_t
     }
 }
 
-fn record_rphf(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn record_rphf(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) -> bool {
     let universal_plan = plan.data::<UniversalShapePlan>();
 
     let mask = universal_plan.rphf_mask;
@@ -380,7 +380,7 @@ fn record_rphf(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_
     false
 }
 
-fn reorder_use(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn reorder_use(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut Buffer) -> bool {
     use super::ot_shaper_use_machine::SyllableType;
 
     let mut ret = false;
@@ -436,7 +436,7 @@ const POST_BASE_FLAGS: u64 = category_flag64(category::FAbv)
     | category_flag64(category::VMPst)
     | category_flag64(category::VMPre);
 
-fn reorder_syllable_use(start: usize, end: usize, buffer: &mut hb_buffer_t) {
+fn reorder_syllable_use(start: usize, end: usize, buffer: &mut Buffer) {
     use super::ot_shaper_use_machine::SyllableType;
 
     let syllable_type = (buffer.info[start].syllable() & 0x0F) as u32;
@@ -504,7 +504,7 @@ fn reorder_syllable_use(start: usize, end: usize, buffer: &mut hb_buffer_t) {
     }
 }
 
-fn record_pref(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn record_pref(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) -> bool {
     let mut start = 0;
     let mut end = buffer.next_syllable(0);
     while start < buffer.len {
@@ -543,7 +543,7 @@ fn has_arabic_joining(script: Script) -> bool {
     )
 }
 
-fn preprocess_text(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn preprocess_text(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) {
     super::ot_shaper_vowel_constraints::preprocess_text_vowel_constraints(buffer);
 }
 
@@ -556,7 +556,7 @@ fn compose(_: &hb_ot_shape_normalize_context_t, a: Codepoint, b: Codepoint) -> O
     crate::hb::unicode::compose(a, b)
 }
 
-fn setup_masks(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut Buffer) {
     let universal_plan = plan.data::<UniversalShapePlan>();
 
     // Do this before allocating use_category().

--- a/src/hb/ot_shaper_use_machine.rs
+++ b/src/hb/ot_shaper_use_machine.rs
@@ -15,7 +15,7 @@
 
 use core::cell::Cell;
 
-use super::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
+use super::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
 use super::machine_cursor::MachineCursor;
 use super::ot_shaper_use::category;
 use super::GlyphInfo;
@@ -265,7 +265,7 @@ pub enum SyllableType {
     NonCluster,
 }
 
-pub fn find_syllables(buffer: &mut hb_buffer_t) {
+pub fn find_syllables(buffer: &mut Buffer) {
     let mut cs = 0;
     let infos = Cell::as_slice_of_cells(Cell::from_mut(&mut buffer.info));
     let p0 = MachineCursor::new(infos, included);

--- a/src/hb/ot_shaper_vowel_constraints.rs
+++ b/src/hb/ot_shaper_vowel_constraints.rs
@@ -2,11 +2,11 @@
 
 #![allow(clippy::single_match)]
 
-use super::buffer::hb_buffer_t;
+use super::buffer::Buffer;
 use super::script;
 use crate::BufferFlags;
 
-fn output_dotted_circle(buffer: &mut hb_buffer_t) {
+fn output_dotted_circle(buffer: &mut Buffer) {
     buffer.output_glyph(0x25CC);
     {
         let out_idx = buffer.out_len - 1;
@@ -14,12 +14,12 @@ fn output_dotted_circle(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn output_with_dotted_circle(buffer: &mut hb_buffer_t) {
+fn output_with_dotted_circle(buffer: &mut Buffer) {
     output_dotted_circle(buffer);
     buffer.next_glyph();
 }
 
-pub fn preprocess_text_vowel_constraints(buffer: &mut hb_buffer_t) {
+pub fn preprocess_text_vowel_constraints(buffer: &mut Buffer) {
     if buffer
         .flags
         .contains(BufferFlags::DO_NOT_INSERT_DOTTED_CIRCLE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub(crate) type U32Set = digest_u32_set::DigestU32Set;
 
 pub use read_fonts::{types::Tag, FontRef};
 
-pub use hb::buffer::{GlyphBuffer, GlyphInfo, GlyphPosition, UnicodeBuffer};
+pub use hb::buffer::{Buffer, BufferContentType, GlyphInfo, GlyphPosition};
 pub use hb::common::{script, Direction, Feature, Language, Script, Variation};
 pub use hb::face::{hb_font_t as Shaper, ShaperBuilder, ShaperData, ShaperInstance};
 pub use hb::ot_shape_plan::{hb_ot_shape_plan_t as ShapePlan, ShapePlanKey};

--- a/tests/shaping/main.rs
+++ b/tests/shaping/main.rs
@@ -125,7 +125,7 @@ pub fn shape(font_path: &str, text: &str, options: &str) -> String {
         .point_size(args.font_ptem)
         .build();
 
-    let mut buffer = harfrust::UnicodeBuffer::new();
+    let mut buffer = harfrust::Buffer::new();
     if let Some(pre_context) = args.pre_context {
         buffer.set_pre_context(&pre_context);
     }
@@ -170,7 +170,7 @@ pub fn shape(font_path: &str, text: &str, options: &str) -> String {
     }
 
     buffer.guess_segment_properties();
-    let glyph_buffer = shaper.shape(buffer, &features);
+    shaper.shape(&mut buffer, &features);
 
     let mut format_flags = harfrust::SerializeFlags::default();
     if args.no_glyph_names {
@@ -197,5 +197,5 @@ pub fn shape(font_path: &str, text: &str, options: &str) -> String {
         format_flags |= harfrust::SerializeFlags::GLYPH_FLAGS;
     }
 
-    glyph_buffer.serialize(&shaper, format_flags)
+    buffer.serialize(&shaper, format_flags)
 }


### PR DESCRIPTION
This removes `GlyphBuffer` and `UnicodeBuffer`, replacing them with a single `Buffer` type to more closely match HB.

Pros:
* Closer to HB API
* Don't need to use `Option<UnicodeBuffer>` and `take()` to reuse buffers
* Possible to make an HB compatible FFI without copies
* Enable support for HB style tracing messages (#280)
* Toward support for WASM shaping in a separate crate (#91)
* Trivial to build the GlyphBuffer/UnicodeBuffer API on top

Cons:
* Larger number of methods so proper usage is less discoverable
* More methods are now fallible since they depend on the current content type

TODOs:
* Probably missed some content type checks but I think I found the important ones
* Replace asserts with errors... deferring since this PR is already large enough