### PR TITLE
Avoid panic when saving syllable indices

### DIFF
--- a/src/hb/ot_shaper_indic.rs
+++ b/src/hb/ot_shaper_indic.rs
@@ -1,6 +1,5 @@
 use alloc::boxed::Box;
 use core::cmp;
-use core::convert::TryFrom;
 use core::ops::Range;
 
 use read_fonts::types::GlyphId;
@@ -1103,7 +1102,9 @@ fn initial_reordering_consonant_syllable(
         // Use syllable() for sort accounting temporarily.
         let syllable = buffer.info[start].syllable();
         for i in start..end {
-            buffer.info[i].set_syllable(u8::try_from(i - start).unwrap());
+            // We don't care about overflow here as we won't actually use these
+            // values if `end - start > 127`.
+            buffer.info[i].set_syllable((i - start) as u8);
         }
 
         buffer.info[start..end].sort_by_key(|a| a.indic_position());


### PR DESCRIPTION
We use a single byte to temporarily save the indices of the pre-sorted characters in each syllable. This overflows and causes a panic if the length of the syllable exceeds 255. However, we don't actually read these values back if the length exceeds 127 (see https://github.com/harfbuzz/harfrust/blob/904ed514cd50f2d345745bc9f6346c54630171ce/src/hb/ot_shaper_indic.rs#L1179) so the overflow is irrelevant and this patch removes the checked operation.

Fixes #305