### PR TITLE
[DO-NOT-MERGE] [buffer] Make unsafe a few hot callsites

### DIFF
--- a/src/hb/buffer.rs
+++ b/src/hb/buffer.rs
@@ -556,13 +556,12 @@ impl hb_buffer_t {
 
     #[inline]
     pub fn cur(&self, i: usize) -> &GlyphInfo {
-        &self.info[self.idx + i]
+        unsafe { self.info.get_unchecked(self.idx + i) }
     }
 
     #[inline]
     pub fn cur_mut(&mut self, i: usize) -> &mut GlyphInfo {
-        let idx = self.idx + i;
-        &mut self.info[idx]
+        unsafe { self.info.get_unchecked_mut(self.idx + i) }
     }
 
     #[inline]
@@ -715,7 +714,7 @@ impl hb_buffer_t {
     {
         start += 1;
 
-        while start < self.len && group(&self.info[start - 1], &self.info[start]) {
+        while start < self.len && group(unsafe { self.info.get_unchecked(start - 1) }, unsafe { self.info.get_unchecked(start) }) {
             start += 1;
         }
 
@@ -915,7 +914,7 @@ impl hb_buffer_t {
                 }
 
                 for i in 0..n {
-                    self.set_out_info(self.out_len + i, self.info[self.idx + i]);
+                    self.set_out_info(self.out_len + i, unsafe { *self.info.get_unchecked(self.idx + i) });
                 }
             }
 

--- a/src/hb/ot_layout.rs
+++ b/src/hb/ot_layout.rs
@@ -220,7 +220,7 @@ fn apply_forward(ctx: &mut OT::hb_ot_apply_context_t, lookup: &LookupInfo) -> bo
     while ctx.buffer.successful {
         let mut j = ctx.buffer.idx;
         while j < ctx.buffer.len && {
-            let info = &ctx.buffer.info[j];
+            let info = unsafe { ctx.buffer.info.get_unchecked(j) };
             !(lookup.digest.may_have(info.glyph_id)
                 && (info.mask & ctx.lookup_mask()) != 0
                 && check_glyph_property(ctx.face, info, ctx.lookup_props))

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -98,7 +98,7 @@ pub fn match_input(
 
         iter.set_match_position(i, iter.index());
 
-        let this = iter.buffer.info[iter.index()];
+        let this = unsafe { *iter.buffer.info.get_unchecked(iter.index()) };
         let this_lig_id = this.lig_id();
         let this_lig_comp = this.lig_comp();
 
@@ -479,8 +479,8 @@ where
     #[inline]
     pub fn match_at(&mut self, idx: usize, source: MatchSource) -> match_t {
         let info = match source {
-            MatchSource::Info => &mut self.buffer.info[idx],
-            MatchSource::OutInfo => &mut self.buffer.out_info_mut()[idx],
+            MatchSource::Info => unsafe { self.buffer.info.get_unchecked_mut(idx) },
+            MatchSource::OutInfo => unsafe { self.buffer.out_info_mut().get_unchecked_mut(idx) },
         };
         let skip = self.matcher.may_skip(info, self.face, self.lookup_props);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ A complete [harfbuzz](https://github.com/harfbuzz/harfbuzz) shaping algorithm po
 #![cfg_attr(not(feature = "std"), no_std)]
 // Forbidding unsafe code only applies to the lib
 // examples continue to use it, so this cannot be placed into Cargo.toml
-#![forbid(unsafe_code)]
+//#![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
 extern crate alloc;


### PR DESCRIPTION
For illustration / discussion only.

This uses `unchecked_get[_mut]` in a few hotspots of the buffer code. Most of them can easily be reasoned as always correct by checking the calling code for loop bounds.

I don't see as much speedup as I was hoping. Also, I have no idea why Gulzar slows down, but it seems to do consistently:
```
behdad:hb 0 (main)$ subprojects/benchmark-1.8.4/tools/compare.py benchmarks before after
Comparing before to after
Benchmark                                                                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_Shape/Roboto-Regular.ttf/en-thelittleprince.txt/harfrust                          -0.0458         -0.0453             7             7             7             7
BM_Shape/Roboto-Regular.ttf/en-words.txt/harfrust                                    -0.0325         -0.0363            12            12            12            11
BM_Shape/SourceSerifVariable-Roman.ttf/react-dom.txt/harfrust                        -0.0266         -0.0269            77            75            76            74
BM_Shape/NotoSansDevanagari-Regular.ttf/hi-words.txt/harfrust                        -0.0295         -0.0301            27            26            27            26
BM_Shape/Amiri-Regular.ttf/fa-thelittleprince.txt/harfrust                           -0.0281         -0.0280            39            38            39            38
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-thelittleprince.txt/harfrust                -0.0140         -0.0140            87            86            87            86
BM_Shape/NotoNastaliqUrdu-Regular.ttf/fa-words.txt/harfrust                          -0.0195         -0.0186           104           102           104           102
BM_Shape/Gulzar-Regular.ttf/fa-thelittleprince.txt/harfrust                          +0.0412         +0.0414          2215          2306          2204          2296
BM_Shape/Gulzar-Regular.ttf/fa-words.txt/harfrust                                    +0.0339         +0.0339          1429          1478          1422          1470
BM_Shape/NotoSansDuployan-Regular.otf/duployan.txt/harfrust                          -0.0422         -0.0424          2928          2804          2915          2792
OVERALL_GEOMEAN                                                                      -0.0167         -0.0170             0             0             0             0
```