### PR TITLE
Avoid parsing subtable if coverage check fails

### DIFF
--- a/src/hb/ot/gpos/cursive.rs
+++ b/src/hb/ot/gpos/cursive.rs
@@ -2,16 +2,13 @@ use crate::hb::buffer::HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_ATTACHMENT;
 use crate::hb::ot_layout_common::lookup_flags;
 use crate::hb::ot_layout_gpos_table::attach_type;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{skipping_iterator_t, Apply};
+use crate::hb::ot_layout_gsubgpos::{skipping_iterator_t, Apply, ApplyState};
 use crate::{Direction, GlyphPosition};
 use read_fonts::tables::gpos::CursivePosFormat1;
 
 impl Apply for CursivePosFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let this = ctx.buffer.cur(0).as_glyph();
-
-        let coverage = self.coverage().ok()?;
-        let index_this = coverage.get(this)? as usize;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let index_this = state.first_coverage_index as usize;
         let records = self.entry_exit_record();
         let offset_data = self.offset_data();
         let entry_this = records.get(index_this)?.entry_anchor(offset_data)?.ok()?;
@@ -28,7 +25,7 @@ impl Apply for CursivePosFormat1<'_> {
 
         let i = iter.index();
         let prev = iter.buffer.info[i].as_glyph();
-        let index_prev = coverage.get(prev)? as usize;
+        let index_prev = state.coverage.index(&self.offset_data(), prev)? as usize;
         let Some(exit_prev) = records
             .get(index_prev)
             .and_then(|rec| rec.exit_anchor(offset_data).transpose().ok().flatten())

--- a/src/hb/ot/gpos/pair.rs
+++ b/src/hb/ot/gpos/pair.rs
@@ -1,32 +1,16 @@
-use crate::hb::ot::{coverage_index, coverage_index_cached, ClassDefInfo, CoverageInfo};
+use crate::hb::ot::ClassDefInfo;
 use crate::hb::ot::{glyph_class, glyph_class_cached};
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
-    skipping_iterator_t, Apply, PairPosFormat1Cache, PairPosFormat1SmallCache, PairPosFormat2Cache,
-    PairPosFormat2SmallCache, SubtableExternalCache, SubtableExternalCacheMode,
+    skipping_iterator_t, Apply, ApplyState, PairPosFormat2Cache, PairPosFormat2SmallCache,
+    SubtableExternalCache, SubtableExternalCacheMode,
 };
 use alloc::boxed::Box;
 use read_fonts::tables::gpos::{PairPosFormat1, PairPosFormat2};
 
 impl Apply for PairPosFormat1<'_> {
-    fn apply_with_external_cache(
-        &self,
-        ctx: &mut hb_ot_apply_context_t,
-        external_cache: &SubtableExternalCache,
-    ) -> Option<()> {
-        let first_glyph = ctx.buffer.cur(0).as_glyph();
-
-        let first_glyph_coverage_index = match external_cache {
-            SubtableExternalCache::PairPosFormat1Cache(cache) => coverage_index_cached(
-                |gid| self.coverage().ok()?.get(gid),
-                first_glyph,
-                &cache.coverage,
-            )?,
-            SubtableExternalCache::PairPosFormat1SmallCache(cache) => {
-                cache.coverage.index(&self.offset_data(), first_glyph)?
-            }
-            _ => coverage_index(self.coverage(), first_glyph)?,
-        };
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let first_glyph_coverage_index = state.first_coverage_index;
 
         let mut iter = skipping_iterator_t::new(ctx, false);
         iter.reset(iter.buffer.idx);
@@ -120,46 +104,11 @@ impl Apply for PairPosFormat1<'_> {
         }
         None
     }
-
-    fn external_cache_create(&self, mode: SubtableExternalCacheMode) -> SubtableExternalCache {
-        match mode {
-            SubtableExternalCacheMode::Full => {
-                SubtableExternalCache::PairPosFormat1Cache(Box::new(PairPosFormat1Cache::new()))
-            }
-            SubtableExternalCacheMode::Small => {
-                if let Some(coverage) =
-                    CoverageInfo::new(&self.offset_data(), self.coverage_offset().to_u32() as u16)
-                {
-                    SubtableExternalCache::PairPosFormat1SmallCache(PairPosFormat1SmallCache {
-                        coverage,
-                    })
-                } else {
-                    SubtableExternalCache::None
-                }
-            }
-            SubtableExternalCacheMode::None => SubtableExternalCache::None,
-        }
-    }
 }
 
 impl Apply for PairPosFormat2<'_> {
-    fn apply_with_external_cache(
-        &self,
-        ctx: &mut hb_ot_apply_context_t,
-        external_cache: &SubtableExternalCache,
-    ) -> Option<()> {
-        let first_glyph = ctx.buffer.cur(0).as_glyph();
-        match external_cache {
-            SubtableExternalCache::PairPosFormat2Cache(cache) => coverage_index_cached(
-                |gid| self.coverage().ok()?.get(gid),
-                first_glyph,
-                &cache.coverage,
-            )?,
-            SubtableExternalCache::PairPosFormat2SmallCache(cache) => {
-                cache.coverage.index(&self.offset_data(), first_glyph)?
-            }
-            _ => coverage_index(self.coverage(), first_glyph)?,
-        };
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let first_glyph = state.first_glyph;
         let mut iter = skipping_iterator_t::new(ctx, false);
         iter.reset(iter.buffer.idx);
 
@@ -204,7 +153,7 @@ impl Apply for PairPosFormat2<'_> {
                 }
             };
         let data = self.offset_data();
-        let (class1, class2) = match external_cache {
+        let (class1, class2) = match state.external_cache {
             SubtableExternalCache::PairPosFormat2Cache(cache) => (
                 glyph_class_cached(
                     |gid| glyph_class(self.class_def1(), gid),
@@ -256,12 +205,10 @@ impl Apply for PairPosFormat2<'_> {
             }
             SubtableExternalCacheMode::Small => {
                 let data = self.offset_data();
-                let coverage = CoverageInfo::new(&data, self.coverage_offset().to_u32() as u16);
                 let class1 = ClassDefInfo::new(&data, self.class_def1_offset().to_u32() as u16);
                 let class2 = ClassDefInfo::new(&data, self.class_def2_offset().to_u32() as u16);
-                if let Some((coverage, (first, second))) = coverage.zip(class1.zip(class2)) {
+                if let Some((first, second)) = class1.zip(class2) {
                     SubtableExternalCache::PairPosFormat2SmallCache(PairPosFormat2SmallCache {
-                        coverage,
                         first,
                         second,
                     })

--- a/src/hb/ot/gpos/single.rs
+++ b/src/hb/ot/gpos/single.rs
@@ -1,11 +1,9 @@
-use crate::hb::ot_layout_gsubgpos::Apply;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
+use crate::hb::ot_layout_gsubgpos::{Apply, ApplyState};
 use read_fonts::tables::gpos::{SinglePosFormat1, SinglePosFormat2};
 
 impl Apply for SinglePosFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        self.coverage().ok()?.get(glyph)?;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, _state: &ApplyState) -> Option<()> {
         let format = self.value_format();
         let offset = self.shape().value_record_byte_range().start;
         super::apply_value(ctx, ctx.buffer.idx, &self.offset_data(), offset, format);
@@ -15,9 +13,8 @@ impl Apply for SinglePosFormat1<'_> {
 }
 
 impl Apply for SinglePosFormat2<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        let index = self.coverage().ok()?.get(glyph)? as usize;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let index = state.first_coverage_index as usize;
         let format = self.value_format();
         let offset =
             self.shape().value_records_byte_range().start + (format.record_byte_len() * index);

--- a/src/hb/ot/gsub/alternate.rs
+++ b/src/hb/ot/gsub/alternate.rs
@@ -1,9 +1,9 @@
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{Apply, WouldApply, WouldApplyContext};
+use crate::hb::ot_layout_gsubgpos::{Apply, ApplyState, WouldApply, WouldApplyContext};
 use read_fonts::tables::gsub::{AlternateSet, AlternateSubstFormat1};
 
 impl Apply for AlternateSet<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, _state: &ApplyState) -> Option<()> {
         let alternates = self.alternate_glyph_ids();
         let len = alternates.len() as u16;
         if len == 0 {
@@ -41,10 +41,9 @@ impl WouldApply for AlternateSubstFormat1<'_> {
 }
 
 impl Apply for AlternateSubstFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        let index = self.coverage().ok()?.get(glyph)?;
-        let set = self.alternate_sets().get(index as usize).ok()?;
-        set.apply(ctx)
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let index = state.first_coverage_index as usize;
+        let set = self.alternate_sets().get(index).ok()?;
+        set.apply(ctx, state)
     }
 }

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -96,7 +96,7 @@ impl ApplyLigatureSet for LigatureSet<'_> {
 
                 // Can't use the fast path if eg. the next char is a default-ignorable
                 // or other skippable.
-                iter.may_skip(&second_info) != may_skip_t::SKIP_NO
+                iter.may_skip(second_info) != may_skip_t::SKIP_NO
             }
         };
 

--- a/src/hb/ot/gsub/ligature.rs
+++ b/src/hb/ot/gsub/ligature.rs
@@ -1,15 +1,13 @@
 use crate::hb::buffer::GlyphInfo;
-use crate::hb::ot::{coverage_index, coverage_index_cached, CoverageInfo};
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
     ligate_input, match_always, match_glyph, match_input, may_skip_t, skipping_iterator_t, Apply,
-    LigatureSubstFormat1Cache, LigatureSubstFormat1SmallCache, SubtableExternalCache,
-    SubtableExternalCacheMode, WouldApply, WouldApplyContext,
+    ApplyState, LigatureSubstFormat1Cache, SubtableExternalCache, SubtableExternalCacheMode,
+    WouldApply, WouldApplyContext,
 };
 use crate::hb::set_digest::hb_set_digest_t;
-use alloc::boxed::Box;
 use read_fonts::tables::gsub::{Ligature, LigatureSet, LigatureSubstFormat1};
-use read_fonts::types::GlyphId;
+use read_fonts::types::{BigEndian, GlyphId, GlyphId16};
 
 impl WouldApply for Ligature<'_> {
     fn would_apply(&self, ctx: &WouldApplyContext) -> bool {
@@ -23,44 +21,45 @@ impl WouldApply for Ligature<'_> {
     }
 }
 
-impl Apply for Ligature<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        // Special-case to make it in-place and not consider this
-        // as a "ligated" substitution.
-        let components = self.component_glyph_ids();
-        if components.is_empty() {
-            ctx.replace_glyph(self.ligature_glyph().into());
-            Some(())
-        } else {
-            let f = |info: &mut GlyphInfo, index| {
-                let value = components.get(index as usize).unwrap().get().to_u16();
-                match_glyph(info, value)
-            };
+fn apply_ligature(
+    ligature: &Ligature,
+    ctx: &mut hb_ot_apply_context_t,
+    components: &[BigEndian<GlyphId16>],
+) -> Option<()> {
+    // Special-case to make it in-place and not consider this
+    // as a "ligated" substitution.
+    if components.is_empty() {
+        ctx.replace_glyph(ligature.ligature_glyph().into());
+        Some(())
+    } else {
+        let f = |info: &mut GlyphInfo, index| {
+            let value = components.get(index as usize).unwrap().get().to_u16();
+            match_glyph(info, value)
+        };
 
-            let mut match_end = 0;
-            let mut total_component_count = 0;
+        let mut match_end = 0;
+        let mut total_component_count = 0;
 
-            if !match_input(
-                ctx,
-                components.len() as u16,
-                f,
-                &mut match_end,
-                Some(&mut total_component_count),
-            ) {
-                ctx.buffer
-                    .unsafe_to_concat(Some(ctx.buffer.idx), Some(match_end));
-                return None;
-            }
-            let count = components.len() + 1;
-            ligate_input(
-                ctx,
-                count,
-                match_end,
-                total_component_count,
-                self.ligature_glyph().into(),
-            );
-            Some(())
+        if !match_input(
+            ctx,
+            components.len() as u16,
+            f,
+            &mut match_end,
+            Some(&mut total_component_count),
+        ) {
+            ctx.buffer
+                .unsafe_to_concat(Some(ctx.buffer.idx), Some(match_end));
+            return None;
         }
+        let count = components.len() + 1;
+        ligate_input(
+            ctx,
+            count,
+            match_end,
+            total_component_count,
+            ligature.ligature_glyph().into(),
+        );
+        Some(())
     }
 }
 
@@ -91,19 +90,20 @@ impl ApplyLigatureSet for LigatureSet<'_> {
             if !matched {
                 true
             } else {
-                second = iter.buffer.info[iter.index()].glyph_id.into();
+                let second_info = &iter.buffer.info[iter.index()];
+                second = second_info.glyph_id.into();
                 unsafe_to = iter.index() + 1;
 
                 // Can't use the fast path if eg. the next char is a default-ignorable
                 // or other skippable.
-                iter.may_skip(&iter.buffer.info[iter.index()]) != may_skip_t::SKIP_NO
+                iter.may_skip(&second_info) != may_skip_t::SKIP_NO
             }
         };
 
         if slow_path {
             // Slow path
             for lig in ligatures.iter().filter_map(Result::ok) {
-                if lig.apply(ctx).is_some() {
+                if apply_ligature(&lig, ctx, lig.component_glyph_ids()).is_some() {
                     return Some(());
                 }
             }
@@ -116,7 +116,7 @@ impl ApplyLigatureSet for LigatureSet<'_> {
             for lig in ligatures.iter().filter_map(|lig| lig.ok()) {
                 let components = lig.component_glyph_ids();
                 if components.is_empty() || components[0].get() == second {
-                    if lig.apply(ctx).is_some() {
+                    if apply_ligature(&lig, ctx, components).is_some() {
                         if unsafe_to_concat {
                             ctx.buffer
                                 .unsafe_to_concat(Some(ctx.buffer.idx), Some(unsafe_to));
@@ -147,57 +147,23 @@ impl WouldApply for LigatureSubstFormat1<'_> {
 }
 
 impl Apply for LigatureSubstFormat1<'_> {
-    fn apply_with_external_cache(
-        &self,
-        ctx: &mut hb_ot_apply_context_t,
-        external_cache: &SubtableExternalCache,
-    ) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-
-        let (index, seconds) = match external_cache {
-            SubtableExternalCache::LigatureSubstFormat1Cache(cache) => (
-                coverage_index_cached(
-                    |gid| self.coverage().ok()?.get(gid),
-                    glyph,
-                    &cache.coverage,
-                )?,
-                &cache.seconds,
-            ),
-            SubtableExternalCache::LigatureSubstFormat1SmallCache(cache) => (
-                cache.coverage.index(&self.offset_data(), glyph)?,
-                &cache.seconds,
-            ),
-            _ => (
-                coverage_index(self.coverage(), glyph)?,
-                &hb_set_digest_t::full(),
-            ),
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let seconds = match state.external_cache {
+            SubtableExternalCache::LigatureSubstFormat1Cache(cache) => &cache.seconds,
+            _ => &hb_set_digest_t::full(),
         };
         self.ligature_sets()
-            .get(index as usize)
+            .get(state.first_coverage_index as usize)
             .ok()
             .and_then(|set| set.apply(ctx, seconds))
     }
 
     fn external_cache_create(&self, mode: SubtableExternalCacheMode) -> SubtableExternalCache {
         match mode {
-            SubtableExternalCacheMode::Full => SubtableExternalCache::LigatureSubstFormat1Cache(
-                Box::new(LigatureSubstFormat1Cache::new(collect_seconds(self))),
-            ),
-            SubtableExternalCacheMode::Small => {
-                if let Some(coverage) =
-                    CoverageInfo::new(&self.offset_data(), self.coverage_offset().to_u32() as u16)
-                {
-                    SubtableExternalCache::LigatureSubstFormat1SmallCache(
-                        LigatureSubstFormat1SmallCache {
-                            coverage,
-                            seconds: collect_seconds(self),
-                        },
-                    )
-                } else {
-                    SubtableExternalCache::None
-                }
-            }
             SubtableExternalCacheMode::None => SubtableExternalCache::None,
+            _ => SubtableExternalCache::LigatureSubstFormat1Cache(LigatureSubstFormat1Cache::new(
+                collect_seconds(self),
+            )),
         }
     }
 }

--- a/src/hb/ot/gsub/multiple.rs
+++ b/src/hb/ot/gsub/multiple.rs
@@ -1,6 +1,6 @@
 use crate::hb::buffer::GlyphPropsFlags;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{Apply, WouldApply, WouldApplyContext};
+use crate::hb::ot_layout_gsubgpos::{Apply, ApplyState, WouldApply, WouldApplyContext};
 use read_fonts::tables::gsub::MultipleSubstFormat1;
 
 impl WouldApply for MultipleSubstFormat1<'_> {
@@ -13,9 +13,8 @@ impl WouldApply for MultipleSubstFormat1<'_> {
 }
 
 impl Apply for MultipleSubstFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let gid = ctx.buffer.cur(0).as_glyph();
-        let index = self.coverage().ok()?.get(gid)? as usize;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let index = state.first_coverage_index as usize;
         let substs = self.sequences().get(index).ok()?.substitute_glyph_ids();
         match substs.len() {
             // Spec disallows this, but Uniscribe allows it.

--- a/src/hb/ot/gsub/reverse_chain.rs
+++ b/src/hb/ot/gsub/reverse_chain.rs
@@ -2,7 +2,7 @@ use crate::hb::buffer::GlyphInfo;
 use crate::hb::ot_layout::MAX_NESTING_LEVEL;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
-    match_backtrack, match_lookahead, Apply, WouldApply, WouldApplyContext,
+    match_backtrack, match_lookahead, Apply, ApplyState, WouldApply, WouldApplyContext,
 };
 use read_fonts::tables::gsub::ReverseChainSingleSubstFormat1;
 
@@ -18,15 +18,12 @@ impl WouldApply for ReverseChainSingleSubstFormat1<'_> {
 }
 
 impl Apply for ReverseChainSingleSubstFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
         // No chaining to this type.
         if ctx.nesting_level_left != MAX_NESTING_LEVEL {
             return None;
         }
-
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        let coverage = self.coverage().ok()?;
-        let index = coverage.get(glyph)? as usize;
+        let index = state.first_coverage_index as usize;
         let substitutes = self.substitute_glyph_ids();
         if index >= substitutes.len() {
             return None;

--- a/src/hb/ot/gsub/single.rs
+++ b/src/hb/ot/gsub/single.rs
@@ -1,5 +1,5 @@
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{Apply, WouldApply, WouldApplyContext};
+use crate::hb::ot_layout_gsubgpos::{Apply, ApplyState, WouldApply, WouldApplyContext};
 use read_fonts::tables::gsub::{SingleSubstFormat1, SingleSubstFormat2};
 
 impl WouldApply for SingleSubstFormat1<'_> {
@@ -10,10 +10,8 @@ impl WouldApply for SingleSubstFormat1<'_> {
 }
 
 impl Apply for SingleSubstFormat1<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        self.coverage().ok()?.get(glyph)?;
-        let subst = (glyph.to_u32() as i32 + self.delta_glyph_id() as i32) as u16;
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let subst = (state.first_glyph.to_u32() as i32 + self.delta_glyph_id() as i32) as u16;
         ctx.replace_glyph(subst.into());
         Some(())
     }
@@ -29,10 +27,12 @@ impl WouldApply for SingleSubstFormat2<'_> {
 }
 
 impl Apply for SingleSubstFormat2<'_> {
-    fn apply(&self, ctx: &mut hb_ot_apply_context_t) -> Option<()> {
-        let glyph = ctx.buffer.cur(0).as_glyph();
-        let index = self.coverage().ok()?.get(glyph)? as usize;
-        let subst = self.substitute_glyph_ids().get(index)?.get().to_u16();
+    fn apply(&self, ctx: &mut hb_ot_apply_context_t, state: &ApplyState) -> Option<()> {
+        let subst = self
+            .substitute_glyph_ids()
+            .get(state.first_coverage_index as usize)?
+            .get()
+            .to_u16();
         ctx.replace_glyph(subst.into());
         Some(())
     }

--- a/src/hb/ot/mod.rs
+++ b/src/hb/ot/mod.rs
@@ -2,7 +2,7 @@ use super::buffer::GlyphPropsFlags;
 use super::ot_layout::TableIndex;
 use super::{common::TagExt, set_digest::hb_set_digest_t};
 use crate::hb::hb_tag_t;
-use crate::hb::ot_layout_gsubgpos::{BinaryCache, MappingCache};
+use crate::hb::ot_layout_gsubgpos::MappingCache;
 use crate::hb::tables::TableRanges;
 use alloc::vec::Vec;
 use lookup::{LookupCache, LookupInfo};
@@ -506,54 +506,6 @@ impl<'a> LayoutTable<'a> {
 
 fn coverage_index(coverage: Result<CoverageTable, ReadError>, gid: GlyphId) -> Option<u16> {
     coverage.ok().and_then(|coverage| coverage.get(gid))
-}
-
-fn coverage_index_cached(
-    coverage: impl Fn(GlyphId) -> Option<u16>,
-    gid: GlyphId,
-    cache: &MappingCache,
-) -> Option<u16> {
-    if let Some(index) = cache.get(gid.into()) {
-        if index == MappingCache::MAX_VALUE {
-            None
-        } else {
-            Some(index as u16)
-        }
-    } else {
-        let index = coverage(gid);
-        if let Some(index) = index {
-            if (index as u32) < MappingCache::MAX_VALUE {
-                cache.set(gid.into(), index as u32);
-            }
-            Some(index)
-        } else {
-            cache.set(gid.into(), MappingCache::MAX_VALUE);
-            None
-        }
-    }
-}
-
-fn coverage_binary_cached(
-    coverage: impl Fn(GlyphId) -> Option<u16>,
-    gid: GlyphId,
-    cache: &BinaryCache,
-) -> Option<bool> {
-    if let Some(index) = cache.get(gid.into()) {
-        if index == BinaryCache::MAX_VALUE {
-            None
-        } else {
-            Some(true)
-        }
-    } else {
-        let index = coverage(gid);
-        if index.is_some() {
-            cache.set(gid.into(), 0);
-            Some(true)
-        } else {
-            cache.set(gid.into(), BinaryCache::MAX_VALUE);
-            None
-        }
-    }
 }
 
 fn covered(coverage: Result<CoverageTable, ReadError>, gid: GlyphId) -> bool {

--- a/src/hb/ot_layout_gsubgpos.rs
+++ b/src/hb/ot_layout_gsubgpos.rs
@@ -738,7 +738,7 @@ impl SubtableCoverage {
                     if (index as u32) < MappingCache::MAX_VALUE {
                         cache.set(gid.into(), index as u32);
                     }
-                    Some(index as u16)
+                    Some(index)
                 } else {
                     cache.set(gid.into(), MappingCache::MAX_VALUE);
                     None


### PR DESCRIPTION
This extracts the primary coverage table (along with any suitable caches) into a field on `SubtableInfo` so that we can check coverage before attempting to parse the subtable. The glyph id, coverage index, coverage metadata and external cache are then passed to the subtable apply function in a new `ApplyState` parameter. This avoids some buffer indexing and reparsing the primary coverage table.

This attempts to clean up and unify some of the caching code paths along with laying some groundwork for future optimizations (like #260).

HR benchmarks seem to show a reasonable gain on non-Latin shaping as a bonus.