### PR TITLE
Upgrade to `read-fonts` 0.39 + bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["harfrust", "hr-shape", "fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.85"  # should match https://github.com/googlefonts/fontations/blob/main/Cargo.toml
 description = "A complete HarfBuzz shaping algorithm port to Rust."
@@ -22,7 +22,8 @@ codegen-units = 1
 inherits = "release"
 
 [workspace.dependencies]
-read-fonts = { version = "0.38.0", default-features = false, features = ["libm"] }
+harfrust = { version = "0.6.0", path = "./harfrust", default-features = false }
+read-fonts = { version = "0.39.0", default-features = false, features = ["libm"] }
 
 [workspace.lints.rust]
 unused_qualifications = "warn"

--- a/harfrust/src/hb/glyph_names.rs
+++ b/harfrust/src/hb/glyph_names.rs
@@ -1,5 +1,6 @@
 use read_fonts::{
-    tables::{cff::Cff, post::Post, postscript::Charset},
+    ps::cff::charset::Charset,
+    tables::{cff::Cff, post::Post},
     FontRef, TableProvider,
 };
 
@@ -29,7 +30,7 @@ impl<'a> GlyphNames<'a> {
         let name = match self {
             Self::Cff(cff, charset) => {
                 let sid = charset.string_id(glyph_id.into()).ok()?;
-                core::str::from_utf8(cff.string(sid)?.bytes()).ok()
+                core::str::from_utf8(cff.string(sid)?).ok()
             }
             Self::Post(post) => {
                 let gid: u16 = glyph_id.try_into().ok()?;

--- a/hr-shape/Cargo.toml
+++ b/hr-shape/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+harfrust = { workspace = true, features = ["std"] }
 clap = { version = "4", features = ["derive"] }
-harfrust = { version = "0.5.2", path = "../harfrust", default-features = false, features = ["std"] }
 
 [[bin]]
 name = "hr-shape"


### PR DESCRIPTION
- Upgrades to `read-fonts` 0.39 (a couple of minor code changes required)
- Bumps version to `0.6.0`
- Uses workspace dependency for in-repo HarfRust dependency to keep version bumps all in one file