### PR TITLE
[fuzz] turn off strip/lto

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,6 +20,11 @@ libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 harfrust = { path = "../harfrust", features = ["std"] }
 read-fonts.workspace = true
 
+# Override workspace release profile: strip and LTO break sanitizer builds
+[profile.release]
+strip = false
+lto = false
+
 [[bin]]
 name = "fuzz_shape"
 path = "fuzz_targets/fuzz_shape.rs"


### PR DESCRIPTION
This was ~possibly~ probably causing us to fail to build on oss-fuzz?

~(edit: I'm now not convinced this is the issue since fontations doesn't have to do this? needs more investigation)~