### PR TITLE
0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-21
+
+This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
+and has an MSRV (minimum supported Rust version) of 1.85.
+
+- Blocklist broken fonts in GDEF. This ports feature from HarfBuzz that was missing before.
+- Add LICENSE file symlink to each crate.
+
+
 ## [0.6.0] - 2026-04-09
 
 This release matches HarfBuzz [v14.1.0][harfbuzz-14.1.0], and has an MSRV (minimum supported Rust version) of 1.85.
@@ -132,6 +141,8 @@ See [their changelog](https://github.com/harfbuzz/rustybuzz/blob/main/CHANGELOG.
 [harfbuzz-12.1.0]: https://github.com/harfbuzz/harfbuzz/releases/tag/12.1.0
 [harfbuzz-12.2.0]: https://github.com/harfbuzz/harfbuzz/releases/tag/12.2.0
 [harfbuzz-12.3.0]: https://github.com/harfbuzz/harfbuzz/releases/tag/12.3.0
+[harfbuzz-13.0.0]: https://github.com/harfbuzz/harfbuzz/releases/tag/13.0.0
+[harfbuzz-14.1.0]: https://github.com/harfbuzz/harfbuzz/releases/tag/14.1.0
 
 [@khaledhosny]: https://github.com/khaledhosny
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["harfrust", "hr-shape", "fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.85"  # should match https://github.com/googlefonts/fontations/blob/main/Cargo.toml
 description = "A complete HarfBuzz shaping algorithm port to Rust."
@@ -22,7 +22,7 @@ codegen-units = 1
 inherits = "release"
 
 [workspace.dependencies]
-harfrust = { version = "0.6.0", path = "./harfrust", default-features = false }
+harfrust = { version = "0.6.1", path = "./harfrust", default-features = false }
 read-fonts = { version = "0.39.0", default-features = false, features = ["libm"] }
 
 [workspace.lints.rust]


### PR DESCRIPTION
This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
and has an MSRV (minimum supported Rust version) of 1.85.

- Blocklist broken fonts in GDEF. This ports feature from HarfBuzz that was missing before.
- Add LICENSE file symlink to each crate.