### PR TITLE
Let read-fonts decide whether libm is needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ inherits = "release"
 
 [workspace.dependencies]
 harfrust = { version = "0.6.1", path = "./harfrust", default-features = false }
-read-fonts = { version = "0.39.0", default-features = false, features = ["libm"] }
+read-fonts = { version = "0.39.0", default-features = false }
 
 [workspace.lints.rust]
 unused_qualifications = "warn"


### PR DESCRIPTION
Read-fonts only needs libm if std is not available. We do not want to hard-required libm for read-fonts here, compare [1].

[1] https://github.com/googlefonts/fontations/blob/main/read-fonts/Cargo.toml#L33C1-L33C26