### PR TITLE
Add support for font funcs

### DIFF
--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -5,7 +5,7 @@ use core::convert::TryFrom;
 use read_fonts::types::{GlyphId, GlyphId16};
 
 use super::buffer::glyph_flag::{SAFE_TO_INSERT_TATWEEL, UNSAFE_TO_BREAK, UNSAFE_TO_CONCAT};
-use super::face::hb_glyph_extents_t;
+use super::face::GlyphExtents;
 use super::unicode::CharExt;
 use super::{hb_font_t, hb_mask_t};
 use crate::hb::set_digest::hb_set_digest_t;
@@ -1994,7 +1994,7 @@ impl GlyphBuffer {
             }
 
             if flags.contains(SerializeFlags::GLYPH_EXTENTS) {
-                let mut extents = hb_glyph_extents_t::default();
+                let mut extents = GlyphExtents::default();
                 face.glyph_extents(info.as_glyph(), &mut extents);
                 write!(
                     &mut s,

--- a/harfrust/src/hb/charmap.rs
+++ b/harfrust/src/hb/charmap.rs
@@ -13,11 +13,10 @@ pub type cache_t = hb_cache_t<21, 19, 256, 32>;
 pub struct Charmap<'a> {
     subtable: Option<(SelectedCmapSubtable, CmapSubtable<'a>)>,
     vs_subtable: Option<Cmap14<'a>>,
-    cache: &'a cache_t,
 }
 
 impl<'a> Charmap<'a> {
-    pub fn new(font: &FontRef<'a>, table_ranges: &TableRanges, cache: &'a cache_t) -> Self {
+    pub fn new(font: &FontRef<'a>, table_ranges: &TableRanges) -> Self {
         if let Some(cmap) = table_ranges.cmap.resolve_table::<Cmap>(font) {
             let data = cmap.offset_data();
             let records = cmap.encoding_records();
@@ -35,18 +34,16 @@ impl<'a> Charmap<'a> {
             Self {
                 subtable,
                 vs_subtable,
-                cache,
             }
         } else {
             Self {
                 subtable: None,
                 vs_subtable: None,
-                cache,
             }
         }
     }
 
-    fn map_impl(&self, mut c: u32) -> Option<GlyphId> {
+    pub fn map(&self, mut c: u32) -> Option<GlyphId> {
         let subtable = self.subtable.as_ref()?;
         if subtable.0.is_mac_roman && c > 0x7F {
             c = unicode_to_macroman(c);
@@ -82,18 +79,6 @@ impl<'a> Charmap<'a> {
             return self.map(0xF000 + c);
         }
         result
-    }
-
-    #[inline(always)]
-    pub fn map(&self, c: u32) -> Option<GlyphId> {
-        if let Some(gid) = self.cache.get(c) {
-            return Some(GlyphId::new(gid));
-        }
-        let gid = self.map_impl(c);
-        if let Some(gid) = gid {
-            self.cache.set(c, gid.to_u32());
-        }
-        gid
     }
 
     pub fn map_variant(&self, c: u32, vs: u32) -> Option<GlyphId> {

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -4,6 +4,7 @@ use smallvec::SmallVec;
 
 use super::aat::AatTables;
 use super::charmap::{cache_t as cmap_cache_t, Charmap};
+use super::font_funcs::{DummyFontFuncs, FontFuncsDispatch};
 use super::glyph_metrics::GlyphMetrics;
 use super::glyph_names::GlyphNames;
 use super::ot::{LayoutTable, OtCache, OtTables};
@@ -13,6 +14,8 @@ use crate::hb::aat::AatCache;
 use crate::hb::buffer::hb_buffer_t;
 use crate::hb::tables::TableRanges;
 use crate::{script, Feature, GlyphBuffer, NormalizedCoord, ShapePlan, UnicodeBuffer, Variation};
+
+pub use super::font_funcs::{AdvanceWidthBatch, BuiltinFontFuncs, FontFuncs, RawAdvanceWidthBatch};
 
 /// Data required for shaping with a single font.
 pub struct ShaperData {
@@ -196,7 +199,7 @@ impl<'a> ShaperBuilder<'a> {
     pub fn build(self) -> crate::Shaper<'a> {
         let font = self.font;
         let units_per_em = self.data.table_ranges.units_per_em;
-        let charmap = Charmap::new(&font, &self.data.table_ranges, &self.data.cmap_cache);
+        let charmap = Charmap::new(&font, &self.data.table_ranges);
         let glyph_metrics = GlyphMetrics::new(&font, &self.data.table_ranges);
         let (coords, feature_variations) = self
             .instance
@@ -214,6 +217,7 @@ impl<'a> ShaperBuilder<'a> {
             font,
             units_per_em,
             charmap,
+            cmap_cache: &self.data.cmap_cache,
             glyph_metrics,
             ot_tables,
             aat_tables,
@@ -227,6 +231,7 @@ pub struct ShapeOptions<'a> {
     plan: Option<&'a ShapePlan>,
     point_size: Option<f32>,
     features: &'a [Feature],
+    font_funcs: Option<&'a mut (dyn FontFuncs + 'a)>,
 }
 
 impl<'a> ShapeOptions<'a> {
@@ -255,6 +260,12 @@ impl<'a> ShapeOptions<'a> {
         self.features = features;
         self
     }
+
+    /// Sets optional font functions used for shaping.
+    pub fn font_funcs(mut self, funcs: Option<&'a mut (dyn FontFuncs + 'a)>) -> Self {
+        self.font_funcs = funcs;
+        self
+    }
 }
 
 /// A configured shaper.
@@ -263,6 +274,7 @@ pub struct hb_font_t<'a> {
     pub(crate) font: FontRef<'a>,
     pub(crate) units_per_em: u16,
     charmap: Charmap<'a>,
+    pub(crate) cmap_cache: &'a cmap_cache_t,
     glyph_metrics: GlyphMetrics<'a>,
     pub(crate) ot_tables: OtTables<'a>,
     pub(crate) aat_tables: AatTables<'a>,
@@ -284,7 +296,15 @@ impl<'a> crate::Shaper<'a> {
     ///
     /// Consumes the buffer. You can then run [`GlyphBuffer::clear`] to get the [`UnicodeBuffer`] back
     /// without allocating a new one.
-    pub fn shape(&self, buffer: UnicodeBuffer, options: ShapeOptions) -> GlyphBuffer {
+    ///
+    /// If a plan is provided, it is up to the caller to ensure that the shape plan matches the
+    /// properties of the provided buffer, otherwise the shaping result will likely be incorrect.
+    ///
+    /// # Panics
+    ///
+    /// Will panic when debugging assertions are enabled if the buffer and plan have mismatched
+    /// properties.    
+    pub fn shape(&self, buffer: UnicodeBuffer, options: ShapeOptions<'_>) -> GlyphBuffer {
         if let Some(plan) = options.plan {
             self.shape_with_plan(plan, buffer, options)
         } else {
@@ -299,23 +319,11 @@ impl<'a> crate::Shaper<'a> {
         }
     }
 
-    /// Shapes the buffer content using the provided font and plan.
-    ///
-    /// Consumes the buffer. You can then run [`GlyphBuffer::clear`] to get the [`UnicodeBuffer`] back
-    /// without allocating a new one.
-    ///
-    /// It is up to the caller to ensure that the shape plan matches the properties of the provided
-    /// buffer, otherwise the shaping result will likely be incorrect.
-    ///
-    /// # Panics
-    ///
-    /// Will panic when debugging assertions are enabled if the buffer and plan have mismatched
-    /// properties.
     fn shape_with_plan(
         &self,
         plan: &ShapePlan,
         buffer: UnicodeBuffer,
-        options: ShapeOptions,
+        options: ShapeOptions<'_>,
     ) -> GlyphBuffer {
         let mut buffer = buffer.0;
         buffer.enter();
@@ -336,6 +344,12 @@ impl<'a> crate::Shaper<'a> {
         if buffer.len > 0 {
             // Save the original direction, we use it later.
             let target_direction = buffer.direction;
+            let (font_funcs, has_custom_funcs): (&mut (dyn FontFuncs + '_), bool) =
+                match options.font_funcs {
+                    Some(user_font_funcs) => (user_font_funcs, true),
+                    None => (&mut DummyFontFuncs, false),
+                };
+            let mut font_funcs = FontFuncsDispatch::new(self, font_funcs, has_custom_funcs);
             OtShapeContext {
                 plan,
                 face: self,
@@ -343,6 +357,7 @@ impl<'a> crate::Shaper<'a> {
                 target_direction,
                 features: options.features,
                 point_size: options.point_size,
+                font_funcs: &mut font_funcs,
             }
             .shape_internal();
         }
@@ -350,10 +365,6 @@ impl<'a> crate::Shaper<'a> {
         buffer.leave();
 
         GlyphBuffer(buffer)
-    }
-
-    pub(crate) fn has_glyph(&self, c: u32) -> bool {
-        self.get_nominal_glyph(c).is_some()
     }
 
     pub(crate) fn get_nominal_glyph(&self, c: u32) -> Option<GlyphId> {
@@ -369,6 +380,7 @@ impl<'a> crate::Shaper<'a> {
             .advance_width(glyph, self.ot_tables.coords)
             .unwrap_or_default()
     }
+
     pub(crate) fn glyph_h_advances(&self, buffer: &mut hb_buffer_t) {
         self.glyph_metrics
             .populate_advance_widths(buffer, self.ot_tables.coords);
@@ -381,21 +393,13 @@ impl<'a> crate::Shaper<'a> {
             .unwrap_or(self.units_per_em as i32)
     }
 
-    pub(crate) fn glyph_h_origin(&self, glyph: GlyphId) -> i32 {
-        self.glyph_h_advance(glyph) / 2
-    }
-
     pub(crate) fn glyph_v_origin(&self, glyph: GlyphId) -> i32 {
         self.glyph_metrics
             .v_origin(glyph, self.ot_tables.coords)
             .unwrap_or_default()
     }
 
-    pub(crate) fn glyph_extents(
-        &self,
-        glyph: GlyphId,
-        glyph_extents: &mut hb_glyph_extents_t,
-    ) -> bool {
+    pub(crate) fn glyph_extents(&self, glyph: GlyphId, glyph_extents: &mut GlyphExtents) -> bool {
         if let Some(extents) = self.glyph_metrics.extents(glyph, self.ot_tables.coords) {
             glyph_extents.x_bearing = extents.x_min;
             glyph_extents.y_bearing = extents.y_max;
@@ -431,11 +435,18 @@ impl<'a> crate::Shaper<'a> {
     }
 }
 
+/// Glyph ink extents in font units.
+///
+/// This matches HarfBuzz's glyph extents layout and semantics.
 #[derive(Clone, Copy, Default, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
-pub struct hb_glyph_extents_t {
+pub struct GlyphExtents {
+    /// Horizontal bearing from glyph origin to the left side of the ink box.
     pub x_bearing: i32,
+    /// Vertical bearing from glyph origin to the top of the ink box.
     pub y_bearing: i32,
+    /// Width of the glyph ink box.
     pub width: i32,
+    /// Height of the glyph ink box.
     pub height: i32,
 }

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 
 use super::aat::AatTables;
 use super::charmap::{cache_t as cmap_cache_t, Charmap};
-use super::font_funcs::{DummyFontFuncs, FontFuncsDispatch};
+use super::font_funcs::FontFuncsDispatch;
 use super::glyph_metrics::GlyphMetrics;
 use super::glyph_names::GlyphNames;
 use super::ot::{LayoutTable, OtCache, OtTables};
@@ -344,12 +344,7 @@ impl<'a> crate::Shaper<'a> {
         if buffer.len > 0 {
             // Save the original direction, we use it later.
             let target_direction = buffer.direction;
-            let (font_funcs, has_custom_funcs): (&mut (dyn FontFuncs + '_), bool) =
-                match options.font_funcs {
-                    Some(user_font_funcs) => (user_font_funcs, true),
-                    None => (&mut DummyFontFuncs, false),
-                };
-            let mut font_funcs = FontFuncsDispatch::new(self, font_funcs, has_custom_funcs);
+            let mut font_funcs = FontFuncsDispatch::new(self, options.font_funcs);
             OtShapeContext {
                 plan,
                 face: self,

--- a/harfrust/src/hb/font_funcs.rs
+++ b/harfrust/src/hb/font_funcs.rs
@@ -1,0 +1,284 @@
+use core::mem::size_of;
+use core::ptr;
+use core::slice;
+
+use read_fonts::types::GlyphId;
+
+use super::buffer::{hb_buffer_t, GlyphInfo, GlyphPosition};
+use super::face::{hb_font_t, GlyphExtents};
+
+/// Raw C-style view over a batch of glyph ids and advance widths.
+#[derive(Clone, Copy, Debug)]
+pub struct RawAdvanceWidthBatch {
+    /// Number of batch entries.
+    pub len: usize,
+    /// Pointer to glyph ids (read-only).
+    pub gids: *const u32,
+    /// Pointer to horizontal advances (writable).
+    pub advances: *mut i32,
+    /// Byte stride between successive glyph ids.
+    pub gid_stride: isize,
+    /// Byte stride between successive advances.
+    pub advance_stride: isize,
+}
+
+/// Safe batch view for glyph id / horizontal-advance updates.
+pub struct AdvanceWidthBatch<'a> {
+    infos: &'a [GlyphInfo],
+    positions: &'a mut [GlyphPosition],
+}
+
+impl<'a> AdvanceWidthBatch<'a> {
+    pub(crate) fn new(buffer: &'a mut hb_buffer_t) -> Self {
+        let len = buffer.len;
+        let infos = &buffer.info[..len];
+        let positions = &mut buffer.pos[..len];
+        Self { infos, positions }
+    }
+
+    /// Returns the number of entries in the batch.
+    pub fn len(&self) -> usize {
+        self.infos.len()
+    }
+
+    /// Returns true if the batch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.infos.is_empty()
+    }
+
+    /// Returns a raw C-style view over this batch.
+    pub fn into_raw(self) -> RawAdvanceWidthBatch {
+        if self.infos.is_empty() {
+            return RawAdvanceWidthBatch {
+                len: 0,
+                gids: ptr::null(),
+                advances: ptr::null_mut(),
+                gid_stride: size_of::<GlyphInfo>() as isize,
+                advance_stride: size_of::<GlyphPosition>() as isize,
+            };
+        }
+
+        RawAdvanceWidthBatch {
+            len: self.infos.len(),
+            // `glyph_id` is the first field in `GlyphInfo`.
+            gids: self.infos.as_ptr().cast::<u32>(),
+            // `x_advance` is the first field in `GlyphPosition`.
+            advances: self.positions.as_mut_ptr().cast::<i32>(),
+            gid_stride: size_of::<GlyphInfo>() as isize,
+            advance_stride: size_of::<GlyphPosition>() as isize,
+        }
+    }
+}
+
+pub struct AdvanceWidthBatchIter<'a> {
+    infos: slice::Iter<'a, GlyphInfo>,
+    positions: slice::IterMut<'a, GlyphPosition>,
+}
+
+impl<'a> Iterator for AdvanceWidthBatchIter<'a> {
+    type Item = (GlyphId, &'a mut i32);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let info = self.infos.next()?;
+        let pos = self.positions.next()?;
+        Some((info.as_glyph(), &mut pos.x_advance))
+    }
+}
+
+impl<'a> IntoIterator for AdvanceWidthBatch<'a> {
+    type Item = (GlyphId, &'a mut i32);
+    type IntoIter = AdvanceWidthBatchIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        AdvanceWidthBatchIter {
+            infos: self.infos.iter(),
+            positions: self.positions.iter_mut(),
+        }
+    }
+}
+
+/// Default implementations backed by font tables.
+pub struct BuiltinFontFuncs<'a> {
+    face: &'a hb_font_t<'a>,
+}
+
+impl<'a> BuiltinFontFuncs<'a> {
+    pub(crate) fn new(face: &'a hb_font_t<'a>) -> Self {
+        Self { face }
+    }
+
+    /// Maps a Unicode scalar value to a nominal glyph.
+    pub fn nominal_glyph(&self, c: u32) -> Option<GlyphId> {
+        self.face.get_nominal_glyph(c)
+    }
+
+    /// Maps a Unicode scalar value and variation selector to a glyph.
+    pub fn variant_glyph(&self, c: u32, vs: u32) -> Option<GlyphId> {
+        self.face.get_nominal_variant_glyph(c, vs)
+    }
+
+    /// Returns the horizontal advance for a glyph.
+    pub fn advance_width(&self, glyph: GlyphId) -> i32 {
+        self.face.glyph_h_advance(glyph)
+    }
+
+    /// Returns the vertical advance for a glyph.
+    pub fn advance_height(&self, glyph: GlyphId) -> i32 {
+        self.face.glyph_v_advance(glyph)
+    }
+
+    /// Returns the horizontal origin for a glyph.
+    pub fn horizontal_origin(&self, glyph: GlyphId) -> i32 {
+        self.advance_width(glyph) / 2
+    }
+
+    /// Returns the vertical origin for a glyph.
+    pub fn vertical_origin(&self, glyph: GlyphId) -> i32 {
+        self.face.glyph_v_origin(glyph)
+    }
+
+    /// Returns extents for a glyph if available.
+    pub fn extents(&self, glyph: GlyphId) -> Option<GlyphExtents> {
+        let mut extents = GlyphExtents::default();
+        if self.face.glyph_extents(glyph, &mut extents) {
+            Some(extents)
+        } else {
+            None
+        }
+    }
+
+    /// Populates horizontal advances for all entries in the batch.
+    pub fn populate_advance_widths(&self, batch: AdvanceWidthBatch<'_>) {
+        for (glyph, advance) in batch {
+            *advance = self.face.glyph_h_advance(glyph);
+        }
+    }
+}
+
+/// Customizable font callback surface.
+pub trait FontFuncs {
+    /// Nominal character-to-glyph mapping callback.
+    fn nominal_glyph(&mut self, builtin: &BuiltinFontFuncs, c: u32) -> Option<GlyphId> {
+        builtin.nominal_glyph(c)
+    }
+
+    /// Variation-selector mapping callback.
+    fn variant_glyph(&mut self, builtin: &BuiltinFontFuncs, c: u32, vs: u32) -> Option<GlyphId> {
+        builtin.variant_glyph(c, vs)
+    }
+
+    /// Horizontal advance callback.
+    fn advance_width(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+        builtin.advance_width(glyph)
+    }
+
+    /// Batch horizontal-advance callback.
+    fn populate_advance_widths(
+        &mut self,
+        builtin: &BuiltinFontFuncs,
+        batch: AdvanceWidthBatch<'_>,
+    ) {
+        for (glyph, advance) in batch {
+            *advance = self.advance_width(builtin, glyph);
+        }
+    }
+
+    /// Vertical advance callback.
+    fn advance_height(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+        builtin.advance_height(glyph)
+    }
+
+    /// Vertical origin callback.
+    fn vertical_origin(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+        builtin.vertical_origin(glyph)
+    }
+
+    /// Glyph extents callback.
+    fn extents(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> Option<GlyphExtents> {
+        builtin.extents(glyph)
+    }
+}
+
+pub struct DummyFontFuncs;
+
+impl FontFuncs for DummyFontFuncs {}
+
+pub(crate) struct FontFuncsDispatch<'a, 'u> {
+    builtin: BuiltinFontFuncs<'a>,
+    funcs: &'u mut (dyn FontFuncs + 'u),
+    has_custom_funcs: bool,
+}
+
+impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
+    pub(crate) fn new(
+        face: &'a hb_font_t<'a>,
+        funcs: &'u mut (dyn FontFuncs + 'u),
+        has_custom_funcs: bool,
+    ) -> Self {
+        Self {
+            builtin: BuiltinFontFuncs::new(face),
+            funcs,
+            has_custom_funcs,
+        }
+    }
+
+    pub(crate) fn font(&self) -> &'a hb_font_t<'a> {
+        self.builtin.face
+    }
+
+    #[inline(always)]
+    pub(crate) fn nominal_glyph(&mut self, c: u32) -> Option<GlyphId> {
+        let cache = self.builtin.face.cmap_cache;
+        if let Some(gid) = cache.get(c) {
+            Some(gid.into())
+        } else if let Some(gid) = self.funcs.nominal_glyph(&self.builtin, c) {
+            cache.set(c, gid.to_u32());
+            Some(gid)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn has_glyph(&mut self, c: u32) -> bool {
+        self.nominal_glyph(c).is_some()
+    }
+
+    #[inline(always)]
+    pub(crate) fn variant_glyph(&mut self, c: u32, vs: u32) -> Option<GlyphId> {
+        self.funcs.variant_glyph(&self.builtin, c, vs)
+    }
+
+    #[inline(always)]
+    pub(crate) fn advance_width(&mut self, glyph: GlyphId) -> i32 {
+        self.funcs.advance_width(&self.builtin, glyph)
+    }
+
+    #[inline(always)]
+    pub(crate) fn advance_height(&mut self, glyph: GlyphId) -> i32 {
+        self.funcs.advance_height(&self.builtin, glyph)
+    }
+
+    #[inline(always)]
+    pub(crate) fn horizontal_origin(&mut self, glyph: GlyphId) -> i32 {
+        self.advance_width(glyph) / 2
+    }
+
+    #[inline(always)]
+    pub(crate) fn vertical_origin(&mut self, glyph: GlyphId) -> i32 {
+        self.funcs.vertical_origin(&self.builtin, glyph)
+    }
+
+    #[inline(always)]
+    pub(crate) fn extents(&mut self, glyph: GlyphId) -> Option<GlyphExtents> {
+        self.funcs.extents(&self.builtin, glyph)
+    }
+
+    pub(crate) fn populate_advance_widths(&mut self, batch: AdvanceWidthBatch<'_>) {
+        self.funcs.populate_advance_widths(&self.builtin, batch);
+    }
+
+    pub(crate) fn has_custom_funcs(&self) -> bool {
+        self.has_custom_funcs
+    }
+}

--- a/harfrust/src/hb/font_funcs.rs
+++ b/harfrust/src/hb/font_funcs.rs
@@ -15,6 +15,9 @@ pub struct RawAdvanceWidthBatch {
     /// Pointer to glyph ids (read-only).
     pub gids: *const u32,
     /// Pointer to horizontal advances (writable).
+    ///
+    /// See "Metrics scaling" in the [FontFuncs] for details
+    /// on what value this method should return.
     pub advances: *mut i32,
     /// Byte stride between successive glyph ids.
     pub gid_stride: isize,
@@ -127,14 +130,12 @@ impl<'a> BuiltinFontFuncs<'a> {
         self.face.glyph_v_advance(glyph)
     }
 
-    /// Returns the horizontal origin for a glyph.
-    pub fn horizontal_origin(&self, glyph: GlyphId) -> i32 {
-        self.advance_width(glyph) / 2
-    }
-
     /// Returns the vertical origin for a glyph.
-    pub fn vertical_origin(&self, glyph: GlyphId) -> i32 {
-        self.face.glyph_v_origin(glyph)
+    pub fn vertical_origin(&self, glyph: GlyphId) -> (i32, i32) {
+        (
+            self.advance_width(glyph) / 2,
+            self.face.glyph_v_origin(glyph),
+        )
     }
 
     /// Returns extents for a glyph if available.
@@ -156,6 +157,11 @@ impl<'a> BuiltinFontFuncs<'a> {
 }
 
 /// Customizable font callback surface.
+///
+/// # Metrics scaling
+///
+/// All font metrics passed to and from these callbacks are in unscaled font
+/// units.
 pub trait FontFuncs {
     /// Nominal character-to-glyph mapping callback.
     fn nominal_glyph(&mut self, builtin: &BuiltinFontFuncs, c: u32) -> Option<GlyphId> {
@@ -168,11 +174,17 @@ pub trait FontFuncs {
     }
 
     /// Horizontal advance callback.
+    ///
+    /// See "Metrics scaling" in the [trait-level docs](FontFuncs) for details
+    /// on what value this method should return.
     fn advance_width(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
         builtin.advance_width(glyph)
     }
 
     /// Batch horizontal-advance callback.
+    ///
+    /// See "Metrics scaling" in the [trait-level docs](FontFuncs) for details
+    /// on what value this method should return.
     fn populate_advance_widths(
         &mut self,
         builtin: &BuiltinFontFuncs,
@@ -184,41 +196,45 @@ pub trait FontFuncs {
     }
 
     /// Vertical advance callback.
+    ///
+    /// See "Metrics scaling" in the [trait-level docs](FontFuncs) for details
+    /// on what value this method should return.
     fn advance_height(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
         builtin.advance_height(glyph)
     }
 
     /// Vertical origin callback.
-    fn vertical_origin(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+    ///
+    /// Returns the (x, y) coordinates of the vertical origin for the given glyph.
+    ///
+    /// See "Metrics scaling" in the [trait-level docs](FontFuncs) for details
+    /// on what values this method should return.
+    fn vertical_origin(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> (i32, i32) {
         builtin.vertical_origin(glyph)
     }
 
     /// Glyph extents callback.
+    ///
+    /// See "Metrics scaling" in the [trait-level docs](FontFuncs) for details
+    /// on what values this method should return.
     fn extents(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> Option<GlyphExtents> {
         builtin.extents(glyph)
     }
 }
 
-pub struct DummyFontFuncs;
-
-impl FontFuncs for DummyFontFuncs {}
-
 pub(crate) struct FontFuncsDispatch<'a, 'u> {
     builtin: BuiltinFontFuncs<'a>,
-    funcs: &'u mut (dyn FontFuncs + 'u),
-    has_custom_funcs: bool,
+    funcs: Option<&'u mut (dyn FontFuncs + 'u)>,
 }
 
 impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
     pub(crate) fn new(
         face: &'a hb_font_t<'a>,
-        funcs: &'u mut (dyn FontFuncs + 'u),
-        has_custom_funcs: bool,
+        funcs: Option<&'u mut (dyn FontFuncs + 'u)>,
     ) -> Self {
         Self {
             builtin: BuiltinFontFuncs::new(face),
             funcs,
-            has_custom_funcs,
         }
     }
 
@@ -231,7 +247,14 @@ impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
         let cache = self.builtin.face.cmap_cache;
         if let Some(gid) = cache.get(c) {
             Some(gid.into())
-        } else if let Some(gid) = self.funcs.nominal_glyph(&self.builtin, c) {
+        } else if let Some(funcs) = &mut self.funcs {
+            if let Some(gid) = funcs.nominal_glyph(&self.builtin, c) {
+                cache.set(c, gid.to_u32());
+                Some(gid)
+            } else {
+                None
+            }
+        } else if let Some(gid) = self.builtin.nominal_glyph(c) {
             cache.set(c, gid.to_u32());
             Some(gid)
         } else {
@@ -246,39 +269,58 @@ impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
 
     #[inline(always)]
     pub(crate) fn variant_glyph(&mut self, c: u32, vs: u32) -> Option<GlyphId> {
-        self.funcs.variant_glyph(&self.builtin, c, vs)
+        if let Some(funcs) = &mut self.funcs {
+            funcs.variant_glyph(&self.builtin, c, vs)
+        } else {
+            self.builtin.variant_glyph(c, vs)
+        }
     }
 
     #[inline(always)]
     pub(crate) fn advance_width(&mut self, glyph: GlyphId) -> i32 {
-        self.funcs.advance_width(&self.builtin, glyph)
+        if let Some(funcs) = &mut self.funcs {
+            funcs.advance_width(&self.builtin, glyph)
+        } else {
+            self.builtin.advance_width(glyph)
+        }
     }
 
     #[inline(always)]
     pub(crate) fn advance_height(&mut self, glyph: GlyphId) -> i32 {
-        self.funcs.advance_height(&self.builtin, glyph)
+        if let Some(funcs) = &mut self.funcs {
+            funcs.advance_height(&self.builtin, glyph)
+        } else {
+            self.builtin.advance_height(glyph)
+        }
     }
 
     #[inline(always)]
-    pub(crate) fn horizontal_origin(&mut self, glyph: GlyphId) -> i32 {
-        self.advance_width(glyph) / 2
-    }
-
-    #[inline(always)]
-    pub(crate) fn vertical_origin(&mut self, glyph: GlyphId) -> i32 {
-        self.funcs.vertical_origin(&self.builtin, glyph)
+    pub(crate) fn vertical_origin(&mut self, glyph: GlyphId) -> (i32, i32) {
+        if let Some(funcs) = &mut self.funcs {
+            funcs.vertical_origin(&self.builtin, glyph)
+        } else {
+            self.builtin.vertical_origin(glyph)
+        }
     }
 
     #[inline(always)]
     pub(crate) fn extents(&mut self, glyph: GlyphId) -> Option<GlyphExtents> {
-        self.funcs.extents(&self.builtin, glyph)
+        if let Some(funcs) = &mut self.funcs {
+            funcs.extents(&self.builtin, glyph)
+        } else {
+            self.builtin.extents(glyph)
+        }
     }
 
     pub(crate) fn populate_advance_widths(&mut self, batch: AdvanceWidthBatch<'_>) {
-        self.funcs.populate_advance_widths(&self.builtin, batch);
+        if let Some(funcs) = &mut self.funcs {
+            funcs.populate_advance_widths(&self.builtin, batch);
+        } else {
+            self.builtin.populate_advance_widths(batch);
+        }
     }
 
     pub(crate) fn has_custom_funcs(&self) -> bool {
-        self.has_custom_funcs
+        self.funcs.is_some()
     }
 }

--- a/harfrust/src/hb/mod.rs
+++ b/harfrust/src/hb/mod.rs
@@ -28,6 +28,7 @@ mod cache;
 mod charmap;
 pub mod common;
 pub mod face;
+mod font_funcs;
 mod glyph_metrics;
 mod glyph_names;
 mod kerning;

--- a/harfrust/src/hb/ot_layout.rs
+++ b/harfrust/src/hb/ot_layout.rs
@@ -3,6 +3,7 @@
 use core::ops::{Index, IndexMut};
 
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot::lookup::LookupInfo;
 use super::ot_layout_gsubgpos::OT;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
@@ -145,6 +146,7 @@ pub fn hb_ot_layout_substitute_start(face: &hb_font_t, buffer: &mut hb_buffer_t)
 pub fn apply_layout_table<T: LayoutTable>(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
+    font_funcs: &mut FontFuncsDispatch,
     buffer: &mut hb_buffer_t,
     table: Option<&T>,
 ) {
@@ -172,7 +174,7 @@ pub fn apply_layout_table<T: LayoutTable>(
         }
 
         if let Some(func) = stage.pause_func {
-            if func(plan, face, ctx.buffer) {
+            if func(plan, font_funcs, ctx.buffer) {
                 ctx.buffer.update_digest();
             }
         }
@@ -825,7 +827,7 @@ impl GlyphInfo {
 
 pub fn _hb_clear_substitution_flags(
     _: &hb_ot_shape_plan_t,
-    _: &hb_font_t,
+    _: &mut FontFuncsDispatch,
     buffer: &mut hb_buffer_t,
 ) -> bool {
     let len = buffer.len;

--- a/harfrust/src/hb/ot_layout_gpos_table.rs
+++ b/harfrust/src/hb/ot_layout_gpos_table.rs
@@ -1,11 +1,17 @@
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::hb_font_t;
 use super::ot_layout::*;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use crate::Direction;
 
-pub fn position(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
-    apply_layout_table(plan, face, buffer, face.ot_tables.gpos.as_ref());
+pub fn position(
+    plan: &hb_ot_shape_plan_t,
+    face: &hb_font_t,
+    font_funcs: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) {
+    apply_layout_table(plan, face, font_funcs, buffer, face.ot_tables.gpos.as_ref());
 }
 
 pub mod attach_type {

--- a/harfrust/src/hb/ot_layout_gsub_table.rs
+++ b/harfrust/src/hb/ot_layout_gsub_table.rs
@@ -1,8 +1,14 @@
 use super::buffer::hb_buffer_t;
+use super::font_funcs::FontFuncsDispatch;
 use super::hb_font_t;
 use super::ot_layout::*;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 
-pub fn substitute(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
-    apply_layout_table(plan, face, buffer, face.ot_tables.gsub.as_ref());
+pub fn substitute(
+    plan: &hb_ot_shape_plan_t,
+    face: &hb_font_t,
+    font_funcs: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) {
+    apply_layout_table(plan, face, font_funcs, buffer, face.ot_tables.gsub.as_ref());
 }

--- a/harfrust/src/hb/ot_map.rs
+++ b/harfrust/src/hb/ot_map.rs
@@ -4,6 +4,7 @@ use core::ops::Range;
 
 use super::buffer::{glyph_flag, hb_buffer_t};
 use super::common::TagExt;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_layout::TableIndex;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::{hb_font_t, hb_mask_t, hb_tag_t, tag, Language, Script};
@@ -69,7 +70,7 @@ pub struct StageMap {
 
 // Pause functions return true if new glyph indices might have been added to the buffer.
 // This is used to update buffer digest.
-pub type pause_func_t = fn(&hb_ot_shape_plan_t, &hb_font_t, &mut hb_buffer_t) -> bool;
+pub type pause_func_t = fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut hb_buffer_t) -> bool;
 
 impl hb_ot_map_t {
     pub const MAX_BITS: u32 = 8;

--- a/harfrust/src/hb/ot_shape.rs
+++ b/harfrust/src/hb/ot_shape.rs
@@ -335,8 +335,8 @@ impl OtShapeContext<'_, '_> {
             return;
         }
 
-        let batch = AdvanceWidthBatch::new(self.buffer);
-        self.font_funcs.populate_advance_widths(batch);
+        let batched_advances = AdvanceWidthBatch::new(self.buffer);
+        self.font_funcs.populate_advance_widths(batched_advances);
     }
 
     // hb_ot_shape_internal: <https://github.com/harfbuzz/harfbuzz/blob/22ea52f42fa4fc168be91ef4e56aee3affda6e28/src/hb-ot-shape.cc#L1171>
@@ -468,8 +468,9 @@ impl OtShapeContext<'_, '_> {
             {
                 let glyph = info.as_glyph();
                 pos.y_advance = self.font_funcs.advance_height(glyph);
-                pos.x_offset -= self.font_funcs.horizontal_origin(glyph);
-                pos.y_offset -= self.font_funcs.vertical_origin(glyph);
+                let (x, y) = self.font_funcs.vertical_origin(glyph);
+                pos.x_offset -= x;
+                pos.y_offset -= y;
             }
         }
 

--- a/harfrust/src/hb/ot_shape.rs
+++ b/harfrust/src/hb/ot_shape.rs
@@ -1,5 +1,6 @@
 use super::aat::map::*;
 use super::buffer::*;
+use super::font_funcs::{AdvanceWidthBatch, FontFuncsDispatch};
 use super::ot_layout::*;
 use super::ot_layout_gpos_table::GPOS;
 use super::ot_map::*;
@@ -102,7 +103,6 @@ impl<'a> hb_ot_shape_planner_t<'a> {
         ];
 
         let empty = F_NONE;
-
         self.ot_map.is_simple = true;
 
         self.ot_map.enable_feature(hb_tag_t::new(b"rvrn"), empty, 1);
@@ -313,7 +313,7 @@ impl<'a> hb_ot_shape_planner_t<'a> {
 }
 
 // hb_ot_shape_context_t: <https://github.com/harfbuzz/harfbuzz/blob/22ea52f42fa4fc168be91ef4e56aee3affda6e28/src/hb-ot-shape.cc#L450>
-pub(crate) struct OtShapeContext<'a> {
+pub(crate) struct OtShapeContext<'a, 'u> {
     pub plan: &'a hb_ot_shape_plan_t,
     pub face: &'a hb_font_t<'a>,
     pub buffer: &'a mut hb_buffer_t,
@@ -321,9 +321,24 @@ pub(crate) struct OtShapeContext<'a> {
     // Transient stuff
     pub target_direction: Direction,
     pub point_size: Option<f32>,
+    pub font_funcs: &'a mut FontFuncsDispatch<'a, 'u>,
 }
 
-impl OtShapeContext<'_> {
+impl OtShapeContext<'_, '_> {
+    fn glyph_h_advances(&mut self) {
+        if self.buffer.len == 0 {
+            return;
+        }
+
+        if !self.font_funcs.has_custom_funcs() {
+            self.face.glyph_h_advances(self.buffer);
+            return;
+        }
+
+        let batch = AdvanceWidthBatch::new(self.buffer);
+        self.font_funcs.populate_advance_widths(batch);
+    }
+
     // hb_ot_shape_internal: <https://github.com/harfbuzz/harfbuzz/blob/22ea52f42fa4fc168be91ef4e56aee3affda6e28/src/hb-ot-shape.cc#L1171>
     pub(crate) fn shape_internal(&mut self) {
         self.buffer.allocate_unicode_vars();
@@ -337,7 +352,7 @@ impl OtShapeContext<'_> {
         ensure_native_direction(self.buffer);
 
         if let Some(func) = self.plan.shaper.preprocess_text {
-            func(self.plan, self.face, self.buffer);
+            func(self.plan, self.font_funcs, self.buffer);
         }
 
         self.substitute_pre();
@@ -371,10 +386,10 @@ impl OtShapeContext<'_> {
         }
 
         deal_with_variation_selectors(self.buffer);
-        hide_default_ignorables(self.buffer, self.face);
+        hide_default_ignorables(self.buffer, self.font_funcs);
 
         if let Some(func) = self.plan.shaper.postprocess_glyphs {
-            func(self.plan, self.face, self.buffer);
+            func(self.plan, self.font_funcs, self.buffer);
         }
     }
 
@@ -385,7 +400,12 @@ impl OtShapeContext<'_> {
         self.buffer
             .allocate_var(GlyphInfo::NORMALIZER_GLYPH_INDEX_VAR);
 
-        ot_shape_normalize::_hb_ot_shape_normalize(self.plan, self.buffer, self.face);
+        ot_shape_normalize::_hb_ot_shape_normalize(
+            self.plan,
+            self.buffer,
+            self.face,
+            self.font_funcs,
+        );
 
         self.setup_masks();
 
@@ -417,7 +437,7 @@ impl OtShapeContext<'_> {
             self.buffer.update_digest();
         } else {
             self.buffer.update_digest();
-            ot_layout_gsub_table::substitute(self.plan, self.face, self.buffer);
+            ot_layout_gsub_table::substitute(self.plan, self.face, self.font_funcs, self.buffer);
         }
     }
 
@@ -440,21 +460,26 @@ impl OtShapeContext<'_> {
         let len = self.buffer.len;
 
         if self.buffer.direction.is_horizontal() {
-            self.face.glyph_h_advances(self.buffer);
+            self.glyph_h_advances();
         } else {
             for (info, pos) in self.buffer.info[..len]
                 .iter()
                 .zip(&mut self.buffer.pos[..len])
             {
                 let glyph = info.as_glyph();
-                pos.y_advance = self.face.glyph_v_advance(glyph);
-                pos.x_offset -= self.face.glyph_h_origin(glyph);
-                pos.y_offset -= self.face.glyph_v_origin(glyph);
+                pos.y_advance = self.font_funcs.advance_height(glyph);
+                pos.x_offset -= self.font_funcs.horizontal_origin(glyph);
+                pos.y_offset -= self.font_funcs.vertical_origin(glyph);
             }
         }
 
         if self.buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_SPACE_FALLBACK != 0 {
-            ot_shape_fallback::_hb_ot_shape_fallback_spaces(self.plan, self.face, self.buffer);
+            ot_shape_fallback::_hb_ot_shape_fallback_spaces(
+                self.plan,
+                self.face,
+                self.buffer,
+                self.font_funcs,
+            );
         }
     }
 
@@ -500,6 +525,7 @@ impl OtShapeContext<'_> {
                 self.face,
                 self.buffer,
                 adjust_offsets_when_zeroing,
+                self.font_funcs,
             );
         }
     }
@@ -510,7 +536,7 @@ impl OtShapeContext<'_> {
         let face = self.face;
         let buffer = &mut *self.buffer;
         if plan.apply_gpos {
-            ot_layout_gpos_table::position(plan, face, buffer);
+            ot_layout_gpos_table::position(plan, face, self.font_funcs, buffer);
         } else if plan.apply_kerx {
             aat::layout::position(plan, face, buffer);
         }
@@ -536,7 +562,7 @@ impl OtShapeContext<'_> {
         self.setup_masks_fraction();
 
         if let Some(func) = self.plan.shaper.setup_masks {
-            func(self.plan, self.face, self.buffer);
+            func(self.plan, self.font_funcs, self.buffer);
         }
 
         for feature in self.features {
@@ -712,19 +738,24 @@ impl OtShapeContext<'_> {
 
     // hb_insert_dotted_circle: <https://github.com/harfbuzz/harfbuzz/blob/22ea52f42fa4fc168be91ef4e56aee3affda6e28/src/hb-ot-shape.cc#L549>
     fn insert_dotted_circle(&mut self) {
-        let buffer = &mut *self.buffer;
-        if !buffer
-            .flags
-            .contains(BufferFlags::DO_NOT_INSERT_DOTTED_CIRCLE)
-            && buffer.flags.contains(BufferFlags::BEGINNING_OF_TEXT)
-            && buffer.context_len[0] == 0
-            && buffer.info[0].is_unicode_mark()
-            && self.face.has_glyph(0x25CC)
-        {
+        let should_insert = {
+            let buffer = &*self.buffer;
+            !buffer
+                .flags
+                .contains(BufferFlags::DO_NOT_INSERT_DOTTED_CIRCLE)
+                && buffer.flags.contains(BufferFlags::BEGINNING_OF_TEXT)
+                && buffer.context_len[0] == 0
+                && buffer.info[0].is_unicode_mark()
+        };
+
+        if should_insert && self.font_funcs.nominal_glyph(0x25CC).is_some() {
+            let mask = self.buffer.cur(0).mask;
+            let cluster = self.buffer.cur(0).cluster;
+            let buffer = &mut *self.buffer;
             let mut info = GlyphInfo {
                 glyph_id: 0x25CC,
-                mask: buffer.cur(0).mask,
-                cluster: buffer.cur(0).cluster,
+                mask,
+                cluster,
                 ..GlyphInfo::default()
             };
 
@@ -744,7 +775,7 @@ impl OtShapeContext<'_> {
 
             for info in &mut self.buffer.info[..len] {
                 if let Some(c) = info.as_codepoint().mirrored() {
-                    if self.face.has_glyph(c) {
+                    if self.font_funcs.nominal_glyph(c).is_some() {
                         info.glyph_id = c;
                         continue;
                     }
@@ -756,7 +787,7 @@ impl OtShapeContext<'_> {
         if self.target_direction.is_vertical() && !self.plan.has_vert {
             for info in &mut self.buffer.info[..len] {
                 if let Some(c) = info.as_codepoint().vertical() {
-                    if self.face.has_glyph(c) {
+                    if self.font_funcs.nominal_glyph(c).is_some() {
                         info.glyph_id = c;
                     }
                 }
@@ -930,7 +961,7 @@ fn zero_mark_widths_by_gdef(buffer: &mut hb_buffer_t, adjust_offsets: bool) {
     }
 }
 
-fn hide_default_ignorables(buffer: &mut hb_buffer_t, face: &hb_font_t) {
+fn hide_default_ignorables(buffer: &mut hb_buffer_t, font_funcs: &mut FontFuncsDispatch<'_, '_>) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_DEFAULT_IGNORABLES != 0
         && !buffer
             .flags
@@ -942,7 +973,7 @@ fn hide_default_ignorables(buffer: &mut hb_buffer_t, face: &hb_font_t) {
         {
             if let Some(invisible) = buffer
                 .invisible
-                .or_else(|| face.get_nominal_glyph(u32::from(' ')))
+                .or_else(|| font_funcs.nominal_glyph(u32::from(' ')))
             {
                 let len = buffer.len;
                 for info in &mut buffer.info[..len] {

--- a/harfrust/src/hb/ot_shape_fallback.rs
+++ b/harfrust/src/hb/ot_shape_fallback.rs
@@ -1,10 +1,19 @@
 use read_fonts::types::GlyphId;
 
 use super::buffer::{hb_buffer_t, GlyphPosition};
-use super::face::hb_glyph_extents_t;
+use super::face::GlyphExtents;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::unicode::*;
 use super::{hb_font_t, Direction};
+
+struct FallbackShapeContext<'a, 'x, 'u> {
+    plan: &'a hb_ot_shape_plan_t,
+    face: &'a hb_font_t<'a>,
+    buffer: &'x mut hb_buffer_t,
+    adjust_offsets_when_zeroing: bool,
+    font_funcs: &'x mut FontFuncsDispatch<'a, 'u>,
+}
 
 fn recategorize_combining_class(u: u32, mut class: u8) -> u8 {
     use modified_combining_class as mcc;
@@ -123,18 +132,17 @@ fn zero_mark_advances(
 }
 
 fn position_mark(
-    _: &hb_ot_shape_plan_t,
     face: &hb_font_t,
     direction: Direction,
+    font_funcs: &mut FontFuncsDispatch<'_, '_>,
     glyph: GlyphId,
     pos: &mut GlyphPosition,
-    base_extents: &mut hb_glyph_extents_t,
+    base_extents: &mut GlyphExtents,
     combining_class: u8,
 ) {
-    let mut mark_extents = hb_glyph_extents_t::default();
-    if !face.glyph_extents(glyph, &mut mark_extents) {
+    let Some(mark_extents) = font_funcs.extents(glyph) else {
         return;
-    }
+    };
 
     let y_gap = face.units_per_em as i32 / 16;
     pos.x_offset = 0;
@@ -246,26 +254,19 @@ fn position_mark(
     }
 }
 
-fn position_around_base(
-    plan: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
-    base: usize,
-    end: usize,
-    adjust_offsets_when_zeroing: bool,
-) {
+fn position_around_base(ctx: &mut FallbackShapeContext, base: usize, end: usize) {
     let mut horizontal_dir = Direction::Invalid;
-    buffer.unsafe_to_break(Some(base), Some(end));
+    let face = ctx.face;
+    ctx.buffer.unsafe_to_break(Some(base), Some(end));
 
-    let base_info = &buffer.info[base];
-    let base_pos = &buffer.pos[base];
+    let base_info = ctx.buffer.info[base];
+    let base_pos = ctx.buffer.pos[base];
     let base_glyph = base_info.as_glyph();
 
-    let mut base_extents = hb_glyph_extents_t::default();
-    if !face.glyph_extents(base_glyph, &mut base_extents) {
-        zero_mark_advances(buffer, base + 1, end, adjust_offsets_when_zeroing);
+    let Some(mut base_extents) = ctx.font_funcs.extents(base_glyph) else {
+        zero_mark_advances(ctx.buffer, base + 1, end, ctx.adjust_offsets_when_zeroing);
         return;
-    }
+    };
 
     base_extents.y_bearing += base_pos.y_offset;
     base_extents.x_bearing = 0;
@@ -273,14 +274,14 @@ fn position_around_base(
     // Use horizontal advance for horizontal positioning.
     // Generally a better idea. Also works for zero-ink glyphs. See:
     // https://github.com/harfbuzz/harfbuzz/issues/1532
-    base_extents.width = face.glyph_h_advance(base_glyph);
+    base_extents.width = ctx.font_funcs.advance_width(base_glyph);
 
     let lig_id = base_info.lig_id() as u32;
     let num_lig_components = base_info.lig_num_comps() as i32;
 
     let mut x_offset = 0;
     let mut y_offset = 0;
-    if buffer.direction.is_forward() {
+    if ctx.buffer.direction.is_forward() {
         x_offset -= base_pos.x_advance;
         y_offset -= base_pos.y_advance;
     }
@@ -289,10 +290,12 @@ fn position_around_base(
     let mut last_combining_class: u8 = 255;
     let mut component_extents = base_extents;
     let mut cluster_extents = base_extents;
+    let direction = ctx.buffer.direction;
+    let font_funcs = &mut *ctx.font_funcs;
 
-    for (info, pos) in buffer.info[base + 1..end]
+    for (info, pos) in ctx.buffer.info[base + 1..end]
         .iter()
-        .zip(&mut buffer.pos[base + 1..end])
+        .zip(&mut ctx.buffer.pos[base + 1..end])
     {
         if info.modified_combining_class() != 0 {
             if num_lig_components > 1 {
@@ -311,10 +314,11 @@ fn position_around_base(
                     component_extents = base_extents;
 
                     if horizontal_dir == Direction::Invalid {
-                        horizontal_dir = if plan.direction.is_horizontal() {
-                            plan.direction
+                        horizontal_dir = if ctx.plan.direction.is_horizontal() {
+                            ctx.plan.direction
                         } else {
-                            plan.script
+                            ctx.plan
+                                .script
                                 .and_then(Direction::from_script)
                                 .unwrap_or(Direction::LeftToRight)
                         };
@@ -338,9 +342,9 @@ fn position_around_base(
             }
 
             position_mark(
-                plan,
                 face,
-                buffer.direction,
+                direction,
+                font_funcs,
                 info.as_glyph(),
                 pos,
                 &mut cluster_extents,
@@ -352,7 +356,7 @@ fn position_around_base(
             pos.x_offset += x_offset;
             pos.y_offset += y_offset;
         } else {
-            if buffer.direction.is_forward() {
+            if direction.is_forward() {
                 x_offset -= pos.x_advance;
                 y_offset -= pos.y_advance;
             } else {
@@ -363,29 +367,22 @@ fn position_around_base(
     }
 }
 
-fn position_cluster_impl(
-    plan: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
-    start: usize,
-    end: usize,
-    adjust_offsets_when_zeroing: bool,
-) {
+fn position_cluster_impl(ctx: &mut FallbackShapeContext, start: usize, end: usize) {
     // Find the base glyph
     let mut i = start;
     while i < end {
-        if !buffer.info[i].is_unicode_mark() {
+        if !ctx.buffer.info[i].is_unicode_mark() {
             // Find mark glyphs
             let mut j = i + 1;
             while j < end
-                && (buffer.info[j].is_hidden()
-                    || buffer.info[j].is_default_ignorable()
-                    || buffer.info[j].is_unicode_mark())
+                && (ctx.buffer.info[j].is_hidden()
+                    || ctx.buffer.info[j].is_default_ignorable()
+                    || ctx.buffer.info[j].is_unicode_mark())
             {
                 j += 1;
             }
 
-            position_around_base(plan, face, buffer, i, j, adjust_offsets_when_zeroing);
+            position_around_base(ctx, i, j);
             i = j - 1;
         }
         i += 1;
@@ -393,55 +390,59 @@ fn position_cluster_impl(
 }
 
 #[inline(always)]
-fn position_cluster(
-    plan: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
-    start: usize,
-    end: usize,
-    adjust_offsets_when_zeroing: bool,
-) {
+fn position_cluster(ctx: &mut FallbackShapeContext, start: usize, end: usize) {
     if end - start < 2 {
         return;
     }
 
-    position_cluster_impl(plan, face, buffer, start, end, adjust_offsets_when_zeroing);
+    position_cluster_impl(ctx, start, end);
 }
 
-pub fn position_marks(
-    plan: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+pub fn position_marks<'a, 'x>(
+    plan: &'a hb_ot_shape_plan_t,
+    face: &'a hb_font_t<'a>,
+    buffer: &'x mut hb_buffer_t,
     adjust_offsets_when_zeroing: bool,
+    font_funcs: &'x mut FontFuncsDispatch<'a, '_>,
 ) {
-    buffer.assert_gsubgpos_vars();
+    let mut ctx = FallbackShapeContext {
+        plan,
+        face,
+        buffer,
+        adjust_offsets_when_zeroing,
+        font_funcs,
+    };
+
+    ctx.buffer.assert_gsubgpos_vars();
 
     let mut start = 0;
-    let len = buffer.len;
+    let len = ctx.buffer.len;
     for i in 1..len {
-        if !buffer.info[i].is_unicode_mark()
-            && !buffer.info[i].is_hidden()
-            && !buffer.info[i].is_default_ignorable()
+        if !ctx.buffer.info[i].is_unicode_mark()
+            && !ctx.buffer.info[i].is_hidden()
+            && !ctx.buffer.info[i].is_default_ignorable()
         {
-            position_cluster(plan, face, buffer, start, i, adjust_offsets_when_zeroing);
+            position_cluster(&mut ctx, start, i);
             start = i;
         }
     }
 
-    position_cluster(plan, face, buffer, start, len, adjust_offsets_when_zeroing);
+    position_cluster(&mut ctx, start, len);
 }
 
 pub fn _hb_ot_shape_fallback_kern(_: &hb_ot_shape_plan_t, _: &hb_font_t, _: &mut hb_buffer_t) {
     // STUB: this is deprecated in HarfBuzz
 }
 
-pub fn _hb_ot_shape_fallback_spaces(
-    _: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+pub fn _hb_ot_shape_fallback_spaces<'a, 'x>(
+    plan: &'a hb_ot_shape_plan_t,
+    face: &'a hb_font_t<'a>,
+    buffer: &'x mut hb_buffer_t,
+    font_funcs: &'x mut FontFuncsDispatch<'a, '_>,
 ) {
     use super::unicode::hb_unicode_funcs_t as t;
 
+    let _ = plan;
     let len = buffer.len;
     let horizontal = buffer.direction.is_horizontal();
     for (info, pos) in buffer.info[..len].iter().zip(&mut buffer.pos[..len]) {
@@ -475,11 +476,11 @@ pub fn _hb_ot_shape_fallback_spaces(
 
                 t::SPACE_FIGURE => {
                     for u in '0'..='9' {
-                        if let Some(glyph) = face.get_nominal_glyph(u as u32) {
+                        if let Some(glyph) = font_funcs.nominal_glyph(u as u32) {
                             if horizontal {
-                                pos.x_advance = face.glyph_h_advance(glyph);
+                                pos.x_advance = font_funcs.advance_width(glyph);
                             } else {
-                                pos.y_advance = face.glyph_v_advance(glyph);
+                                pos.y_advance = font_funcs.advance_height(glyph);
                             }
                             break;
                         }
@@ -487,15 +488,15 @@ pub fn _hb_ot_shape_fallback_spaces(
                 }
 
                 t::SPACE_PUNCTUATION => {
-                    let punct = face
-                        .get_nominal_glyph('.' as u32)
-                        .or_else(|| face.get_nominal_glyph(',' as u32));
+                    let punct = font_funcs
+                        .nominal_glyph('.' as u32)
+                        .or_else(|| font_funcs.nominal_glyph(',' as u32));
 
                     if let Some(glyph) = punct {
                         if horizontal {
-                            pos.x_advance = face.glyph_h_advance(glyph);
+                            pos.x_advance = font_funcs.advance_width(glyph);
                         } else {
-                            pos.y_advance = face.glyph_v_advance(glyph);
+                            pos.y_advance = font_funcs.advance_height(glyph);
                         }
                     }
                 }

--- a/harfrust/src/hb/ot_shape_normalize.rs
+++ b/harfrust/src/hb/ot_shape_normalize.rs
@@ -1,10 +1,12 @@
 use crate::hb::unicode::Codepoint;
 
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::hb_font_t;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::{ComposeFn, DecomposeFn, MAX_COMBINING_MARKS};
 use super::unicode::{hb_unicode_funcs_t, CharExt};
+use read_fonts::types::GlyphId;
 
 impl GlyphInfo {
     declare_buffer_var!(
@@ -17,12 +19,29 @@ impl GlyphInfo {
     );
 }
 
-pub struct hb_ot_shape_normalize_context_t<'a> {
+pub struct hb_ot_shape_normalize_context_t<'a, 'x, 'u> {
     pub plan: &'a hb_ot_shape_plan_t,
-    pub buffer: &'a mut hb_buffer_t,
-    pub face: &'a hb_font_t<'a>,
+    pub buffer: &'x mut hb_buffer_t,
+    pub font_funcs: &'x mut FontFuncsDispatch<'a, 'u>,
     pub decompose: DecomposeFn,
     pub compose: ComposeFn,
+}
+
+impl hb_ot_shape_normalize_context_t<'_, '_, '_> {
+    fn nominal_glyph(&mut self, codepoint: u32) -> Option<GlyphId> {
+        self.font_funcs.nominal_glyph(codepoint)
+    }
+
+    fn variant_glyph(&mut self, codepoint: u32, selector: u32) -> Option<GlyphId> {
+        self.font_funcs.variant_glyph(codepoint, selector)
+    }
+
+    fn set_current_glyph(&mut self) {
+        let info = self.buffer.cur_mut(0);
+        if let Some(glyph_id) = self.font_funcs.nominal_glyph(info.glyph_id) {
+            info.set_normalizer_glyph_index(u32::from(glyph_id));
+        }
+    }
 }
 
 pub type hb_ot_shape_normalization_mode_t = i32;
@@ -88,12 +107,6 @@ fn compose_unicode(
     super::unicode::compose(a, b)
 }
 
-fn set_glyph(info: &mut GlyphInfo, font: &hb_font_t) {
-    if let Some(glyph_id) = font.get_nominal_glyph(info.glyph_id) {
-        info.set_normalizer_glyph_index(u32::from(glyph_id));
-    }
-}
-
 fn output_char(buffer: &mut hb_buffer_t, unichar: u32, glyph: u32) {
     // This is very confusing indeed.
     buffer.cur_mut(0).set_normalizer_glyph_index(glyph);
@@ -119,9 +132,9 @@ fn decompose(ctx: &mut hb_ot_shape_normalize_context_t, shortest: bool, ab: Code
         return 0;
     };
 
-    let a_glyph = ctx.face.get_nominal_glyph(a);
+    let a_glyph = ctx.nominal_glyph(a);
     let b_glyph = if b != 0 {
-        match ctx.face.get_nominal_glyph(b) {
+        match ctx.nominal_glyph(b) {
             Some(glyph_id) => Some(glyph_id),
             None => return 0,
         }
@@ -164,7 +177,7 @@ fn decompose(ctx: &mut hb_ot_shape_normalize_context_t, shortest: bool, ab: Code
 
 fn decompose_current_character(ctx: &mut hb_ot_shape_normalize_context_t, shortest: bool) {
     let u = ctx.buffer.cur(0).as_codepoint();
-    let glyph = ctx.face.get_nominal_glyph(u);
+    let glyph = ctx.nominal_glyph(u);
 
     if let Some(glyph) = glyph {
         if shortest {
@@ -186,7 +199,7 @@ fn decompose_current_character(ctx: &mut hb_ot_shape_normalize_context_t, shorte
     if ctx.buffer.cur(0).is_unicode_space() {
         let space_type = u.space_fallback();
         if space_type != hb_unicode_funcs_t::NOT_SPACE {
-            let space_glyph = ctx.face.get_nominal_glyph(0x0020).or(ctx.buffer.invisible);
+            let space_glyph = ctx.nominal_glyph(0x0020).or(ctx.buffer.invisible);
 
             if let Some(space_glyph) = space_glyph {
                 ctx.buffer
@@ -202,7 +215,7 @@ fn decompose_current_character(ctx: &mut hb_ot_shape_normalize_context_t, shorte
     // U+2011 is the only sensible character that is a no-break version of another character
     // and not a space.  The space ones are handled already.  Handle this lone one.
     if u == 0x2011 {
-        if let Some(other_glyph) = ctx.face.get_nominal_glyph(0x2010) {
+        if let Some(other_glyph) = ctx.nominal_glyph(0x2010) {
             next_char(ctx.buffer, u32::from(other_glyph));
             return;
         }
@@ -217,51 +230,47 @@ fn handle_variation_selector_cluster(
     end: usize,
     _: bool,
 ) {
-    let face = ctx.face;
-
     // Currently if there's a variation-selector we give-up on normalization, it's just too hard.
-    let buffer = &mut *ctx.buffer;
-    while buffer.idx < end - 1 && buffer.successful {
-        if buffer.cur(1).as_codepoint().is_variation_selector() {
-            if let Some(glyph_id) = face.get_nominal_variant_glyph(
-                buffer.cur(0).as_codepoint(),
-                buffer.cur(1).as_codepoint(),
-            ) {
-                buffer
+    while ctx.buffer.idx < end - 1 && ctx.buffer.successful {
+        if ctx.buffer.cur(1).as_codepoint().is_variation_selector() {
+            let base = ctx.buffer.cur(0).as_codepoint();
+            let selector = ctx.buffer.cur(1).as_codepoint();
+            if let Some(glyph_id) = ctx.variant_glyph(base, selector) {
+                ctx.buffer
                     .cur_mut(0)
                     .set_normalizer_glyph_index(u32::from(glyph_id));
-                let unicode = buffer.cur(0).glyph_id;
-                buffer.replace_glyphs(2, 1, &[unicode]);
+                let unicode = ctx.buffer.cur(0).glyph_id;
+                ctx.buffer.replace_glyphs(2, 1, &[unicode]);
             } else {
                 // Just pass on the two characters separately, let GSUB do its magic.
-                set_glyph(buffer.cur_mut(0), face);
-                buffer.next_glyph();
+                ctx.set_current_glyph();
+                ctx.buffer.next_glyph();
 
-                buffer.scratch_flags |= HB_BUFFER_SCRATCH_FLAG_HAS_VARIATION_SELECTOR_FALLBACK;
+                ctx.buffer.scratch_flags |= HB_BUFFER_SCRATCH_FLAG_HAS_VARIATION_SELECTOR_FALLBACK;
 
-                buffer.cur_mut(0).set_variation_selector(true);
+                ctx.buffer.cur_mut(0).set_variation_selector(true);
 
-                if buffer.not_found_variation_selector.is_some() {
-                    buffer.cur_mut(0).clear_default_ignorable();
+                if ctx.buffer.not_found_variation_selector.is_some() {
+                    ctx.buffer.cur_mut(0).clear_default_ignorable();
                 }
 
-                set_glyph(buffer.cur_mut(0), face);
-                buffer.next_glyph();
+                ctx.set_current_glyph();
+                ctx.buffer.next_glyph();
             }
 
             // Skip any further variation selectors.
-            while buffer.idx < end && buffer.cur(0).as_codepoint().is_variation_selector() {
-                set_glyph(buffer.cur_mut(0), face);
-                buffer.next_glyph();
+            while ctx.buffer.idx < end && ctx.buffer.cur(0).as_codepoint().is_variation_selector() {
+                ctx.set_current_glyph();
+                ctx.buffer.next_glyph();
             }
         } else {
-            set_glyph(buffer.cur_mut(0), face);
-            buffer.next_glyph();
+            ctx.set_current_glyph();
+            ctx.buffer.next_glyph();
         }
     }
 
     if ctx.buffer.idx < end {
-        set_glyph(ctx.buffer.cur_mut(0), face);
+        ctx.set_current_glyph();
         ctx.buffer.next_glyph();
     }
 }
@@ -291,10 +300,11 @@ fn compare_combining_class(pa: &GlyphInfo, pb: &GlyphInfo) -> bool {
     a > b
 }
 
-pub fn _hb_ot_shape_normalize(
-    plan: &hb_ot_shape_plan_t,
-    buffer: &mut hb_buffer_t,
-    face: &hb_font_t,
+pub fn _hb_ot_shape_normalize<'a, 'x>(
+    plan: &'a hb_ot_shape_plan_t,
+    buffer: &'x mut hb_buffer_t,
+    _face: &'a hb_font_t<'a>,
+    font_funcs: &'x mut FontFuncsDispatch<'a, '_>,
 ) {
     if buffer.is_empty() {
         return;
@@ -316,7 +326,7 @@ pub fn _hb_ot_shape_normalize(
     let mut ctx = hb_ot_shape_normalize_context_t {
         plan,
         buffer,
-        face,
+        font_funcs,
         decompose: plan.shaper.decompose.unwrap_or(decompose_unicode),
         compose: plan.shaper.compose.unwrap_or(compose_unicode),
     };
@@ -354,11 +364,13 @@ pub fn _hb_ot_shape_normalize(
                 let len = end - ctx.buffer.idx;
                 let mut done = 0;
                 while done < len {
-                    let cur = ctx.buffer.cur_mut(done);
-                    cur.set_normalizer_glyph_index(match face.get_nominal_glyph(cur.glyph_id) {
+                    let codepoint = ctx.buffer.cur(done).glyph_id;
+                    let glyph_id = match ctx.nominal_glyph(codepoint) {
                         Some(glyph_id) => u32::from(glyph_id),
                         None => break,
-                    });
+                    };
+                    let cur = ctx.buffer.cur_mut(done);
+                    cur.set_normalizer_glyph_index(glyph_id);
                     done += 1;
                 }
                 ctx.buffer.next_glyphs(done);
@@ -463,7 +475,7 @@ pub fn _hb_ot_shape_normalize(
                 let a = ctx.buffer.out_info()[starter].as_codepoint();
                 let b = cur.as_codepoint();
                 if let Some(composed) = (ctx.compose)(&ctx, a, b) {
-                    if let Some(glyph_id) = face.get_nominal_glyph(composed) {
+                    if let Some(glyph_id) = ctx.nominal_glyph(composed) {
                         // Copy to out-ctx.buffer.
                         ctx.buffer.next_glyph();
                         if !ctx.buffer.successful {

--- a/harfrust/src/hb/ot_shaper.rs
+++ b/harfrust/src/hb/ot_shaper.rs
@@ -1,14 +1,13 @@
-use alloc::boxed::Box;
-use core::any::Any;
-
-use crate::hb::unicode::Codepoint;
-
 use super::buffer::*;
 use super::common::TagExt;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_shape::*;
 use super::ot_shape_normalize::*;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
-use super::{hb_font_t, hb_tag_t, script, Direction, Script};
+use super::unicode::Codepoint;
+use super::{hb_tag_t, script, Direction, Script};
+use alloc::boxed::Box;
+use core::any::Any;
 
 impl GlyphInfo {
     declare_buffer_var!(
@@ -73,11 +72,12 @@ pub struct hb_ot_shaper_t {
 
     /// Called during `shape()`.
     /// Shapers can use to modify text before shaping starts.
-    pub preprocess_text: Option<fn(&hb_ot_shape_plan_t, &hb_font_t, &mut hb_buffer_t)>,
+    pub preprocess_text: Option<fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut hb_buffer_t)>,
 
     /// Called during `shape()`.
     /// Shapers can use to modify text before shaping starts.
-    pub postprocess_glyphs: Option<fn(&hb_ot_shape_plan_t, &hb_font_t, &mut hb_buffer_t)>,
+    pub postprocess_glyphs:
+        Option<fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut hb_buffer_t)>,
 
     /// How to normalize.
     pub normalization_preference: hb_ot_shape_normalization_mode_t,
@@ -91,7 +91,7 @@ pub struct hb_ot_shaper_t {
     /// Called during `shape()`.
     /// Shapers should use map to get feature masks and set on buffer.
     /// Shapers may NOT modify characters.
-    pub setup_masks: Option<fn(&hb_ot_shape_plan_t, &hb_font_t, &mut hb_buffer_t)>,
+    pub setup_masks: Option<fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut hb_buffer_t)>,
 
     /// If not `None`, then must match found GPOS script tag for
     /// GPOS to be applied.  Otherwise, fallback positioning will be used.

--- a/harfrust/src/hb/ot_shaper_arabic.rs
+++ b/harfrust/src/hb/ot_shaper_arabic.rs
@@ -1,15 +1,15 @@
-use crate::Direction;
-use alloc::boxed::Box;
-
 use super::algs::*;
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_map::*;
 use super::ot_shape::*;
 use super::ot_shape_normalize::HB_OT_SHAPE_NORMALIZATION_MODE_AUTO;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::*;
 use super::unicode::*;
-use super::{hb_font_t, hb_mask_t, hb_tag_t, script, GlyphInfo, Script};
+use super::{hb_mask_t, hb_tag_t, script, GlyphInfo, Script};
+use crate::Direction;
+use alloc::boxed::Box;
 
 const HB_BUFFER_SCRATCH_FLAG_ARABIC_HAS_STCH: hb_buffer_scratch_flags_t =
     HB_BUFFER_SCRATCH_FLAG_SHAPER0;
@@ -179,7 +179,11 @@ impl GlyphInfo {
     );
 }
 
-fn deallocate_buffer_var(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn deallocate_buffer_var(
+    _: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     buffer.deallocate_var(GlyphInfo::ARABIC_SHAPING_ACTION_VAR);
 
     false
@@ -387,7 +391,11 @@ fn mongolian_variation_selectors(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn setup_masks_arabic_plan(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks_arabic_plan(
+    plan: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) {
     buffer.allocate_var(GlyphInfo::ARABIC_SHAPING_ACTION_VAR);
 
     let arabic_plan = plan.data::<arabic_shape_plan_t>();
@@ -409,7 +417,11 @@ pub fn setup_masks_inner(
     }
 }
 
-fn arabic_fallback_shape(_: &hb_ot_shape_plan_t, _: &hb_font_t, _: &mut hb_buffer_t) -> bool {
+fn arabic_fallback_shape(
+    _: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    _: &mut hb_buffer_t,
+) -> bool {
     false
 }
 
@@ -418,7 +430,11 @@ fn arabic_fallback_shape(_: &hb_ot_shape_plan_t, _: &hb_font_t, _: &mut hb_buffe
 // https://docs.microsoft.com/en-us/typography/script-development/syriac
 // We implement this in a generic way, such that the Arabic subtending
 // marks can use it as well.
-fn record_stch(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn record_stch(
+    plan: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     let arabic_plan = plan.data::<arabic_shape_plan_t>();
     if !arabic_plan.has_stch {
         return false;
@@ -452,7 +468,7 @@ fn record_stch(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_
     false
 }
 
-fn apply_stch(face: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_ARABIC_HAS_STCH == 0 {
         return;
     }
@@ -498,7 +514,7 @@ fn apply_stch(face: &hb_font_t, buffer: &mut hb_buffer_t) {
             let end = i;
             while i != 0 && arabic_action_t::is_stch(buffer.info[i - 1].arabic_shaping_action()) {
                 i -= 1;
-                let width = face.glyph_h_advance(buffer.info[i].as_glyph());
+                let width = face.advance_width(buffer.info[i].as_glyph());
 
                 if buffer.info[i].arabic_shaping_action() == arabic_action_t::STRETCHING_FIXED {
                     w_fixed += width;
@@ -547,7 +563,7 @@ fn apply_stch(face: &hb_font_t, buffer: &mut hb_buffer_t) {
                 buffer.unsafe_to_break(Some(context), Some(end));
                 let mut x_offset = w_remaining / 2;
                 for k in (start + 1..=end).rev() {
-                    let width = face.glyph_h_advance(buffer.info[k - 1].as_glyph());
+                    let width = face.advance_width(buffer.info[k - 1].as_glyph());
 
                     let mut repeat = 1;
                     if buffer.info[k - 1].arabic_shaping_action()
@@ -602,7 +618,11 @@ fn apply_stch(face: &hb_font_t, buffer: &mut hb_buffer_t) {
     }
 }
 
-fn postprocess_glyphs_arabic(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn postprocess_glyphs_arabic(
+    _: &hb_ot_shape_plan_t,
+    face: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) {
     apply_stch(face, buffer);
 }
 

--- a/harfrust/src/hb/ot_shaper_hangul.rs
+++ b/harfrust/src/hb/ot_shaper_hangul.rs
@@ -1,6 +1,7 @@
 use alloc::boxed::Box;
 
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_map::*;
 use super::ot_shape::*;
 use super::ot_shape_normalize::HB_OT_SHAPE_NORMALIZATION_MODE_NONE;
@@ -100,15 +101,19 @@ fn is_hangul_tone(u: u32) -> bool {
     (0x302E..=0x302F).contains(&u)
 }
 
-fn is_zero_width_char(face: &hb_font_t, c: Codepoint) -> bool {
-    if let Some(glyph) = face.get_nominal_glyph(c) {
-        face.glyph_h_advance(glyph) == 0
+fn is_zero_width_char(face: &mut FontFuncsDispatch, c: Codepoint) -> bool {
+    if let Some(glyph) = face.nominal_glyph(c) {
+        face.advance_width(glyph) == 0
     } else {
         false
     }
 }
 
-fn preprocess_text_hangul(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn preprocess_text_hangul(
+    _: &hb_ot_shape_plan_t,
+    face: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) {
     buffer.allocate_var(GlyphInfo::HANGUL_SHAPING_FEATURE_VAR);
 
     // Hangul syllables come in two shapes: LV, and LVT.  Of those:
@@ -352,7 +357,11 @@ fn preprocess_text_hangul(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut
     buffer.sync();
 }
 
-fn setup_masks_hangul(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks_hangul(
+    plan: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) {
     let hangul_plan = plan.data::<hangul_shape_plan_t>();
     for info in buffer.info_slice_mut() {
         info.mask |= hangul_plan.mask_array[info.hangul_shaping_feature() as usize];

--- a/harfrust/src/hb/ot_shaper_indic.rs
+++ b/harfrust/src/hb/ot_shaper_indic.rs
@@ -4,10 +4,9 @@ use core::ops::Range;
 
 use read_fonts::types::GlyphId;
 
-use crate::hb::unicode::Codepoint;
-
 use super::algs::*;
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_layout::*;
 use super::ot_layout_gsubgpos::WouldApplyContext;
 use super::ot_map::*;
@@ -16,6 +15,7 @@ use super::ot_shape_normalize::*;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::*;
 use super::ot_shaper_syllabic::*;
+use super::unicode::Codepoint;
 use super::unicode::{hb_gc, CharExt};
 use super::{hb_font_t, hb_mask_t, hb_tag_t, script, GlyphInfo, Script};
 
@@ -576,7 +576,7 @@ fn override_features(planner: &mut hb_ot_shape_planner_t) {
     planner.ot_map.add_gsub_pause(Some(syllabic_clear_var)); // Don't need syllables anymore.
 }
 
-fn preprocess_text(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn preprocess_text(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
     super::ot_shaper_vowel_constraints::preprocess_text_vowel_constraints(buffer);
 }
 
@@ -608,7 +608,7 @@ fn compose(_: &hb_ot_shape_normalize_context_t, a: Codepoint, b: Codepoint) -> O
     crate::hb::unicode::compose(a, b)
 }
 
-fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
     buffer.allocate_var(GlyphInfo::INDIC_CATEGORY_VAR);
     buffer.allocate_var(GlyphInfo::INDIC_POSITION_VAR);
 
@@ -619,7 +619,11 @@ fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) 
     }
 }
 
-fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_syllables(
+    _: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_indic_machine::find_syllables_indic(buffer);
@@ -637,7 +641,7 @@ fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer
 
 fn initial_reordering(
     plan: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
+    font_funcs: &mut FontFuncsDispatch,
     buffer: &mut hb_buffer_t,
 ) -> bool {
     use super::ot_shaper_indic_machine::SyllableType;
@@ -646,9 +650,9 @@ fn initial_reordering(
 
     let indic_plan = plan.data::<IndicShapePlan>();
 
-    update_consonant_positions(plan, indic_plan, face, buffer);
+    update_consonant_positions(plan, indic_plan, font_funcs, buffer);
     if insert_dotted_circles(
-        face,
+        font_funcs,
         buffer,
         SyllableType::BrokenCluster as u8,
         ot_category_t::OT_DOTTEDCIRCLE,
@@ -661,7 +665,7 @@ fn initial_reordering(
     let mut start = 0;
     let mut end = buffer.next_syllable(0);
     while start < buffer.len {
-        initial_reordering_syllable(plan, indic_plan, face, start, end, buffer);
+        initial_reordering_syllable(plan, indic_plan, font_funcs, start, end, buffer);
         start = end;
         end = buffer.next_syllable(start);
     }
@@ -672,15 +676,16 @@ fn initial_reordering(
 fn update_consonant_positions(
     plan: &hb_ot_shape_plan_t,
     indic_plan: &IndicShapePlan,
-    face: &hb_font_t,
+    font_funcs: &mut FontFuncsDispatch,
     buffer: &mut hb_buffer_t,
 ) {
     let mut virama_glyph = None;
     if indic_plan.config.virama != 0 {
-        virama_glyph = face.get_nominal_glyph(indic_plan.config.virama);
+        virama_glyph = font_funcs.nominal_glyph(indic_plan.config.virama);
     }
 
     if let Some(virama) = virama_glyph {
+        let face = font_funcs.font();
         for info in buffer.info_slice_mut() {
             if info.indic_position() == ot_position_t::POS_BASE_C {
                 let consonant = info.as_glyph();
@@ -755,7 +760,7 @@ fn consonant_position_from_face(
 fn initial_reordering_syllable(
     plan: &hb_ot_shape_plan_t,
     indic_plan: &IndicShapePlan,
-    face: &hb_font_t,
+    font_funcs: &mut FontFuncsDispatch,
     start: usize,
     end: usize,
     buffer: &mut hb_buffer_t,
@@ -775,11 +780,11 @@ fn initial_reordering_syllable(
     match syllable_type {
         // We made the vowels look like consonants.  So let's call the consonant logic!
         SyllableType::VowelSyllable | SyllableType::ConsonantSyllable => {
-            initial_reordering_consonant_syllable(plan, indic_plan, face, start, end, buffer);
+            initial_reordering_consonant_syllable(plan, indic_plan, font_funcs, start, end, buffer);
         }
         // We already inserted dotted-circles, so just call the standalone_cluster.
         SyllableType::BrokenCluster | SyllableType::StandaloneCluster => {
-            initial_reordering_standalone_cluster(plan, indic_plan, face, start, end, buffer);
+            initial_reordering_standalone_cluster(plan, indic_plan, font_funcs, start, end, buffer);
         }
         SyllableType::SymbolCluster | SyllableType::NonIndicCluster => {}
     }
@@ -790,11 +795,12 @@ fn initial_reordering_syllable(
 fn initial_reordering_consonant_syllable(
     plan: &hb_ot_shape_plan_t,
     indic_plan: &IndicShapePlan,
-    face: &hb_font_t,
+    font_funcs: &mut FontFuncsDispatch,
     start: usize,
     end: usize,
     buffer: &mut hb_buffer_t,
 ) {
+    let face = font_funcs.font();
     // https://github.com/harfbuzz/harfbuzz/issues/435#issuecomment-335560167
     // For compatibility with legacy usage in Kannada,
     // Ra+h+ZWJ must behave like Ra+ZWJ+h...
@@ -1313,7 +1319,7 @@ fn initial_reordering_consonant_syllable(
 fn initial_reordering_standalone_cluster(
     plan: &hb_ot_shape_plan_t,
     indic_plan: &IndicShapePlan,
-    face: &hb_font_t,
+    face: &mut FontFuncsDispatch,
     start: usize,
     end: usize,
     buffer: &mut hb_buffer_t,
@@ -1323,7 +1329,11 @@ fn initial_reordering_standalone_cluster(
     initial_reordering_consonant_syllable(plan, indic_plan, face, start, end, buffer);
 }
 
-fn final_reordering(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn final_reordering(
+    plan: &hb_ot_shape_plan_t,
+    face: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     if buffer.is_empty() {
         return false;
     }
@@ -1340,7 +1350,7 @@ fn final_reordering(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb
 
 fn final_reordering_impl(
     plan: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
+    face: &mut FontFuncsDispatch,
     start: usize,
     end: usize,
     buffer: &mut hb_buffer_t,
@@ -1356,7 +1366,7 @@ fn final_reordering_impl(
     // We don't call load_virama_glyph(), since we know it's already loaded.
     let mut virama_glyph = None;
     if indic_plan.config.virama != 0 {
-        if let Some(g) = face.get_nominal_glyph(indic_plan.config.virama) {
+        if let Some(g) = face.nominal_glyph(indic_plan.config.virama) {
             virama_glyph = Some(g.to_u32());
         }
     }

--- a/harfrust/src/hb/ot_shaper_khmer.rs
+++ b/harfrust/src/hb/ot_shaper_khmer.rs
@@ -1,8 +1,5 @@
-use alloc::boxed::Box;
-
-use crate::hb::unicode::Codepoint;
-
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_map::*;
 use super::ot_shape::*;
 use super::ot_shape_normalize::*;
@@ -11,7 +8,9 @@ use super::ot_shaper::*;
 use super::ot_shaper_indic::ot_category_t;
 use super::ot_shaper_syllabic::*;
 use super::unicode::CharExt;
-use super::{hb_font_t, hb_mask_t, hb_tag_t, GlyphInfo};
+use super::unicode::Codepoint;
+use super::{hb_mask_t, hb_tag_t, GlyphInfo};
+use alloc::boxed::Box;
 
 pub const KHMER_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {
     collect_features: Some(collect_features),
@@ -126,7 +125,11 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 }
 
-fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_syllables(
+    _: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_khmer_machine::find_syllables_khmer(buffer);
@@ -142,7 +145,11 @@ fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer
     false
 }
 
-fn reorder_khmer(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn reorder_khmer(
+    plan: &hb_ot_shape_plan_t,
+    face: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     use super::ot_shaper_khmer_machine::SyllableType;
 
     let mut ret = false;
@@ -301,7 +308,7 @@ fn compose(_: &hb_ot_shape_normalize_context_t, a: Codepoint, b: Codepoint) -> O
     crate::hb::unicode::compose(a, b)
 }
 
-fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
     buffer.allocate_var(GlyphInfo::KHMER_CATEGORY_VAR);
 
     // We cannot setup masks here.  We save information about characters

--- a/harfrust/src/hb/ot_shaper_myanmar.rs
+++ b/harfrust/src/hb/ot_shaper_myanmar.rs
@@ -1,4 +1,5 @@
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_map::*;
 use super::ot_shape::*;
 use super::ot_shape_normalize::*;
@@ -6,7 +7,7 @@ use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::*;
 use super::ot_shaper_indic::{ot_category_t, ot_position_t};
 use super::ot_shaper_syllabic::*;
-use super::{hb_font_t, hb_tag_t, GlyphInfo};
+use super::{hb_tag_t, GlyphInfo};
 use crate::hb::ot_shaper_indic::ot_category_t::OT_VPre;
 
 pub const MYANMAR_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {
@@ -115,7 +116,11 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 }
 
-fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_syllables(
+    _: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_myanmar_machine::find_syllables_myanmar(buffer);
@@ -131,7 +136,11 @@ fn setup_syllables(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer
     false
 }
 
-fn reorder_myanmar(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn reorder_myanmar(
+    _: &hb_ot_shape_plan_t,
+    face: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     use super::ot_shaper_myanmar_machine::SyllableType;
 
     let mut ret = false;
@@ -321,7 +330,7 @@ fn initial_reordering_consonant_syllable(start: usize, end: usize, buffer: &mut 
     }
 }
 
-fn setup_masks(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
     buffer.allocate_var(GlyphInfo::MYANMAR_CATEGORY_VAR);
     buffer.allocate_var(GlyphInfo::MYANMAR_POSITION_VAR);
 

--- a/harfrust/src/hb/ot_shaper_syllabic.rs
+++ b/harfrust/src/hb/ot_shaper_syllabic.rs
@@ -1,10 +1,11 @@
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
-use super::{hb_font_t, GlyphInfo};
+use super::GlyphInfo;
 use crate::BufferFlags;
 
 pub fn insert_dotted_circles(
-    face: &hb_font_t,
+    font_funcs: &mut FontFuncsDispatch,
     buffer: &mut hb_buffer_t,
     broken_syllable_type: u8,
     dottedcircle_category: u8,
@@ -22,7 +23,7 @@ pub fn insert_dotted_circles(
         return false;
     }
 
-    let dottedcircle_glyph = match face.get_nominal_glyph(0x25CC) {
+    let dottedcircle_glyph = match font_funcs.nominal_glyph(0x25CC) {
         Some(g) => g.to_u32(),
         None => return false,
     };
@@ -74,7 +75,7 @@ pub fn insert_dotted_circles(
 
 pub(crate) fn syllabic_clear_var(
     _: &hb_ot_shape_plan_t,
-    _: &hb_font_t,
+    _: &mut FontFuncsDispatch,
     buffer: &mut hb_buffer_t,
 ) -> bool {
     for info in &mut buffer.info {

--- a/harfrust/src/hb/ot_shaper_thai.rs
+++ b/harfrust/src/hb/ot_shaper_thai.rs
@@ -1,10 +1,11 @@
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_layout::*;
 use super::ot_shape_normalize::HB_OT_SHAPE_NORMALIZATION_MODE_AUTO;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::*;
+use super::script;
 use super::unicode::GeneralCategory;
-use super::{hb_font_t, script};
 
 pub const THAI_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {
     collect_features: None,
@@ -131,7 +132,7 @@ static RD_MAPPINGS: &[PuaMapping] = &[
     PuaMapping::new(0x0000, 0x0000, 0x0000),
 ];
 
-fn pua_shape(u: u32, action: Action, face: &hb_font_t) -> u32 {
+fn pua_shape(u: u32, action: Action, face: &mut FontFuncsDispatch) -> u32 {
     let mappings = match action {
         Action::NOP => return u,
         Action::SD => SD_MAPPINGS,
@@ -142,11 +143,11 @@ fn pua_shape(u: u32, action: Action, face: &hb_font_t) -> u32 {
 
     for m in mappings {
         if m.u as u32 == u {
-            if face.get_nominal_glyph(m.win_pua as u32).is_some() {
+            if face.nominal_glyph(m.win_pua as u32).is_some() {
                 return m.win_pua as u32;
             }
 
-            if face.get_nominal_glyph(m.mac_pua as u32).is_some() {
+            if face.nominal_glyph(m.mac_pua as u32).is_some() {
                 return m.mac_pua as u32;
             }
 
@@ -270,7 +271,7 @@ static BELOW_STATE_MACHINE: &[[BSME; 3]] = &[
     ],
 ];
 
-fn do_pua_shaping(face: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn do_pua_shaping(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
     let mut above_state = ABOVE_START_STATE[Consonant::NotConsonant as usize];
     let mut below_state = BELOW_START_STATE[Consonant::NotConsonant as usize];
     let mut base = 0;
@@ -308,7 +309,11 @@ fn do_pua_shaping(face: &hb_font_t, buffer: &mut hb_buffer_t) {
 }
 
 // TODO: more tests
-fn preprocess_text(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn preprocess_text(
+    plan: &hb_ot_shape_plan_t,
+    face: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) {
     // This function implements the shaping logic documented here:
     //
     //   https://linux.thai.net/~thep/th-otf/shaping.html

--- a/harfrust/src/hb/ot_shaper_use.rs
+++ b/harfrust/src/hb/ot_shaper_use.rs
@@ -1,9 +1,6 @@
-use alloc::boxed::Box;
-
-use crate::hb::unicode::Codepoint;
-
 use super::algs::*;
 use super::buffer::*;
+use super::font_funcs::FontFuncsDispatch;
 use super::ot_layout::*;
 use super::ot_map::*;
 use super::ot_shape::*;
@@ -12,8 +9,9 @@ use super::ot_shape_plan::hb_ot_shape_plan_t;
 use super::ot_shaper::*;
 use super::ot_shaper_arabic::arabic_shape_plan_t;
 use super::ot_shaper_syllabic::*;
-use super::unicode::CharExt;
-use super::{hb_font_t, hb_mask_t, hb_tag_t, script, GlyphInfo, Script};
+use super::unicode::{CharExt, Codepoint};
+use super::{hb_mask_t, hb_tag_t, script, GlyphInfo, Script};
+use alloc::boxed::Box;
 
 pub const UNIVERSAL_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {
     collect_features: Some(collect_features),
@@ -237,7 +235,11 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 }
 
-fn setup_syllables(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_syllables(
+    plan: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_use_machine::find_syllables(buffer);
@@ -350,7 +352,11 @@ fn setup_topographical_masks(plan: &hb_ot_shape_plan_t, buffer: &mut hb_buffer_t
     }
 }
 
-fn record_rphf(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn record_rphf(
+    plan: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     let universal_plan = plan.data::<UniversalShapePlan>();
 
     let mask = universal_plan.rphf_mask;
@@ -380,13 +386,17 @@ fn record_rphf(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_
     false
 }
 
-fn reorder_use(_: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn reorder_use(
+    _: &hb_ot_shape_plan_t,
+    font: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     use super::ot_shaper_use_machine::SyllableType;
 
     let mut ret = false;
 
     if insert_dotted_circles(
-        face,
+        font,
         buffer,
         SyllableType::BrokenCluster as u8,
         category::B,
@@ -504,7 +514,11 @@ fn reorder_syllable_use(start: usize, end: usize, buffer: &mut hb_buffer_t) {
     }
 }
 
-fn record_pref(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) -> bool {
+fn record_pref(
+    _: &hb_ot_shape_plan_t,
+    _: &mut FontFuncsDispatch,
+    buffer: &mut hb_buffer_t,
+) -> bool {
     let mut start = 0;
     let mut end = buffer.next_syllable(0);
     while start < buffer.len {
@@ -543,7 +557,7 @@ fn has_arabic_joining(script: Script) -> bool {
     )
 }
 
-fn preprocess_text(_: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn preprocess_text(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
     super::ot_shaper_vowel_constraints::preprocess_text_vowel_constraints(buffer);
 }
 
@@ -556,7 +570,7 @@ fn compose(_: &hb_ot_shape_normalize_context_t, a: Codepoint, b: Codepoint) -> O
     crate::hb::unicode::compose(a, b)
 }
 
-fn setup_masks(plan: &hb_ot_shape_plan_t, _: &hb_font_t, buffer: &mut hb_buffer_t) {
+fn setup_masks(plan: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
     let universal_plan = plan.data::<UniversalShapePlan>();
 
     // Do this before allocating use_category().

--- a/harfrust/src/lib.rs
+++ b/harfrust/src/lib.rs
@@ -23,7 +23,16 @@ pub use read_fonts::{types::Tag, FontRef};
 
 pub use hb::buffer::{GlyphBuffer, GlyphInfo, GlyphPosition, UnicodeBuffer};
 pub use hb::common::{script, Direction, Feature, Language, Script, Variation};
-pub use hb::face::{hb_font_t as Shaper, ShapeOptions, ShaperBuilder, ShaperData, ShaperInstance};
+pub use hb::face::{
+    hb_font_t as Shaper, GlyphExtents, ShapeOptions, ShaperBuilder, ShaperData, ShaperInstance,
+};
+
+/// Font callbacks for overriding default metric and glyph operations during shaping.
+pub mod funcs {
+    pub use crate::hb::face::{
+        AdvanceWidthBatch, BuiltinFontFuncs, FontFuncs, RawAdvanceWidthBatch,
+    };
+}
 pub use hb::ot_shape_plan::{hb_ot_shape_plan_t as ShapePlan, ShapePlanKey};
 
 /// Type alias for a normalized variation coordinate.

--- a/harfrust/tests/font_funcs.rs
+++ b/harfrust/tests/font_funcs.rs
@@ -114,8 +114,7 @@ fn font_funcs_batch_advance_override_is_used() {
         fn populate_advance_widths(&mut self, _: &BuiltinFontFuncs, batch: AdvanceWidthBatch) {
             self.batch_calls += 1;
             assert!(!batch.is_empty());
-
-            for (_, advance) in batch.into_iter() {
+            for (_, advance) in batch {
                 *advance = 777;
             }
         }

--- a/harfrust/tests/font_funcs.rs
+++ b/harfrust/tests/font_funcs.rs
@@ -1,0 +1,398 @@
+use std::fs;
+use std::path::PathBuf;
+
+use harfrust::{
+    funcs::{AdvanceWidthBatch, BuiltinFontFuncs, FontFuncs},
+    Direction, FontRef, ShapeOptions, ShaperData, UnicodeBuffer,
+};
+use read_fonts::types::GlyphId;
+
+fn test_font_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fonts")
+        .join("rb_custom")
+        .join("OpenSans.subset1.ttf")
+}
+
+fn with_test_shaper<T>(f: impl FnOnce(&harfrust::Shaper) -> T) -> T {
+    let font_data = fs::read(test_font_path()).expect("failed to read test font");
+    let font = FontRef::new(&font_data).expect("failed to parse test font");
+    let data = ShaperData::new(&font);
+    let shaper = data.shaper(&font).build();
+    f(&shaper)
+}
+
+fn with_test_shaper_from_path<T>(font_path: PathBuf, f: impl FnOnce(&harfrust::Shaper) -> T) -> T {
+    let font_data = fs::read(font_path).expect("failed to read test font");
+    let font = FontRef::new(&font_data).expect("failed to parse test font");
+    let data = ShaperData::new(&font);
+    let shaper = data.shaper(&font).build();
+    f(&shaper)
+}
+
+fn buffer_with_text(text: &str) -> UnicodeBuffer {
+    let mut buffer = UnicodeBuffer::new();
+    buffer.push_str(text);
+    buffer.guess_segment_properties();
+    buffer
+}
+
+#[test]
+fn font_funcs_nominal_override_is_used() {
+    struct ForceNotdef {
+        nominal_calls: usize,
+    }
+
+    impl FontFuncs for ForceNotdef {
+        fn nominal_glyph(&mut self, _: &BuiltinFontFuncs, _: u32) -> Option<GlyphId> {
+            self.nominal_calls += 1;
+            Some(GlyphId::new(0))
+        }
+    }
+
+    let mut funcs = ForceNotdef { nominal_calls: 0 };
+
+    let glyphs = with_test_shaper(|shaper| {
+        shaper.shape(
+            buffer_with_text("abc"),
+            ShapeOptions::new().font_funcs(Some(&mut funcs)),
+        )
+    });
+
+    assert!(funcs.nominal_calls > 0);
+    assert!(!glyphs.glyph_infos().is_empty());
+    assert!(glyphs.glyph_infos().iter().all(|info| info.glyph_id == 0));
+}
+
+#[test]
+fn font_funcs_default_fallback_is_available() {
+    struct DelegatingFuncs {
+        nominal_calls: usize,
+    }
+
+    impl FontFuncs for DelegatingFuncs {
+        fn nominal_glyph(&mut self, builtin: &BuiltinFontFuncs, c: u32) -> Option<GlyphId> {
+            self.nominal_calls += 1;
+            builtin.nominal_glyph(c)
+        }
+    }
+
+    let mut funcs = DelegatingFuncs { nominal_calls: 0 };
+
+    let (baseline, with_funcs) = with_test_shaper(|shaper| {
+        let baseline = shaper.shape(buffer_with_text("abc"), ShapeOptions::new());
+        let with_funcs = shaper.shape(
+            buffer_with_text("abc"),
+            ShapeOptions::new().font_funcs(Some(&mut funcs)),
+        );
+        (baseline, with_funcs)
+    });
+
+    assert!(funcs.nominal_calls > 0);
+    assert_eq!(
+        baseline
+            .glyph_infos()
+            .iter()
+            .map(|g| g.glyph_id)
+            .collect::<Vec<_>>(),
+        with_funcs
+            .glyph_infos()
+            .iter()
+            .map(|g| g.glyph_id)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn font_funcs_batch_advance_override_is_used() {
+    struct BatchAdvanceFuncs {
+        batch_calls: usize,
+    }
+
+    impl FontFuncs for BatchAdvanceFuncs {
+        fn populate_advance_widths(&mut self, _: &BuiltinFontFuncs, batch: AdvanceWidthBatch) {
+            self.batch_calls += 1;
+            assert!(!batch.is_empty());
+
+            for (_, advance) in batch.into_iter() {
+                *advance = 777;
+            }
+        }
+    }
+
+    let mut funcs = BatchAdvanceFuncs { batch_calls: 0 };
+
+    let glyphs = with_test_shaper(|shaper| {
+        shaper.shape(
+            buffer_with_text("abc"),
+            ShapeOptions::new().font_funcs(Some(&mut funcs)),
+        )
+    });
+
+    assert!(funcs.batch_calls > 0);
+    assert!(!glyphs.glyph_positions().is_empty());
+    assert!(glyphs
+        .glyph_positions()
+        .iter()
+        .all(|pos| pos.x_advance == 777));
+}
+
+#[test]
+fn font_funcs_batch_advance_uses_individual_override_by_default() {
+    struct AdvanceOnlyFuncs {
+        advance_width_calls: usize,
+    }
+
+    impl FontFuncs for AdvanceOnlyFuncs {
+        fn advance_width(&mut self, _: &BuiltinFontFuncs, _: GlyphId) -> i32 {
+            self.advance_width_calls += 1;
+            333
+        }
+    }
+
+    let mut funcs = AdvanceOnlyFuncs {
+        advance_width_calls: 0,
+    };
+
+    let glyphs = with_test_shaper(|shaper| {
+        shaper.shape(
+            buffer_with_text("abc"),
+            ShapeOptions::new().font_funcs(Some(&mut funcs)),
+        )
+    });
+
+    assert!(funcs.advance_width_calls > 0);
+    assert!(!glyphs.glyph_positions().is_empty());
+    assert!(glyphs
+        .glyph_positions()
+        .iter()
+        .all(|pos| pos.x_advance == 333));
+}
+
+#[test]
+fn font_funcs_batch_hb_raw_view_is_available() {
+    struct HbRawFuncs {
+        batch_calls: usize,
+    }
+
+    impl FontFuncs for HbRawFuncs {
+        fn populate_advance_widths(&mut self, _: &BuiltinFontFuncs, batch: AdvanceWidthBatch) {
+            self.batch_calls += 1;
+            let raw = batch.into_raw();
+            assert_eq!(raw.len, 3);
+            assert!(!raw.gids.is_null());
+            assert!(!raw.advances.is_null());
+            assert!(raw.gid_stride > 0);
+            assert!(raw.advance_stride > 0);
+        }
+    }
+
+    let mut funcs = HbRawFuncs { batch_calls: 0 };
+
+    let _ = with_test_shaper(|shaper| {
+        shaper.shape(
+            buffer_with_text("abc"),
+            ShapeOptions::new().font_funcs(Some(&mut funcs)),
+        )
+    });
+
+    assert!(funcs.batch_calls > 0);
+}
+
+#[test]
+fn font_funcs_vertical_origin_override_is_used() {
+    struct VOriginFuncs {
+        v_origin_calls: usize,
+    }
+
+    impl FontFuncs for VOriginFuncs {
+        fn vertical_origin(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+            self.v_origin_calls += 1;
+            builtin.vertical_origin(glyph)
+        }
+    }
+
+    let mut funcs = VOriginFuncs { v_origin_calls: 0 };
+
+    let mut buffer = UnicodeBuffer::new();
+    buffer.push_str("abc");
+    buffer.set_direction(Direction::TopToBottom);
+    buffer.guess_segment_properties();
+    buffer.set_direction(Direction::TopToBottom);
+
+    let _ = with_test_shaper(|shaper| {
+        shaper.shape(buffer, ShapeOptions::new().font_funcs(Some(&mut funcs)))
+    });
+
+    assert!(funcs.v_origin_calls > 0);
+}
+
+#[test]
+fn font_funcs_batch_advance_not_called_for_empty_buffer() {
+    struct BatchAdvanceFuncs {
+        batch_calls: usize,
+    }
+
+    impl FontFuncs for BatchAdvanceFuncs {
+        fn populate_advance_widths(&mut self, _: &BuiltinFontFuncs, _: AdvanceWidthBatch) {
+            self.batch_calls += 1;
+        }
+    }
+
+    let mut funcs = BatchAdvanceFuncs { batch_calls: 0 };
+
+    let glyphs = with_test_shaper(|shaper| {
+        shaper.shape(
+            buffer_with_text(""),
+            ShapeOptions::new().font_funcs(Some(&mut funcs)),
+        )
+    });
+
+    assert_eq!(funcs.batch_calls, 0);
+    assert!(glyphs.glyph_infos().is_empty());
+}
+
+#[test]
+fn font_funcs_variant_glyph_override_is_used() {
+    struct VariantFuncs {
+        variant_calls: usize,
+    }
+
+    impl FontFuncs for VariantFuncs {
+        fn variant_glyph(&mut self, _: &BuiltinFontFuncs, _: u32, _: u32) -> Option<GlyphId> {
+            self.variant_calls += 1;
+            Some(GlyphId::new(1))
+        }
+    }
+
+    let mut funcs = VariantFuncs { variant_calls: 0 };
+
+    let glyphs = with_test_shaper(|shaper| {
+        shaper.shape(
+            buffer_with_text("a\u{FE0F}"),
+            ShapeOptions::new().font_funcs(Some(&mut funcs)),
+        )
+    });
+
+    assert!(funcs.variant_calls > 0);
+    assert_eq!(glyphs.glyph_infos().len(), 1);
+    assert_eq!(glyphs.glyph_infos()[0].glyph_id, 1);
+}
+
+#[test]
+fn font_funcs_advance_width_override_is_used() {
+    struct AdvanceFuncs {
+        advance_width_calls: usize,
+    }
+
+    impl FontFuncs for AdvanceFuncs {
+        fn advance_width(&mut self, _: &BuiltinFontFuncs, _: GlyphId) -> i32 {
+            self.advance_width_calls += 1;
+            100
+        }
+    }
+
+    let mut funcs = AdvanceFuncs {
+        advance_width_calls: 0,
+    };
+
+    let glyphs = with_test_shaper_from_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fonts")
+            .join("in-house")
+            .join("d9b8bc10985f24796826c29f7ccba3d0ae11ec02.ttf"),
+        |shaper| {
+            shaper.shape(
+                buffer_with_text("\u{0718}\u{070F}\u{0718}\u{0718}\u{002E}"),
+                ShapeOptions::new().font_funcs(Some(&mut funcs)),
+            )
+        },
+    );
+
+    assert!(funcs.advance_width_calls > 0);
+    assert!(!glyphs.glyph_positions().is_empty());
+    assert!(glyphs
+        .glyph_positions()
+        .iter()
+        .any(|pos| pos.x_advance != 0));
+}
+
+#[test]
+fn font_funcs_advance_height_override_is_used() {
+    struct AdvanceHeightFuncs {
+        advance_height_calls: usize,
+    }
+
+    impl FontFuncs for AdvanceHeightFuncs {
+        fn advance_height(&mut self, _: &BuiltinFontFuncs, _: GlyphId) -> i32 {
+            self.advance_height_calls += 1;
+            50
+        }
+    }
+
+    let mut funcs = AdvanceHeightFuncs {
+        advance_height_calls: 0,
+    };
+
+    let mut buffer = UnicodeBuffer::new();
+    buffer.push_str("abc");
+    buffer.set_direction(Direction::TopToBottom);
+    buffer.guess_segment_properties();
+
+    let glyphs = with_test_shaper(|shaper| {
+        shaper.shape(buffer, ShapeOptions::new().font_funcs(Some(&mut funcs)))
+    });
+
+    assert!(funcs.advance_height_calls > 0);
+    assert!(!glyphs.glyph_positions().is_empty());
+    assert!(glyphs
+        .glyph_positions()
+        .iter()
+        .all(|pos| pos.y_advance == 50));
+}
+
+#[test]
+fn font_funcs_extents_override_is_used() {
+    struct ExtentsFuncs {
+        extents_calls: usize,
+    }
+
+    impl FontFuncs for ExtentsFuncs {
+        fn extents(
+            &mut self,
+            default: &BuiltinFontFuncs,
+            glyph: GlyphId,
+        ) -> Option<harfrust::GlyphExtents> {
+            self.extents_calls += 1;
+            default.extents(glyph).map(|mut e| {
+                e.width = 999;
+                e
+            })
+        }
+    }
+
+    let mut funcs = ExtentsFuncs { extents_calls: 0 };
+
+    let glyphs = with_test_shaper_from_path(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fonts")
+            .join("in-house")
+            .join("8228d035fcd65d62ec9728fb34f42c63be93a5d3.ttf"),
+        |shaper| {
+            shaper.shape(
+                buffer_with_text("x\u{0301}X\u{0301}"),
+                ShapeOptions::new().font_funcs(Some(&mut funcs)),
+            )
+        },
+    );
+
+    assert!(funcs.extents_calls > 0);
+    assert_eq!(glyphs.glyph_positions().len(), 4);
+    assert!(glyphs
+        .glyph_positions()
+        .iter()
+        .any(|pos| pos.x_offset != 0 || pos.y_offset != 0));
+}

--- a/harfrust/tests/font_funcs.rs
+++ b/harfrust/tests/font_funcs.rs
@@ -138,7 +138,7 @@ fn font_funcs_batch_advance_override_is_used() {
 }
 
 #[test]
-fn font_funcs_batch_advance_uses_individual_override_by_default() {
+fn font_funcs_batch_advance_uses_single_glyph_override_by_default() {
     struct AdvanceOnlyFuncs {
         advance_width_calls: usize,
     }
@@ -161,7 +161,7 @@ fn font_funcs_batch_advance_uses_individual_override_by_default() {
         )
     });
 
-    assert!(funcs.advance_width_calls > 0);
+    assert!(funcs.advance_width_calls >= 2);
     assert!(!glyphs.glyph_positions().is_empty());
     assert!(glyphs
         .glyph_positions()
@@ -206,7 +206,7 @@ fn font_funcs_vertical_origin_override_is_used() {
     }
 
     impl FontFuncs for VOriginFuncs {
-        fn vertical_origin(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> i32 {
+        fn vertical_origin(&mut self, builtin: &BuiltinFontFuncs, glyph: GlyphId) -> (i32, i32) {
             self.v_origin_calls += 1;
             builtin.vertical_origin(glyph)
         }
@@ -224,7 +224,7 @@ fn font_funcs_vertical_origin_override_is_used() {
         shaper.shape(buffer, ShapeOptions::new().font_funcs(Some(&mut funcs)))
     });
 
-    assert!(funcs.v_origin_calls > 0);
+    assert!(funcs.v_origin_calls >= 2);
 }
 
 #[test]
@@ -310,7 +310,7 @@ fn font_funcs_advance_width_override_is_used() {
         },
     );
 
-    assert!(funcs.advance_width_calls > 0);
+    assert!(funcs.advance_width_calls >= 2);
     assert!(!glyphs.glyph_positions().is_empty());
     assert!(glyphs
         .glyph_positions()
@@ -344,7 +344,7 @@ fn font_funcs_advance_height_override_is_used() {
         shaper.shape(buffer, ShapeOptions::new().font_funcs(Some(&mut funcs)))
     });
 
-    assert!(funcs.advance_height_calls > 0);
+    assert!(funcs.advance_height_calls >= 2);
     assert!(!glyphs.glyph_positions().is_empty());
     assert!(glyphs
         .glyph_positions()
@@ -388,7 +388,7 @@ fn font_funcs_extents_override_is_used() {
         },
     );
 
-    assert!(funcs.extents_calls > 0);
+    assert!(funcs.extents_calls >= 2);
     assert_eq!(glyphs.glyph_positions().len(), 4);
     assert!(glyphs
         .glyph_positions()


### PR DESCRIPTION
Add a new FontFuncs trait, support for configuring it in ShapeOptions and all the lovely plumbing to make use of it.

The patch is larger than I would like but the changes are fairly invasive because the callbacks need to be passed (mutably!) through a lot of layers which required some reorganizing of code and some additional lifetimes.