### PR TITLE
0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-26
+
+This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
+and has an MSRV (minimum supported Rust version) of 1.85.
+
+- Refactor ot shape context functions into methods.
+- Added `ShapeOptions` type as argument to shape calls, preparation for being
+  able to pass font functions. `ShapeOptions` accepts shape plan, point size, features.
+  `shape_with_plan()` function removed in favor of new builder-style API.
+- Document release process to avoid missing LICENSE files.
+
+Release 0.7.1 was released prematurely and yanked from crates.io.
+
 ## [0.7.1] - 2026-05-26
 
 This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
@@ -142,8 +155,9 @@ This release matches HarfBuzz [v11.2.1][harfbuzz-11.2.1], and has an MSRV (minim
 HarfRust is a fork of RustyBuzz.
 See [their changelog](https://github.com/harfbuzz/rustybuzz/blob/main/CHANGELOG.md) for details of prior releases.
 
-[Unreleased]: https://github.com/harfbuzz/harfrust/compare/0.7.1...HEAD
-[0.7.0]: https://github.com/harfbuzz/harfrust/compare/0.7.0...0.7.1
+[Unreleased]: https://github.com/harfbuzz/harfrust/compare/0.8.0...HEAD
+[0.8.0]: https://github.com/harfbuzz/harfrust/compare/0.7.1...0.8.0
+[0.7.1]: https://github.com/harfbuzz/harfrust/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/harfbuzz/harfrust/compare/0.6.2...0.7.0
 [0.6.2]: https://github.com/harfbuzz/harfrust/compare/0.6.1...0.6.2
 [0.6.1]: https://github.com/harfbuzz/harfrust/compare/0.6.0...0.6.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["harfrust", "hr-shape", "fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.85"  # should match https://github.com/googlefonts/fontations/blob/main/Cargo.toml
 description = "A complete HarfBuzz shaping algorithm port to Rust."
@@ -22,7 +22,7 @@ codegen-units = 1
 inherits = "release"
 
 [workspace.dependencies]
-harfrust = { version = "0.7.1", path = "./harfrust", default-features = false }
+harfrust = { version = "0.8.0", path = "./harfrust", default-features = false }
 read-fonts = { version = "0.39.0", default-features = false }
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ There are no `unsafe` in this library and in most of its dependencies (excluding
 * Edit CHANGELOG.md following the conventions in that file, at least
   * Add information about which HarfBuzz release is tracked
   * Update diff links at the bottom
+  * Determine diff from previous release and
   * Summarize changes
+  * Determine new version number according to SemVer
 * Update Cargo.toml release version following SemVer
 * Commit to a branch and file a PR
 * Get PR reviewed and land


### PR DESCRIPTION
This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0), and has an MSRV (minimum supported Rust version) of 1.85.

- Refactor ot shape context functions into methods.
- Added `ShapeOptions` type as argument to shape calls, preparation for being able to pass font functions. `ShapeOptions` accepts shape plan, point size, features. `shape_with_plan()` function removed in favor of new builder-style API.
- Document release process to avoid missing LICENSE files.