### PR TITLE
Handling scaling like HarfBuzz

### DIFF
--- a/harfrust/src/hb/aat/layout.rs
+++ b/harfrust/src/hb/aat/layout.rs
@@ -4,7 +4,8 @@ use super::map;
 use super::{layout_kerx_table, layout_morx_table, layout_trak_table};
 use crate::hb::aat::layout_common::{AatApplyContext, HB_BUFFER_SCRATCH_FLAG_AAT_HAS_DELETED};
 use crate::hb::{
-    buffer::hb_buffer_t, hb_font_t, hb_tag_t, ot_shape_plan::hb_ot_shape_plan_t, GlyphInfo,
+    buffer::hb_buffer_t, face::Scale, hb_font_t, hb_tag_t, ot_shape_plan::hb_ot_shape_plan_t,
+    GlyphInfo,
 };
 use crate::Feature;
 
@@ -514,7 +515,7 @@ pub fn substitute(
         builder.compile(face, &mut aat_map);
     }
 
-    let mut c = AatApplyContext::new(plan, face, buffer);
+    let mut c = AatApplyContext::new(plan, face, Scale::default(), buffer);
     layout_morx_table::apply(
         &mut c,
         if features.is_empty() {
@@ -543,8 +544,13 @@ pub fn remove_deleted_glyphs(buffer: &mut hb_buffer_t) {
 ///
 /// See <https://github.com/harfbuzz/harfbuzz/blob/2c22a65f0cb99544c36580b9703a43b5dc97a9e1/src/hb-aat-layout.cc#L363>
 #[doc(alias = "hb_aat_layout_position")]
-pub fn position(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buffer_t) {
-    let mut c = AatApplyContext::new(plan, face, buffer);
+pub fn position(
+    plan: &hb_ot_shape_plan_t,
+    face: &hb_font_t,
+    scale: Scale,
+    buffer: &mut hb_buffer_t,
+) {
+    let mut c = AatApplyContext::new(plan, face, scale, buffer);
     layout_kerx_table::apply(&mut c);
 }
 
@@ -555,8 +561,9 @@ pub fn position(plan: &hb_ot_shape_plan_t, face: &hb_font_t, buffer: &mut hb_buf
 pub fn track(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
+    scale: Scale,
     point_size: Option<f32>,
     buffer: &mut hb_buffer_t,
 ) {
-    layout_trak_table::apply(plan, face, point_size, buffer);
+    layout_trak_table::apply(plan, face, scale, point_size, buffer);
 }

--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -2,6 +2,7 @@ use super::layout::DELETED_GLYPH;
 use super::map::RangeFlags;
 use crate::hb::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_SHAPER0};
 use crate::hb::face::hb_font_t;
+use crate::hb::face::Scale;
 use crate::hb::hb_mask_t;
 use crate::hb::ot_layout_gsubgpos::MappingCache;
 use crate::hb::ot_shape_plan::hb_ot_shape_plan_t;
@@ -37,6 +38,7 @@ pub(crate) fn get_class<T: bytemuck::AnyBitPattern + FixedSize>(
 pub struct AatApplyContext<'a> {
     pub plan: &'a hb_ot_shape_plan_t,
     pub face: &'a hb_font_t<'a>,
+    pub scale: Scale,
     pub buffer: &'a mut hb_buffer_t,
     pub has_glyph_classes: bool,
     pub range_flags: Option<&'a [RangeFlags]>,
@@ -54,11 +56,13 @@ impl<'a> AatApplyContext<'a> {
     pub fn new(
         plan: &'a hb_ot_shape_plan_t,
         face: &'a hb_font_t<'a>,
+        scale: Scale,
         buffer: &'a mut hb_buffer_t,
     ) -> Self {
         Self {
             plan,
             face,
+            scale,
             buffer,
             has_glyph_classes: face.ot_tables.has_glyph_classes(),
             range_flags: None,
@@ -70,6 +74,16 @@ impl<'a> AatApplyContext<'a> {
             machine_class_cache: None,
             start_end_safe_to_break: 0,
         }
+    }
+
+    #[inline(always)]
+    pub(crate) fn scale_x(&self, value: i32) -> i32 {
+        self.scale.scale_x(value)
+    }
+
+    #[inline(always)]
+    pub(crate) fn scale_y(&self, value: i32) -> i32 {
+        self.scale.scale_y(value)
     }
 
     pub(crate) fn reverse_buffer(&mut self) {

--- a/harfrust/src/hb/aat/layout_kerx_table.rs
+++ b/harfrust/src/hb/aat/layout_kerx_table.rs
@@ -194,13 +194,15 @@ impl SimpleKerning for Subtable6<'_> {
 }
 
 fn apply_simple_kerning<T: SimpleKerning>(c: &mut AatApplyContext, subtable: &Subtable, kind: &T) {
-    let mut ctx = hb_ot_apply_context_t::new(TableIndex::GPOS, c.face, c.buffer);
+    let scale = c.scale;
+    let mut ctx = hb_ot_apply_context_t::new(TableIndex::GPOS, c.face, c.scale, c.buffer);
     ctx.set_lookup_mask(c.plan.kern_mask);
     ctx.lookup_props = u32::from(lookup_flags::IGNORE_MARKS);
     ctx.update_matchers();
 
     let horizontal = ctx.buffer.direction.is_horizontal();
     let cross_stream = subtable.is_cross_stream();
+    let use_x_scale = horizontal ^ cross_stream;
 
     let first_set = c.first_set.as_ref().unwrap();
     let second_set = c.second_set.as_ref().unwrap();
@@ -231,6 +233,11 @@ fn apply_simple_kerning<T: SimpleKerning>(c: &mut AatApplyContext, subtable: &Su
             0
         } else {
             kind.simple_kerning(a, b).unwrap_or(0)
+        };
+        let kern = if use_x_scale {
+            scale.scale_x(kern)
+        } else {
+            scale.scale_y(kern)
         };
 
         let pos = &mut iter.buffer.pos;
@@ -531,6 +538,7 @@ impl StateTableDriver<Subtable1<'_>, BigEndian<u16>> for Driver1 {
             // "Each pops one glyph from the kerning stack and applies the kerning value to it.
             // The end of the list is marked by an odd value...
             let mut last = false;
+            let use_x_scale = c.buffer.direction.is_horizontal() ^ has_cross_stream;
             while !last && self.depth != 0 {
                 self.depth -= 1;
                 let idx = self.stack[self.depth];
@@ -543,7 +551,11 @@ impl StateTableDriver<Subtable1<'_>, BigEndian<u16>> for Driver1 {
                 // "The end of the list is marked by an odd value..."
                 last = v & 1 != 0;
                 v &= !1;
-
+                let scaled_v = if use_x_scale {
+                    c.scale_x(v)
+                } else {
+                    c.scale_y(v)
+                };
                 // Testing shows that CoreText only applies kern (cross-stream or not)
                 // if none has been applied by previous subtables. That is, it does
                 // NOT seem to accumulate as otherwise implied by specs.
@@ -561,12 +573,12 @@ impl StateTableDriver<Subtable1<'_>, BigEndian<u16>> for Driver1 {
                             pos.set_attach_chain(0);
                             pos.y_offset = 0;
                         } else if pos.attach_type() != 0 {
-                            pos.y_offset += v;
+                            pos.y_offset += scaled_v;
                             has_gpos_attachment = true;
                         }
                     } else if glyph_mask & c.plan.kern_mask != 0 {
-                        pos.x_advance += v;
-                        pos.x_offset += v;
+                        pos.x_advance += scaled_v;
+                        pos.x_offset += scaled_v;
                     }
                 } else {
                     if has_cross_stream {
@@ -576,13 +588,13 @@ impl StateTableDriver<Subtable1<'_>, BigEndian<u16>> for Driver1 {
                             pos.set_attach_chain(0);
                             pos.x_offset = 0;
                         } else if pos.attach_type() != 0 {
-                            pos.x_offset += v;
+                            pos.x_offset += scaled_v;
                             has_gpos_attachment = true;
                         }
                     } else if glyph_mask & c.plan.kern_mask != 0 {
                         if pos.y_offset == 0 {
-                            pos.y_advance += v;
-                            pos.y_offset += v;
+                            pos.y_advance += scaled_v;
+                            pos.y_offset += scaled_v;
                         }
                     }
                 }
@@ -634,9 +646,13 @@ impl StateTableDriver<Subtable4<'_>, BigEndian<u16>> for Driver4<'_> {
                         .map(|point| (point.x(), point.y()))
                         .unwrap_or_default();
 
+                    let x_offset =
+                        c.scale_x(i32::from(mark_anchor.0)) - c.scale_x(i32::from(curr_anchor.0));
+                    let y_offset =
+                        c.scale_y(i32::from(mark_anchor.1)) - c.scale_y(i32::from(curr_anchor.1));
                     let pos = c.buffer.cur_pos_mut();
-                    pos.x_offset = i32::from(mark_anchor.0 - curr_anchor.0);
-                    pos.y_offset = i32::from(mark_anchor.1 - curr_anchor.1);
+                    pos.x_offset = x_offset;
+                    pos.y_offset = y_offset;
                 }
                 (_, Subtable4Actions::ControlPointCoords(coords)) => {
                     let action_idx = entry.action_index() as usize * 4;
@@ -644,9 +660,11 @@ impl StateTableDriver<Subtable4<'_>, BigEndian<u16>> for Driver4<'_> {
                     let mark_y = coords.get(action_idx + 1)?.get() as i32;
                     let curr_x = coords.get(action_idx + 2)?.get() as i32;
                     let curr_y = coords.get(action_idx + 3)?.get() as i32;
+                    let x_offset = c.scale_x(mark_x) - c.scale_x(curr_x);
+                    let y_offset = c.scale_y(mark_y) - c.scale_y(curr_y);
                     let pos = c.buffer.cur_pos_mut();
-                    pos.x_offset = mark_x - curr_x;
-                    pos.y_offset = mark_y - curr_y;
+                    pos.x_offset = x_offset;
+                    pos.y_offset = y_offset;
                 }
                 _ => {}
             }

--- a/harfrust/src/hb/aat/layout_trak_table.rs
+++ b/harfrust/src/hb/aat/layout_trak_table.rs
@@ -7,11 +7,12 @@ use read_fonts::tables::trak::TrackTableEntry;
 use read_fonts::types::{BigEndian, Fixed};
 use read_fonts::FontData;
 
-use crate::hb::{buffer::hb_buffer_t, hb_font_t, ot_shape_plan::hb_ot_shape_plan_t};
+use crate::hb::{buffer::hb_buffer_t, face::Scale, hb_font_t, ot_shape_plan::hb_ot_shape_plan_t};
 
 pub fn apply(
     _plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
+    scale: Scale,
     point_size: Option<f32>,
     buffer: &mut hb_buffer_t,
 ) -> Option<()> {
@@ -26,9 +27,9 @@ pub fn apply(
     }
 
     let advance_to_add = if buffer.direction.is_horizontal() {
-        trak.get_h_tracking(ptem, 0.0)
+        scale.scale_x(trak.get_h_tracking(ptem, 0.0))
     } else {
-        trak.get_v_tracking(ptem, 0.0)
+        scale.scale_y(trak.get_v_tracking(ptem, 0.0))
     };
 
     foreach_grapheme!(buffer, start, end, {

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -2,6 +2,11 @@ use read_fonts::types::{F2Dot14, Fixed, GlyphId};
 use read_fonts::{FontRef, TableProvider};
 use smallvec::SmallVec;
 
+// libm used for f32::floor() and f32::ceil()
+#[cfg(not(feature = "std"))]
+#[allow(unused_imports)]
+use core_maths::CoreFloat as _;
+
 use super::aat::AatTables;
 use super::charmap::{cache_t as cmap_cache_t, Charmap};
 use super::font_funcs::FontFuncsDispatch;
@@ -284,6 +289,8 @@ impl<'a> ShapeOptions<'a> {
 pub(crate) struct Scale {
     x_mult: i64,
     y_mult: i64,
+    x_multf: f32,
+    y_multf: f32,
 }
 
 impl Default for Scale {
@@ -291,6 +298,8 @@ impl Default for Scale {
         Self {
             x_mult: 1 << 16,
             y_mult: 1 << 16,
+            x_multf: 1.0,
+            y_multf: 1.0,
         }
     }
 }
@@ -303,7 +312,13 @@ impl Scale {
             return Self::default();
         };
         let [x_mult, y_mult] = [x_scale, y_scale].map(|s| Self::mult_from_scale(s, upem));
-        Self { x_mult, y_mult }
+        let upem = upem as f32;
+        Self {
+            x_mult,
+            y_mult,
+            x_multf: x_scale as f32 / upem,
+            y_multf: y_scale as f32 / upem,
+        }
     }
 
     #[inline(always)]
@@ -316,18 +331,19 @@ impl Scale {
         Self::scale_by_mult(y, self.y_mult)
     }
 
-    /// Scales glyph extents using corner-based arithmetic matching HarfBuzz's
-    /// `scale_glyph_extents` in `hb-font.hh`. The float path there is a no-op
-    /// since `em_scale_x`/`em_scale_y` already return integers.
+    /// Scales glyph extents using HarfBuzz's corner-based float arithmetic:
+    /// floor the origin corners and ceil the far corners before deriving the
+    /// final width/height.
+    /// hb_font_t::scale_glyph_extents: <https://github.com/harfbuzz/harfbuzz/blob/88adc6437ef561486a5adf1822410297ef4a852b/src/hb-font.hh#L201>
     pub(crate) fn scale_extents(&self, mut extents: GlyphExtents) -> GlyphExtents {
-        let x1 = self.scale_x(extents.x_bearing);
-        let y1 = self.scale_y(extents.y_bearing);
-        let x2 = self.scale_x(extents.x_bearing + extents.width);
-        let y2 = self.scale_y(extents.y_bearing + extents.height);
-        extents.x_bearing = x1;
-        extents.y_bearing = y1;
-        extents.width = x2 - x1;
-        extents.height = y2 - y1;
+        let x1 = extents.x_bearing as f32 * self.x_multf;
+        let y1 = extents.y_bearing as f32 * self.y_multf;
+        let x2 = (extents.x_bearing + extents.width) as f32 * self.x_multf;
+        let y2 = (extents.y_bearing + extents.height) as f32 * self.y_multf;
+        extents.x_bearing = x1.floor() as i32;
+        extents.y_bearing = y1.floor() as i32;
+        extents.width = x2.ceil() as i32 - extents.x_bearing;
+        extents.height = y2.ceil() as i32 - extents.y_bearing;
         extents
     }
 
@@ -526,10 +542,8 @@ mod tests {
 
     #[test]
     fn extents_scale_from_corners_like_harfbuzz() {
-        // HarfBuzz scale_glyph_extents scales corners then derives width/height:
-        //   x1 = scale_x(x_bearing), x2 = scale_x(x_bearing + width), width = x2 - x1
-        // With independent scaling, scale_x(width=3) at 1500/1000 = round(4.5) = 5.
-        // With corner scaling, x2 = scale_x(4) = 6, x1 = scale_x(1) = 2 → width = 4.
+        // HarfBuzz scales corners in floating point, floors the bearings,
+        // ceils the far corners, and then derives width/height from them.
         let scale = Scale::new(Some((1500, 1500)), 1000);
         let extents = GlyphExtents {
             x_bearing: 1,
@@ -538,9 +552,9 @@ mod tests {
             height: -2,
         };
         let scaled = scale.scale_extents(extents);
-        assert_eq!(scaled.x_bearing, 2);
+        assert_eq!(scaled.x_bearing, 1);
         assert_eq!(scaled.y_bearing, 6);
-        assert_eq!(scaled.width, 4); // corner: round(6)-round(2)=4, independent: round(4.5)=5
+        assert_eq!(scaled.width, 5);
         assert_eq!(scaled.height, -3);
     }
 }

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -11,7 +11,6 @@ use super::ot::{LayoutTable, OtCache, OtTables};
 use super::ot_layout::TableIndex;
 use super::ot_shape::OtShapeContext;
 use crate::hb::aat::AatCache;
-use crate::hb::buffer::hb_buffer_t;
 use crate::hb::tables::TableRanges;
 use crate::{script, Feature, GlyphBuffer, NormalizedCoord, ShapePlan, UnicodeBuffer, Variation};
 
@@ -281,37 +280,69 @@ impl<'a> ShapeOptions<'a> {
     }
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone)]
 pub(crate) struct Scale {
     x_mult: i64,
     y_mult: i64,
 }
 
+impl Default for Scale {
+    fn default() -> Self {
+        Self {
+            x_mult: 1 << 16,
+            y_mult: 1 << 16,
+        }
+    }
+}
+
 impl Scale {
-    fn new(scale: Option<(i32, i32)>, upem: i32) -> Self {
+    pub(crate) fn new(scale: Option<(i32, i32)>, upem: i32) -> Self {
         let (Some((x_scale, y_scale)), true) = (scale, upem != 0) else {
-            // If we don't have a scale or upem is 0, we follow HarfBuzz's
-            // convention and disable scaling by setting the multipliers
-            // to 0.
+            // When scale is not configured, or upem is zero, return results
+            // in font units.
             return Self::default();
         };
-        let [x_mult, y_mult] = [x_scale, y_scale].map(|s| ((s as i64) << 16) / upem as i64);
+        let [x_mult, y_mult] = [x_scale, y_scale].map(|s| Self::mult_from_scale(s, upem));
         Self { x_mult, y_mult }
     }
 
     #[inline(always)]
-    fn em_scale(value: i32, mult: i64) -> i32 {
+    pub(crate) fn scale_x(&self, x: i32) -> i32 {
+        Self::scale_by_mult(x, self.x_mult)
+    }
+
+    #[inline(always)]
+    pub(crate) fn scale_y(&self, y: i32) -> i32 {
+        Self::scale_by_mult(y, self.y_mult)
+    }
+
+    /// Scales glyph extents using corner-based arithmetic matching HarfBuzz's
+    /// `scale_glyph_extents` in `hb-font.hh`. The float path there is a no-op
+    /// since `em_scale_x`/`em_scale_y` already return integers.
+    pub(crate) fn scale_extents(&self, mut extents: GlyphExtents) -> GlyphExtents {
+        let x1 = self.scale_x(extents.x_bearing);
+        let y1 = self.scale_y(extents.y_bearing);
+        let x2 = self.scale_x(extents.x_bearing + extents.width);
+        let y2 = self.scale_y(extents.y_bearing + extents.height);
+        extents.x_bearing = x1;
+        extents.y_bearing = y1;
+        extents.width = x2 - x1;
+        extents.height = y2 - y1;
+        extents
+    }
+
+    #[inline(always)]
+    fn mult_from_scale(scale: i32, upem: i32) -> i64 {
+        if scale < 0 {
+            -((-(scale as i64)) << 16) / upem as i64
+        } else {
+            ((scale as i64) << 16) / upem as i64
+        }
+    }
+
+    #[inline(always)]
+    fn scale_by_mult(value: i32, mult: i64) -> i32 {
         (((value as i64) * mult + 32768) >> 16) as i32
-    }
-
-    #[inline(always)]
-    pub(crate) fn em_scale_x(&self, x: i32) -> i32 {
-        Self::em_scale(x, self.x_mult)
-    }
-
-    #[inline(always)]
-    pub(crate) fn em_scale_y(&self, y: i32) -> i32 {
-        Self::em_scale(y, self.y_mult)
     }
 }
 
@@ -322,7 +353,7 @@ pub struct hb_font_t<'a> {
     pub(crate) units_per_em: u16,
     charmap: Charmap<'a>,
     pub(crate) cmap_cache: &'a cmap_cache_t,
-    glyph_metrics: GlyphMetrics<'a>,
+    pub(crate) glyph_metrics: GlyphMetrics<'a>,
     pub(crate) ot_tables: OtTables<'a>,
     pub(crate) aat_tables: AatTables<'a>,
 }
@@ -424,11 +455,6 @@ impl<'a> crate::Shaper<'a> {
             .unwrap_or_default()
     }
 
-    pub(crate) fn glyph_h_advances(&self, buffer: &mut hb_buffer_t) {
-        self.glyph_metrics
-            .populate_advance_widths(buffer, self.ot_tables.coords);
-    }
-
     pub(crate) fn glyph_v_advance(&self, glyph: GlyphId) -> i32 {
         -self
             .glyph_metrics
@@ -492,4 +518,29 @@ pub struct GlyphExtents {
     pub width: i32,
     /// Height of the glyph ink box.
     pub height: i32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extents_scale_from_corners_like_harfbuzz() {
+        // HarfBuzz scale_glyph_extents scales corners then derives width/height:
+        //   x1 = scale_x(x_bearing), x2 = scale_x(x_bearing + width), width = x2 - x1
+        // With independent scaling, scale_x(width=3) at 1500/1000 = round(4.5) = 5.
+        // With corner scaling, x2 = scale_x(4) = 6, x1 = scale_x(1) = 2 → width = 4.
+        let scale = Scale::new(Some((1500, 1500)), 1000);
+        let extents = GlyphExtents {
+            x_bearing: 1,
+            y_bearing: 4,
+            width: 3,
+            height: -2,
+        };
+        let scaled = scale.scale_extents(extents);
+        assert_eq!(scaled.x_bearing, 2);
+        assert_eq!(scaled.y_bearing, 6);
+        assert_eq!(scaled.width, 4); // corner: round(6)-round(2)=4, independent: round(4.5)=5
+        assert_eq!(scaled.height, -3);
+    }
 }

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -357,7 +357,8 @@ impl Scale {
     /// Scales glyph extents using HarfBuzz's corner-based float arithmetic:
     /// floor the origin corners and ceil the far corners before deriving the
     /// final width/height.
-    /// hb_font_t::scale_glyph_extents: <https://github.com/harfbuzz/harfbuzz/blob/88adc6437ef561486a5adf1822410297ef4a852b/src/hb-font.hh#L201>
+    /// hb_font_t::scale_glyph_extents: <https://github.com/harfbuzz/harfbuzz/blob/88adc6437ef561486a5adf1822410297ef4a852b/src/hb-font.hh#L201>'
+    #[allow(clippy::cast_precision_loss)]
     pub(crate) fn scale_extents(&self, mut extents: GlyphExtents) -> GlyphExtents {
         let x1 = extents.x_bearing as f32 * self.x_multf;
         let y1 = extents.y_bearing as f32 * self.y_multf;

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -229,6 +229,7 @@ impl<'a> ShaperBuilder<'a> {
 #[derive(Default)]
 pub struct ShapeOptions<'a> {
     plan: Option<&'a ShapePlan>,
+    scale: Option<(i32, i32)>,
     point_size: Option<f32>,
     features: &'a [Feature],
     font_funcs: Option<&'a mut (dyn FontFuncs + 'a)>,
@@ -249,6 +250,18 @@ impl<'a> ShapeOptions<'a> {
         self
     }
 
+    /// Sets the scale factor to use during shaping.
+    pub fn scale(mut self, scale: Option<i32>) -> Self {
+        self.scale = scale.map(|s| (s, s));
+        self
+    }
+
+    /// Sets separate x- and y-scale factors to use during shaping.
+    pub fn scale_separate(mut self, scale: Option<(i32, i32)>) -> Self {
+        self.scale = scale;
+        self
+    }
+
     /// Sets the size used for application of the tracking table.
     pub fn point_size(mut self, point_size: Option<f32>) -> Self {
         self.point_size = point_size;
@@ -265,6 +278,40 @@ impl<'a> ShapeOptions<'a> {
     pub fn font_funcs(mut self, funcs: Option<&'a mut (dyn FontFuncs + 'a)>) -> Self {
         self.font_funcs = funcs;
         self
+    }
+}
+
+#[derive(Copy, Clone, Default)]
+pub(crate) struct Scale {
+    x_mult: i64,
+    y_mult: i64,
+}
+
+impl Scale {
+    fn new(scale: Option<(i32, i32)>, upem: i32) -> Self {
+        let (Some((x_scale, y_scale)), true) = (scale, upem != 0) else {
+            // If we don't have a scale or upem is 0, we follow HarfBuzz's
+            // convention and disable scaling by setting the multipliers
+            // to 0.
+            return Self::default();
+        };
+        let [x_mult, y_mult] = [x_scale, y_scale].map(|s| ((s as i64) << 16) / upem as i64);
+        Self { x_mult, y_mult }
+    }
+
+    #[inline(always)]
+    fn em_scale(value: i32, mult: i64) -> i32 {
+        (((value as i64) * mult + 32768) >> 16) as i32
+    }
+
+    #[inline(always)]
+    pub(crate) fn em_scale_x(&self, x: i32) -> i32 {
+        Self::em_scale(x, self.x_mult)
+    }
+
+    #[inline(always)]
+    pub(crate) fn em_scale_y(&self, y: i32) -> i32 {
+        Self::em_scale(y, self.y_mult)
     }
 }
 
@@ -344,7 +391,8 @@ impl<'a> crate::Shaper<'a> {
         if buffer.len > 0 {
             // Save the original direction, we use it later.
             let target_direction = buffer.direction;
-            let mut font_funcs = FontFuncsDispatch::new(self, options.font_funcs);
+            let scale = Scale::new(options.scale, self.units_per_em as i32);
+            let mut font_funcs = FontFuncsDispatch::new(self, scale, options.font_funcs);
             OtShapeContext {
                 plan,
                 face: self,

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -327,6 +327,8 @@ impl Default for Scale {
     }
 }
 
+// Various conversions between f32 and i32
+#[allow(clippy::cast_precision_loss)]
 impl Scale {
     pub(crate) fn new(scale: Option<(i32, i32)>, upem: i32) -> Self {
         let (Some((x_scale, y_scale)), true) = (scale, upem != 0) else {
@@ -358,7 +360,6 @@ impl Scale {
     /// floor the origin corners and ceil the far corners before deriving the
     /// final width/height.
     /// hb_font_t::scale_glyph_extents: <https://github.com/harfbuzz/harfbuzz/blob/88adc6437ef561486a5adf1822410297ef4a852b/src/hb-font.hh#L201>'
-    #[allow(clippy::cast_precision_loss)]
     pub(crate) fn scale_extents(&self, mut extents: GlyphExtents) -> GlyphExtents {
         let x1 = extents.x_bearing as f32 * self.x_multf;
         let y1 = extents.y_bearing as f32 * self.y_multf;

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -255,12 +255,35 @@ impl<'a> ShapeOptions<'a> {
     }
 
     /// Sets the scale factor to use during shaping.
+    ///
+    /// The font scale is a number related to, but not the same as, font size.
+    /// Typically the client establishes a scale factor to be used between the
+    /// two. For example, 64, or 256, which would be the fractional-precision
+    /// part of the font scale. This is necessary because position and metric
+    /// values are integer types and you need to leave room for fractional
+    /// values in there.
+    ///
+    /// For example, to set the font size to 20, with 64 levels of fractional
+    /// precision you would call provide a scale of `20 * 64`.
+    ///
+    /// In the example above, even what font size 20 means is up to you. It
+    /// might be 20 pixels, or 20 points, or 20 millimeters. HarfRust does
+    /// not care about that.
+    ///
+    /// The choice of scale is yours but needs to be consistent between what
+    /// you set here, and what you expect as output as well as the values
+    /// returned by [font functions](FontFuncs).
+    ///
+    /// This defaults to `None` which means that no scale is applied-- positions
+    /// and metrics will be returned in font units.
     pub fn scale(mut self, scale: Option<i32>) -> Self {
         self.scale = scale.map(|s| (s, s));
         self
     }
 
     /// Sets separate x- and y-scale factors to use during shaping.
+    ///
+    /// Each axis uses the same semantics as [`scale`](Self::scale).
     pub fn scale_separate(mut self, scale: Option<(i32, i32)>) -> Self {
         self.scale = scale;
         self

--- a/harfrust/src/hb/font_funcs.rs
+++ b/harfrust/src/hb/font_funcs.rs
@@ -162,8 +162,14 @@ impl<'a> BuiltinFontFuncs<'a> {
 ///
 /// # Metrics scaling
 ///
-/// All font metrics passed to and from these callbacks are in unscaled font
-/// units.
+/// All font metrics returned by these callbacks must be consistent with the
+/// scale factor configured via
+/// [`ShapeOptions::scale`](crate::ShapeOptions::scale).
+///
+/// If no scale is set, values must be in unscaled font units (i.e. the same
+/// coordinate space as the font's `units_per_em`). If a scale is set —
+/// for example `font_size * 64` for FreeType-style 26.6 — then all returned
+/// values must already be in that scaled coordinate space.
 pub trait FontFuncs {
     /// Nominal character-to-glyph mapping callback.
     fn nominal_glyph(&mut self, builtin: &BuiltinFontFuncs, c: u32) -> Option<GlyphId> {

--- a/harfrust/src/hb/font_funcs.rs
+++ b/harfrust/src/hb/font_funcs.rs
@@ -254,6 +254,26 @@ impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
     }
 
     #[inline(always)]
+    fn scale_x(&self, value: i32) -> i32 {
+        self.scale.scale_x(value)
+    }
+
+    #[inline(always)]
+    fn scale_y(&self, value: i32) -> i32 {
+        self.scale.scale_y(value)
+    }
+
+    #[inline(always)]
+    fn scale_point(&self, point: (i32, i32)) -> (i32, i32) {
+        (self.scale_x(point.0), self.scale_y(point.1))
+    }
+
+    #[inline(always)]
+    fn scale_extents(&self, extents: GlyphExtents) -> GlyphExtents {
+        self.scale.scale_extents(extents)
+    }
+
+    #[inline(always)]
     pub(crate) fn nominal_glyph(&mut self, c: u32) -> Option<GlyphId> {
         let cache = self.builtin.face.cmap_cache;
         if let Some(gid) = cache.get(c) {
@@ -292,7 +312,7 @@ impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
         if let Some(funcs) = &mut self.funcs {
             funcs.advance_width(&self.builtin, glyph)
         } else {
-            self.builtin.advance_width(glyph)
+            self.scale_x(self.builtin.advance_width(glyph))
         }
     }
 
@@ -301,7 +321,7 @@ impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
         if let Some(funcs) = &mut self.funcs {
             funcs.advance_height(&self.builtin, glyph)
         } else {
-            self.builtin.advance_height(glyph)
+            self.scale_y(self.builtin.advance_height(glyph))
         }
     }
 
@@ -310,7 +330,7 @@ impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
         if let Some(funcs) = &mut self.funcs {
             funcs.vertical_origin(&self.builtin, glyph)
         } else {
-            self.builtin.vertical_origin(glyph)
+            self.scale_point(self.builtin.vertical_origin(glyph))
         }
     }
 
@@ -319,7 +339,7 @@ impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
         if let Some(funcs) = &mut self.funcs {
             funcs.extents(&self.builtin, glyph)
         } else {
-            self.builtin.extents(glyph)
+            Some(self.scale_extents(self.builtin.extents(glyph)?))
         }
     }
 
@@ -327,11 +347,13 @@ impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
         if let Some(funcs) = &mut self.funcs {
             funcs.populate_advance_widths(&self.builtin, batch);
         } else {
-            self.builtin.populate_advance_widths(batch);
+            let font = self.font();
+            font.glyph_metrics.populate_advance_widths(
+                batch.infos,
+                batch.positions,
+                font.coords(),
+                self.scale,
+            );
         }
-    }
-
-    pub(crate) fn has_custom_funcs(&self) -> bool {
-        self.funcs.is_some()
     }
 }

--- a/harfrust/src/hb/font_funcs.rs
+++ b/harfrust/src/hb/font_funcs.rs
@@ -4,6 +4,8 @@ use core::slice;
 
 use read_fonts::types::GlyphId;
 
+use crate::hb::face::Scale;
+
 use super::buffer::{hb_buffer_t, GlyphInfo, GlyphPosition};
 use super::face::{hb_font_t, GlyphExtents};
 
@@ -224,22 +226,31 @@ pub trait FontFuncs {
 
 pub(crate) struct FontFuncsDispatch<'a, 'u> {
     builtin: BuiltinFontFuncs<'a>,
+    scale: Scale,
     funcs: Option<&'u mut (dyn FontFuncs + 'u)>,
 }
 
 impl<'a, 'u> FontFuncsDispatch<'a, 'u> {
     pub(crate) fn new(
         face: &'a hb_font_t<'a>,
+        scale: Scale,
         funcs: Option<&'u mut (dyn FontFuncs + 'u)>,
     ) -> Self {
         Self {
             builtin: BuiltinFontFuncs::new(face),
+            scale,
             funcs,
         }
     }
 
+    #[inline(always)]
     pub(crate) fn font(&self) -> &'a hb_font_t<'a> {
         self.builtin.face
+    }
+
+    #[inline(always)]
+    pub(crate) fn scale(&self) -> &Scale {
+        &self.scale
     }
 
     #[inline(always)]

--- a/harfrust/src/hb/glyph_metrics.rs
+++ b/harfrust/src/hb/glyph_metrics.rs
@@ -1,5 +1,7 @@
-use crate::hb::buffer::hb_buffer_t;
-use crate::{hb::tables::TableRanges, Tag};
+use crate::{
+    hb::{face::Scale, tables::TableRanges},
+    GlyphInfo, GlyphPosition, Tag,
+};
 use read_fonts::{
     tables::{
         glyf::Glyf,
@@ -111,8 +113,14 @@ impl<'a> GlyphMetrics<'a> {
         Some(advance)
     }
 
-    pub fn populate_advance_widths(&self, buf: &mut hb_buffer_t, coords: &[F2Dot14]) {
-        for (info, pos) in buf.info.iter().zip(buf.pos.iter_mut()) {
+    pub(crate) fn populate_advance_widths(
+        &self,
+        infos: &[GlyphInfo],
+        pos: &mut [GlyphPosition],
+        coords: &[F2Dot14],
+        scale: Scale,
+    ) {
+        for (info, pos) in infos.iter().zip(pos.iter_mut()) {
             pos.x_advance = self
                 .h_metrics
                 .get(info.glyph_id as usize)
@@ -123,19 +131,22 @@ impl<'a> GlyphMetrics<'a> {
         }
         if !coords.is_empty() {
             if let Some(hvar) = self.hvar.as_ref() {
-                for (info, pos) in buf.info.iter().zip(buf.pos.iter_mut()) {
+                for (info, pos) in infos.iter().zip(pos.iter_mut()) {
                     pos.x_advance += hvar
                         .advance_width_delta(info.as_glyph(), coords)
                         .unwrap_or_default()
                         .to_i32();
                 }
             } else {
-                for (info, pos) in buf.info.iter().zip(buf.pos.iter_mut()) {
+                for (info, pos) in infos.iter().zip(pos.iter_mut()) {
                     if let Some(deltas) = self.phantom_deltas(info.as_glyph(), coords) {
                         pos.x_advance += deltas[1].x.to_i32() - deltas[0].x.to_i32();
                     }
                 }
             }
+        }
+        for pos in pos.iter_mut() {
+            pos.x_advance = scale.scale_x(pos.x_advance);
         }
     }
 

--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -11,6 +11,7 @@ use read_fonts::{
 use super::aat::layout_common::{AatApplyContext, ClassCache, START_OF_TEXT};
 use super::aat::layout_kerx_table::SimpleKerning;
 use super::buffer::*;
+use super::face::Scale;
 use super::ot_layout::TableIndex;
 use super::ot_layout_common::lookup_flags;
 use super::ot_layout_gpos_table::attach_type;
@@ -33,9 +34,10 @@ pub(crate) fn get_class(machine: &aat::StateTable, glyph_id: GlyphId, cache: &Cl
 pub fn hb_ot_layout_kern(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
+    scale: Scale,
     buffer: &mut hb_buffer_t,
 ) -> Option<()> {
-    let mut c = AatApplyContext::new(plan, face, buffer);
+    let mut c = AatApplyContext::new(plan, face, scale, buffer);
 
     let (kern, subtable_caches) = c.face.aat_tables.kern.as_ref()?;
 
@@ -120,6 +122,7 @@ pub fn hb_ot_layout_kern(
 
 fn machine_kern<F>(
     face: &hb_font_t,
+    scale: Scale,
     buffer: &mut hb_buffer_t,
     kern_mask: hb_mask_t,
     cross_stream: bool,
@@ -128,13 +131,13 @@ fn machine_kern<F>(
     F: Fn(u32, u32) -> i32,
 {
     buffer.unsafe_to_concat(None, None);
-    let mut ctx = hb_ot_apply_context_t::new(TableIndex::GPOS, face, buffer);
+    let mut ctx = hb_ot_apply_context_t::new(TableIndex::GPOS, face, scale, buffer);
     ctx.set_lookup_mask(kern_mask);
     ctx.lookup_props = u32::from(lookup_flags::IGNORE_MARKS);
     ctx.update_matchers();
 
     let horizontal = ctx.buffer.direction.is_horizontal();
-
+    let use_x_scale = horizontal ^ cross_stream;
     let mut i = 0;
     let mut iter = skipping_iterator_t::new(&mut ctx, false);
     while i < iter.buffer.len {
@@ -155,7 +158,11 @@ fn machine_kern<F>(
 
         let info = &iter.buffer.info;
         let kern = get_kerning(info[i].glyph_id, info[j].glyph_id);
-
+        let kern = if use_x_scale {
+            scale.scale_x(kern)
+        } else {
+            scale.scale_y(kern)
+        };
         let pos = &mut iter.buffer.pos;
         if kern != 0 {
             if horizontal {
@@ -199,6 +206,7 @@ fn apply_simple_kerning<T: SimpleKerning>(
 
     machine_kern(
         c.face,
+        c.scale,
         c.buffer,
         c.plan.kern_mask,
         is_cross_stream,
@@ -417,6 +425,8 @@ fn state_machine_transition(
     is_cross_stream: bool,
     driver: &mut StateMachineDriver,
 ) {
+    let scale = c.scale;
+    let use_x_scale = c.buffer.direction.is_horizontal() ^ is_cross_stream;
     let buffer = &mut *c.buffer;
     let kern_mask = c.plan.kern_mask;
 
@@ -455,6 +465,11 @@ fn state_machine_transition(
             // "The end of the list is marked by an odd value..."
             last = v & 1 != 0;
             v &= !1;
+            let scaled_v = if use_x_scale {
+                scale.scale_x(v)
+            } else {
+                scale.scale_y(v)
+            };
 
             // Testing shows that CoreText only applies kern (cross-stream or not)
             // if none has been applied by previous subtables. That is, it does
@@ -473,12 +488,12 @@ fn state_machine_transition(
                         pos.set_attach_chain(0);
                         pos.y_offset = 0;
                     } else if pos.attach_type() != 0 {
-                        pos.y_offset += v;
+                        pos.y_offset += scaled_v;
                         has_gpos_attachment = true;
                     }
                 } else if glyph_mask & kern_mask != 0 {
-                    pos.x_advance += v;
-                    pos.x_offset += v;
+                    pos.x_advance += scaled_v;
+                    pos.x_offset += scaled_v;
                 }
             } else {
                 if is_cross_stream {
@@ -488,13 +503,13 @@ fn state_machine_transition(
                         pos.set_attach_chain(0);
                         pos.x_offset = 0;
                     } else if pos.attach_type() != 0 {
-                        pos.x_offset += v;
+                        pos.x_offset += scaled_v;
                         has_gpos_attachment = true;
                     }
                 } else if glyph_mask & kern_mask != 0 {
                     if pos.y_offset == 0 {
-                        pos.y_advance += v;
-                        pos.y_offset += v;
+                        pos.y_advance += scaled_v;
+                        pos.y_offset += scaled_v;
                     }
                 }
             }

--- a/harfrust/src/hb/ot/gpos/cursive.rs
+++ b/harfrust/src/hb/ot/gpos/cursive.rs
@@ -40,6 +40,10 @@ impl Apply for CursivePosFormat1<'_> {
 
         let (exit_x, exit_y) = ctx.face.ot_tables.resolve_anchor(&exit_prev);
         let (entry_x, entry_y) = ctx.face.ot_tables.resolve_anchor(&entry_this);
+        let exit_x = ctx.scale_x(exit_x);
+        let exit_y = ctx.scale_y(exit_y);
+        let entry_x = ctx.scale_x(entry_x);
+        let entry_y = ctx.scale_y(entry_y);
 
         let direction = ctx.buffer.direction;
         let j = ctx.buffer.idx;

--- a/harfrust/src/hb/ot/gpos/mark.rs
+++ b/harfrust/src/hb/ot/gpos/mark.rs
@@ -30,18 +30,16 @@ impl MarkArrayExt for MarkArray<'_> {
 
         let (base_x, base_y) = ctx.face.ot_tables.resolve_anchor(base_anchor);
         let (mark_x, mark_y) = ctx.face.ot_tables.resolve_anchor(mark_anchor);
-        let base_x = ctx.scale_x(base_x);
-        let base_y = ctx.scale_y(base_y);
-        let mark_x = ctx.scale_x(mark_x);
-        let mark_y = ctx.scale_y(mark_y);
+        let x_offset = ctx.scale_x(base_x - mark_x);
+        let y_offset = ctx.scale_y(base_y - mark_y);
 
         ctx.buffer
             .unsafe_to_break(Some(glyph_pos), Some(ctx.buffer.idx + 1));
 
         let idx = ctx.buffer.idx;
         let pos = ctx.buffer.cur_pos_mut();
-        pos.x_offset = base_x - mark_x;
-        pos.y_offset = base_y - mark_y;
+        pos.x_offset = x_offset;
+        pos.y_offset = y_offset;
         pos.set_attach_type(attach_type::MARK);
         pos.set_attach_chain((glyph_pos as isize - idx as isize) as i16);
 

--- a/harfrust/src/hb/ot/gpos/mark.rs
+++ b/harfrust/src/hb/ot/gpos/mark.rs
@@ -30,6 +30,10 @@ impl MarkArrayExt for MarkArray<'_> {
 
         let (base_x, base_y) = ctx.face.ot_tables.resolve_anchor(base_anchor);
         let (mark_x, mark_y) = ctx.face.ot_tables.resolve_anchor(mark_anchor);
+        let base_x = ctx.scale_x(base_x);
+        let base_y = ctx.scale_y(base_y);
+        let mark_x = ctx.scale_x(mark_x);
+        let mark_y = ctx.scale_y(mark_y);
 
         ctx.buffer
             .unsafe_to_break(Some(glyph_pos), Some(ctx.buffer.idx + 1));

--- a/harfrust/src/hb/ot/gpos/mod.rs
+++ b/harfrust/src/hb/ot/gpos/mod.rs
@@ -19,6 +19,7 @@ fn apply_value(
     mut offset: usize,
     format: ValueFormat,
 ) -> Option<bool> {
+    let scale = ctx.scale;
     let pos = &mut ctx.buffer.pos[idx];
     let is_horizontal = ctx.buffer.direction.is_horizontal();
     let mut worked = false;
@@ -31,21 +32,21 @@ fn apply_value(
         }};
     }
     if format.contains(ValueFormat::X_PLACEMENT) {
-        pos.x_offset += read_value!();
+        pos.x_offset += scale.scale_x(read_value!());
     }
     if format.contains(ValueFormat::Y_PLACEMENT) {
-        pos.y_offset += read_value!();
+        pos.y_offset += scale.scale_y(read_value!());
     }
     if format.contains(ValueFormat::X_ADVANCE) {
         if is_horizontal {
-            pos.x_advance += read_value!();
+            pos.x_advance += scale.scale_x(read_value!());
         } else {
             offset += 2;
         }
     }
     if format.contains(ValueFormat::Y_ADVANCE) {
         if !is_horizontal {
-            pos.y_advance -= read_value!();
+            pos.y_advance -= scale.scale_y(read_value!());
         } else {
             offset += 2;
         }
@@ -79,21 +80,21 @@ fn apply_value(
             }};
         }
         if format.contains(ValueFormat::X_PLACEMENT_DEVICE) {
-            pos.x_offset += read_delta!();
+            pos.x_offset += scale.scale_x(read_delta!());
         }
         if format.contains(ValueFormat::Y_PLACEMENT_DEVICE) {
-            pos.y_offset += read_delta!();
+            pos.y_offset += scale.scale_y(read_delta!());
         }
         if format.contains(ValueFormat::X_ADVANCE_DEVICE) {
             if is_horizontal {
-                pos.x_advance += read_delta!();
+                pos.x_advance += scale.scale_x(read_delta!());
             } else {
                 offset += 2;
             }
         }
         if format.contains(ValueFormat::Y_ADVANCE_DEVICE) {
             if !is_horizontal {
-                pos.y_advance -= read_delta!();
+                pos.y_advance -= scale.scale_y(read_delta!());
             } else {
                 offset += 2;
             }

--- a/harfrust/src/hb/ot_layout.rs
+++ b/harfrust/src/hb/ot_layout.rs
@@ -150,7 +150,7 @@ pub fn apply_layout_table<T: LayoutTable>(
     buffer: &mut hb_buffer_t,
     table: Option<&T>,
 ) {
-    let mut ctx = OT::hb_ot_apply_context_t::new(T::INDEX, face, buffer);
+    let mut ctx = OT::hb_ot_apply_context_t::new(T::INDEX, face, *font_funcs.scale(), buffer);
 
     for (stage_index, stage) in plan.ot_map.stages(T::INDEX).iter().enumerate() {
         if let Some(table) = table {

--- a/harfrust/src/hb/ot_layout_gsubgpos.rs
+++ b/harfrust/src/hb/ot_layout_gsubgpos.rs
@@ -3,6 +3,7 @@
 use super::buffer::GlyphInfo;
 use super::buffer::{hb_buffer_t, GlyphPropsFlags};
 use super::cache::hb_cache_t;
+use super::face::Scale;
 use super::hb_font_t;
 use super::hb_mask_t;
 use super::ot_layout::*;
@@ -853,6 +854,7 @@ pub mod OT {
     pub struct hb_ot_apply_context_t<'a> {
         pub table_index: TableIndex,
         pub face: &'a hb_font_t<'a>,
+        pub scale: Scale,
         pub buffer: &'a mut hb_buffer_t,
         lookup_mask: hb_mask_t,
         pub per_syllable: bool,
@@ -876,11 +878,13 @@ pub mod OT {
         pub fn new(
             table_index: TableIndex,
             face: &'a hb_font_t<'a>,
+            scale: Scale,
             buffer: &'a mut hb_buffer_t,
         ) -> Self {
             Self {
                 table_index,
                 face,
+                scale,
                 buffer,
                 lookup_mask: 1,
                 per_syllable: false,
@@ -899,6 +903,16 @@ pub mod OT {
                 match_positions_len: 0,
                 match_positions: MatchPositions::from_elem(0, 1),
             }
+        }
+
+        #[inline(always)]
+        pub fn scale_x(&self, value: i32) -> i32 {
+            self.scale.scale_x(value)
+        }
+
+        #[inline(always)]
+        pub fn scale_y(&self, value: i32) -> i32 {
+            self.scale.scale_y(value)
         }
 
         pub fn random_number(&mut self) -> u32 {

--- a/harfrust/src/hb/ot_shape.rs
+++ b/harfrust/src/hb/ot_shape.rs
@@ -329,12 +329,6 @@ impl OtShapeContext<'_, '_> {
         if self.buffer.len == 0 {
             return;
         }
-
-        if !self.font_funcs.has_custom_funcs() {
-            self.face.glyph_h_advances(self.buffer);
-            return;
-        }
-
         let batched_advances = AdvanceWidthBatch::new(self.buffer);
         self.font_funcs.populate_advance_widths(batched_advances);
     }
@@ -539,16 +533,22 @@ impl OtShapeContext<'_, '_> {
         if plan.apply_gpos {
             ot_layout_gpos_table::position(plan, face, self.font_funcs, buffer);
         } else if plan.apply_kerx {
-            aat::layout::position(plan, face, buffer);
+            aat::layout::position(plan, face, *self.font_funcs.scale(), buffer);
         }
         if plan.apply_kern {
-            kerning::hb_ot_layout_kern(plan, face, buffer);
+            kerning::hb_ot_layout_kern(plan, face, *self.font_funcs.scale(), buffer);
         } else if plan.apply_fallback_kern {
             ot_shape_fallback::_hb_ot_shape_fallback_kern(plan, face, buffer);
         }
 
         if plan.apply_trak {
-            aat::layout::track(plan, face, self.point_size, buffer);
+            aat::layout::track(
+                plan,
+                face,
+                *self.font_funcs.scale(),
+                self.point_size,
+                buffer,
+            );
         }
     }
 

--- a/harfrust/src/hb/ot_shape_fallback.rs
+++ b/harfrust/src/hb/ot_shape_fallback.rs
@@ -144,7 +144,7 @@ fn position_mark(
         return;
     };
 
-    let y_gap = face.units_per_em as i32 / 16;
+    let y_gap = font_funcs.scale().scale_y(face.units_per_em as i32 / 16);
     pos.x_offset = 0;
     pos.y_offset = 0;
 
@@ -445,6 +445,7 @@ pub fn _hb_ot_shape_fallback_spaces<'a, 'x>(
     let _ = plan;
     let len = buffer.len;
     let horizontal = buffer.direction.is_horizontal();
+    let scale = *font_funcs.scale();
     for (info, pos) in buffer.info[..len].iter().zip(&mut buffer.pos[..len]) {
         if info.is_unicode_space() && !info.ligated() {
             let space_type = info.unicode_space_fallback_type();
@@ -459,18 +460,18 @@ pub fn _hb_ot_shape_fallback_spaces<'a, 'x>(
                     let length =
                         (face.units_per_em as i32 + (space_type as i32) / 2) / space_type as i32;
                     if horizontal {
-                        pos.x_advance = length;
+                        pos.x_advance = scale.scale_x(length);
                     } else {
-                        pos.y_advance = -length;
+                        pos.y_advance = -scale.scale_y(length);
                     }
                 }
 
                 t::SPACE_4_EM_18 => {
                     let length = ((face.units_per_em as i64) * 4 / 18) as i32;
                     if horizontal {
-                        pos.x_advance = length;
+                        pos.x_advance = scale.scale_x(length);
                     } else {
-                        pos.y_advance = -length;
+                        pos.y_advance = -scale.scale_y(length);
                     }
                 }
 

--- a/harfrust/tests/scaling.rs
+++ b/harfrust/tests/scaling.rs
@@ -1,0 +1,221 @@
+use std::fs;
+use std::path::PathBuf;
+
+use harfrust::{
+    funcs::{AdvanceWidthBatch, BuiltinFontFuncs, FontFuncs},
+    FontRef, ShapeOptions, ShaperData, UnicodeBuffer,
+};
+use read_fonts::types::GlyphId;
+
+fn test_font_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fonts")
+        .join("rb_custom")
+        .join("OpenSans.subset1.ttf")
+}
+
+fn with_test_shaper<T>(f: impl FnOnce(&harfrust::Shaper) -> T) -> T {
+    let font_data = fs::read(test_font_path()).expect("failed to read test font");
+    let font = FontRef::new(&font_data).expect("failed to parse test font");
+    let data = ShaperData::new(&font);
+    let shaper = data.shaper(&font).build();
+    f(&shaper)
+}
+
+fn with_test_shaper_from_path<T>(font_path: PathBuf, f: impl FnOnce(&harfrust::Shaper) -> T) -> T {
+    let font_data = fs::read(font_path).expect("failed to read test font");
+    let font = FontRef::new(&font_data).expect("failed to parse test font");
+    let data = ShaperData::new(&font);
+    let shaper = data.shaper(&font).build();
+    f(&shaper)
+}
+
+fn buffer_with_text(text: &str) -> UnicodeBuffer {
+    let mut buffer = UnicodeBuffer::new();
+    buffer.push_str(text);
+    buffer.guess_segment_properties();
+    buffer
+}
+
+fn assert_positions_scaled(
+    baseline: &[harfrust::GlyphPosition],
+    scaled: &[harfrust::GlyphPosition],
+    factor: i32,
+) {
+    assert_eq!(baseline.len(), scaled.len());
+    for (baseline, scaled) in baseline.iter().zip(scaled) {
+        assert_eq!(scaled.x_advance, baseline.x_advance * factor);
+        assert_eq!(scaled.y_advance, baseline.y_advance * factor);
+        assert!((scaled.x_offset - baseline.x_offset * factor).abs() <= 1);
+        assert!((scaled.y_offset - baseline.y_offset * factor).abs() <= 1);
+    }
+}
+
+#[test]
+fn font_funcs_batch_advance_override_is_used_with_scale() {
+    struct BatchAdvanceFuncs {
+        batch_calls: usize,
+    }
+
+    impl FontFuncs for BatchAdvanceFuncs {
+        fn populate_advance_widths(&mut self, _: &BuiltinFontFuncs, batch: AdvanceWidthBatch) {
+            self.batch_calls += 1;
+            assert!(!batch.is_empty());
+            for (_, advance) in batch {
+                *advance = 777;
+            }
+        }
+    }
+
+    let mut funcs = BatchAdvanceFuncs { batch_calls: 0 };
+
+    let glyphs = with_test_shaper(|shaper| {
+        shaper.shape(
+            buffer_with_text("abc"),
+            ShapeOptions::new()
+                .scale(Some(shaper.units_per_em() * 2))
+                .font_funcs(Some(&mut funcs)),
+        )
+    });
+
+    assert!(funcs.batch_calls > 0);
+    assert!(!glyphs.glyph_positions().is_empty());
+    assert!(glyphs
+        .glyph_positions()
+        .iter()
+        .all(|pos| pos.x_advance == 777));
+}
+
+#[test]
+fn font_funcs_advance_width_override_is_not_scaled() {
+    struct AdvanceFuncs;
+
+    impl FontFuncs for AdvanceFuncs {
+        fn advance_width(&mut self, _: &BuiltinFontFuncs, _: GlyphId) -> i32 {
+            100
+        }
+    }
+
+    let mut funcs = AdvanceFuncs;
+
+    let glyphs = with_test_shaper(|shaper| {
+        shaper.shape(
+            buffer_with_text("abc"),
+            ShapeOptions::new()
+                .scale(Some(shaper.units_per_em() * 2))
+                .font_funcs(Some(&mut funcs)),
+        )
+    });
+
+    assert!(glyphs
+        .glyph_positions()
+        .iter()
+        .all(|pos| pos.x_advance == 100));
+}
+
+fn aat_kern_font_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fonts")
+        .join("text-rendering-tests")
+        .join("TestKERNOne.otf")
+}
+
+#[test]
+fn aat_kern_scale_doubles_advances_and_offsets() {
+    // TestKERNOne.otf: the u-T and T-u pairs carry an AAT kern value, so
+    // both advances and any x-offsets must be doubled at 2× scale.
+    let (baseline, scaled) = with_test_shaper_from_path(aat_kern_font_path(), |shaper| {
+        let text = "\u{0131}\u{0054}\u{0075}\u{0054}\u{0075}\u{0054}\u{0131}";
+        let baseline = shaper.shape(buffer_with_text(text), ShapeOptions::new());
+        let scaled = shaper.shape(
+            buffer_with_text(text),
+            ShapeOptions::new().scale(Some(shaper.units_per_em() * 2)),
+        );
+        (baseline, scaled)
+    });
+
+    assert_eq!(baseline.glyph_infos().len(), scaled.glyph_infos().len());
+    assert_positions_scaled(baseline.glyph_positions(), scaled.glyph_positions(), 2);
+}
+
+#[test]
+fn aat_kern_negative_scale_flips_advances() {
+    let (baseline, scaled) = with_test_shaper_from_path(aat_kern_font_path(), |shaper| {
+        let text = "\u{0131}\u{0054}\u{0075}\u{0054}\u{0075}\u{0054}\u{0131}";
+        let baseline = shaper.shape(buffer_with_text(text), ShapeOptions::new());
+        let scaled = shaper.shape(
+            buffer_with_text(text),
+            ShapeOptions::new().scale(Some(-(shaper.units_per_em() * 2))),
+        );
+        (baseline, scaled)
+    });
+
+    assert_eq!(baseline.glyph_infos().len(), scaled.glyph_infos().len());
+    for (b, s) in baseline
+        .glyph_positions()
+        .iter()
+        .zip(scaled.glyph_positions())
+    {
+        assert_eq!(s.x_advance, -(b.x_advance * 2));
+        assert_eq!(s.y_advance, -(b.y_advance * 2));
+    }
+}
+
+#[test]
+fn shape_scale_doubles_positioned_output() {
+    let font_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fonts")
+        .join("in-house")
+        .join("8228d035fcd65d62ec9728fb34f42c63be93a5d3.ttf");
+
+    let (baseline, scaled) = with_test_shaper_from_path(font_path, |shaper| {
+        let text = "x\u{0301}AVX\u{0301}";
+        let baseline = shaper.shape(buffer_with_text(text), ShapeOptions::new());
+        let scaled = shaper.shape(
+            buffer_with_text(text),
+            ShapeOptions::new().scale(Some(shaper.units_per_em() * 2)),
+        );
+        (baseline, scaled)
+    });
+
+    assert_eq!(baseline.glyph_infos().len(), scaled.glyph_infos().len());
+    assert_eq!(
+        baseline
+            .glyph_infos()
+            .iter()
+            .map(|info| info.glyph_id)
+            .collect::<Vec<_>>(),
+        scaled
+            .glyph_infos()
+            .iter()
+            .map(|info| info.glyph_id)
+            .collect::<Vec<_>>()
+    );
+    assert_positions_scaled(baseline.glyph_positions(), scaled.glyph_positions(), 2);
+}
+
+#[test]
+fn shape_negative_scale_flips_and_doubles_advances() {
+    let (baseline, scaled) = with_test_shaper(|shaper| {
+        let text = "abc";
+        let baseline = shaper.shape(buffer_with_text(text), ShapeOptions::new());
+        let scaled = shaper.shape(
+            buffer_with_text(text),
+            ShapeOptions::new().scale(Some(-(shaper.units_per_em() * 2))),
+        );
+        (baseline, scaled)
+    });
+
+    assert_eq!(baseline.glyph_infos().len(), scaled.glyph_infos().len());
+    for (baseline, scaled) in baseline
+        .glyph_positions()
+        .iter()
+        .zip(scaled.glyph_positions())
+    {
+        assert_eq!(scaled.x_advance, -(baseline.x_advance * 2));
+        assert_eq!(scaled.y_advance, -(baseline.y_advance * 2));
+    }
+}


### PR DESCRIPTION
The `ShapeOptions` type has two new methods `scale()` and `scale_separate()` that allows the user to provide scaling factors which are then applied to various values throughout the shaping pipeline. Values coming from `FontFuncs` overrides are assumed to already be scaled.

This needs some new doc comments to properly describe how scaling works but I'm sending this now for testing purposes.

edit: used some copilot assistance for this task