### PR TITLE
0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-28
+
+This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
+and has an MSRV (minimum supported Rust version) of 1.85.
+
+- Added support for font function overrides to enable injection of hinted metrics and control
+  over character mapping. See `FontFuncs` and `ShapeOptions::font_funcs`.
+- Added internal scaling support. See `ShapeOptions::scale` and `ShapeOptions::scale_separate`.
+
 ## [0.8.0] - 2026-05-26
 
 This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
@@ -155,7 +164,8 @@ This release matches HarfBuzz [v11.2.1][harfbuzz-11.2.1], and has an MSRV (minim
 HarfRust is a fork of RustyBuzz.
 See [their changelog](https://github.com/harfbuzz/rustybuzz/blob/main/CHANGELOG.md) for details of prior releases.
 
-[Unreleased]: https://github.com/harfbuzz/harfrust/compare/0.8.0...HEAD
+[Unreleased]: https://github.com/harfbuzz/harfrust/compare/0.8.1...HEAD
+[0.8.1]: https://github.com/harfbuzz/harfrust/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/harfbuzz/harfrust/compare/0.7.1...0.8.0
 [0.7.1]: https://github.com/harfbuzz/harfrust/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/harfbuzz/harfrust/compare/0.6.2...0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["harfrust", "hr-shape", "fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.85"  # should match https://github.com/googlefonts/fontations/blob/main/Cargo.toml
 description = "A complete HarfBuzz shaping algorithm port to Rust."
@@ -22,7 +22,7 @@ codegen-units = 1
 inherits = "release"
 
 [workspace.dependencies]
-harfrust = { version = "0.8.0", path = "./harfrust", default-features = false }
+harfrust = { version = "0.8.1", path = "./harfrust", default-features = false }
 read-fonts = { version = "0.39.0", default-features = false }
 
 [workspace.lints.rust]


### PR DESCRIPTION
This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0), and has an MSRV (minimum supported Rust version) of 1.85.

- Added support for font function overrides to enable injection of hinted metrics and control over character mapping. See `FontFuncs` and `ShapeOptions::font_funcs`.
- Added internal scaling support. See `ShapeOptions::scale` and `ShapeOptions::scale_separate`.