### PR TITLE
Re-export GlyphId

### DIFF
--- a/harfrust/src/lib.rs
+++ b/harfrust/src/lib.rs
@@ -19,7 +19,10 @@ mod digest_u32_set;
 #[cfg(not(feature = "std"))]
 pub(crate) type U32Set = digest_u32_set::DigestU32Set;
 
-pub use read_fonts::{types::Tag, FontRef};
+pub use read_fonts::{
+    types::{GlyphId, Tag},
+    FontRef,
+};
 
 pub use hb::buffer::{GlyphBuffer, GlyphInfo, GlyphPosition, UnicodeBuffer};
 pub use hb::common::{script, Direction, Feature, Language, Script, Variation};


### PR DESCRIPTION
This is now used in `FontFuncs` and currently requires the user to add an explicit `read-fonts` or `font-types` dependency to access it.