### PR TITLE
[aat] Mark in-place deleted glyph replacements

### DIFF
--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -157,6 +157,10 @@ impl<'a> AatApplyContext<'a> {
 
     pub fn replace_glyph_inplace(&mut self, i: usize, glyph: u32) {
         self.buffer.info[i].glyph_id = glyph;
+        if glyph == DELETED_GLYPH {
+            self.buffer.scratch_flags |= HB_BUFFER_SCRATCH_FLAG_AAT_HAS_DELETED;
+            self.buffer.info[i].set_aat_deleted();
+        }
         if self.using_buffer_glyph_set {
             self.buffer.glyph_set.insert(glyph);
         }


### PR DESCRIPTION
Contextual and non-contextual AAT subtables replace glyphs in place. When such a replacement produced the AAT deleted glyph, we changed only the glyph ID and did not set the AAT-deleted metadata that later cleanup uses to remove deleted glyphs from the buffer.

Make replace_glyph_inplace() match the other AAT replacement helpers (output_glyph, replace_glyph, delete_glyph) by setting the deleted scratch flag and glyph-info marker for glyph 0xFFFF.

This surfaced when shaping Apple Color Emoji, whose morx noncontextual subtable deletes the U+FE0F variation selector in place: the deleted glyph was retained and later shown as a zero-advance space, so e.g. "❤️" shaped as [u2764|space=0+0] instead of [u2764].

Port of harfbuzz/harfbuzz commit
f9d86e2d73bb57239ad37da1bd5e7bc9f1bf7720.

Testing:
- cargo run -p hr-shape -- "Apple Color Emoji.ttc" ❤️ now prints [u2764=0+800] (was [u2764=0+800|space=0+0])
- cargo test -p harfrust  (6146 passed)