### PR TITLE
0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-06-02
+
+This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
+and has an MSRV (minimum supported Rust version) of 1.85.
+
+- Use bytes instead of str storage for language tag table.
+
 ## [0.8.3] - 2026-06-01
 
 This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
@@ -184,7 +191,8 @@ This release matches HarfBuzz [v11.2.1][harfbuzz-11.2.1], and has an MSRV (minim
 HarfRust is a fork of RustyBuzz.
 See [their changelog](https://github.com/harfbuzz/rustybuzz/blob/main/CHANGELOG.md) for details of prior releases.
 
-[Unreleased]: https://github.com/harfbuzz/harfrust/compare/0.8.3...HEAD
+[Unreleased]: https://github.com/harfbuzz/harfrust/compare/0.8.4...HEAD
+[0.8.4]: https://github.com/harfbuzz/harfrust/compare/0.8.3...0.8.4
 [0.8.3]: https://github.com/harfbuzz/harfrust/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/harfbuzz/harfrust/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/harfbuzz/harfrust/compare/0.8.0...0.8.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["harfrust", "hr-shape", "fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 rust-version = "1.85"  # should match https://github.com/googlefonts/fontations/blob/main/Cargo.toml
 description = "A complete HarfBuzz shaping algorithm port to Rust."


### PR DESCRIPTION
This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0), and has an MSRV (minimum supported Rust version) of 1.85.

- Use bytes instead of str storage for language tag table.