### PR TITLE
Release 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-06-02
+
+This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
+and has an MSRV (minimum supported Rust version) of 1.85.
+
+- Fix GPOS attachment offset overflow #384
+- Require read-fonts 0.40.
+
 ## [0.8.4] - 2026-06-02
 
 This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),
@@ -192,6 +200,7 @@ HarfRust is a fork of RustyBuzz.
 See [their changelog](https://github.com/harfbuzz/rustybuzz/blob/main/CHANGELOG.md) for details of prior releases.
 
 [Unreleased]: https://github.com/harfbuzz/harfrust/compare/0.8.4...HEAD
+[0.8.5]: https://github.com/harfbuzz/harfrust/compare/0.8.4...0.8.5
 [0.8.4]: https://github.com/harfbuzz/harfrust/compare/0.8.3...0.8.4
 [0.8.3]: https://github.com/harfbuzz/harfrust/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/harfbuzz/harfrust/compare/0.8.1...0.8.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["harfrust", "hr-shape", "fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 rust-version = "1.85"  # should match https://github.com/googlefonts/fontations/blob/main/Cargo.toml
 description = "A complete HarfBuzz shaping algorithm port to Rust."
@@ -22,8 +22,8 @@ codegen-units = 1
 inherits = "release"
 
 [workspace.dependencies]
-harfrust = { version = "0.8.4", path = "./harfrust", default-features = false }
-read-fonts = { version = "0.39.0", default-features = false }
+harfrust = { version = "0.8.5", path = "./harfrust", default-features = false }
+read-fonts = { version = "0.40.0", default-features = false }
 
 [workspace.lints.rust]
 unused_qualifications = "warn"


### PR DESCRIPTION
This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0), and has an MSRV (minimum supported Rust version) of 1.85.

- Fix GPOS attachment offset overflow #384
- Require read-fonts 0.40.