### PR TITLE
Fix integer overflow in fallback positioning shaper

### DIFF
--- a/harfrust/src/hb/ot_shape_fallback.rs
+++ b/harfrust/src/hb/ot_shape_fallback.rs
@@ -155,30 +155,38 @@ fn position_mark(
         combining_class::DoubleBelow | combining_class::DoubleAbove
             if direction.is_horizontal() =>
         {
-            pos.x_offset += base_extents.x_bearing
-                + if direction.is_forward() {
+            pos.x_offset = pos
+                .x_offset
+                .saturating_add(base_extents.x_bearing)
+                .saturating_add(if direction.is_forward() {
                     base_extents.width
                 } else {
                     0
-                }
-                - mark_extents.width / 2
-                - mark_extents.x_bearing;
+                })
+                .saturating_sub(mark_extents.width / 2)
+                .saturating_sub(mark_extents.x_bearing);
         }
 
         combining_class::AttachedBelowLeft
         | combining_class::BelowLeft
         | combining_class::AboveLeft => {
             // Left align.
-            pos.x_offset += base_extents.x_bearing - mark_extents.x_bearing;
+            pos.x_offset = pos
+                .x_offset
+                .saturating_add(base_extents.x_bearing)
+                .saturating_sub(mark_extents.x_bearing);
         }
 
         combining_class::AttachedAboveRight
         | combining_class::BelowRight
         | combining_class::AboveRight => {
             // Right align.
-            pos.x_offset += base_extents.x_bearing + base_extents.width
-                - mark_extents.width
-                - mark_extents.x_bearing;
+            pos.x_offset = pos
+                .x_offset
+                .saturating_add(base_extents.x_bearing)
+                .saturating_add(base_extents.width)
+                .saturating_sub(mark_extents.width)
+                .saturating_sub(mark_extents.x_bearing);
         }
 
         combining_class::AttachedBelow
@@ -187,8 +195,11 @@ fn position_mark(
         | combining_class::Above
         | _ => {
             // Center align.
-            pos.x_offset += base_extents.x_bearing + (base_extents.width - mark_extents.width) / 2
-                - mark_extents.x_bearing;
+            pos.x_offset = pos
+                .x_offset
+                .saturating_add(base_extents.x_bearing)
+                .saturating_add((base_extents.width.saturating_sub(mark_extents.width)) / 2)
+                .saturating_sub(mark_extents.x_bearing);
         }
     }
 
@@ -210,18 +221,21 @@ fn position_mark(
         | combining_class::AttachedBelow => {
             if !is_attached {
                 // Add gap.
-                base_extents.height -= y_gap;
+                base_extents.height = base_extents.height.saturating_sub(y_gap);
             }
 
-            pos.y_offset = base_extents.y_bearing + base_extents.height - mark_extents.y_bearing;
+            pos.y_offset = base_extents
+                .y_bearing
+                .saturating_add(base_extents.height)
+                .saturating_sub(mark_extents.y_bearing);
 
             // Never shift up "below" marks.
             if (y_gap > 0) == (pos.y_offset > 0) {
-                base_extents.height -= pos.y_offset;
+                base_extents.height = base_extents.height.saturating_sub(pos.y_offset);
                 pos.y_offset = 0;
             }
 
-            base_extents.height += mark_extents.height;
+            base_extents.height = base_extents.height.saturating_add(mark_extents.height);
         }
 
         combining_class::DoubleAbove
@@ -232,22 +246,24 @@ fn position_mark(
         | combining_class::AttachedAboveRight => {
             if !is_attached {
                 // Add gap.
-                base_extents.y_bearing += y_gap;
-                base_extents.height -= y_gap;
+                base_extents.y_bearing = base_extents.y_bearing.saturating_add(y_gap);
+                base_extents.height = base_extents.height.saturating_sub(y_gap);
             }
 
-            pos.y_offset = base_extents.y_bearing - (mark_extents.y_bearing + mark_extents.height);
+            pos.y_offset = base_extents
+                .y_bearing
+                .saturating_sub(mark_extents.y_bearing.saturating_add(mark_extents.height));
 
             // Don't shift down "above" marks too much.
             if (y_gap > 0) != (pos.y_offset > 0) {
                 let correction = -pos.y_offset / 2;
-                base_extents.y_bearing += correction;
-                base_extents.height -= correction;
-                pos.y_offset += correction;
+                base_extents.y_bearing = base_extents.y_bearing.saturating_add(correction);
+                base_extents.height = base_extents.height.saturating_sub(correction);
+                pos.y_offset = pos.y_offset.saturating_add(correction);
             }
 
-            base_extents.y_bearing -= mark_extents.height;
-            base_extents.height += mark_extents.height;
+            base_extents.y_bearing = base_extents.y_bearing.saturating_sub(mark_extents.height);
+            base_extents.height = base_extents.height.saturating_add(mark_extents.height);
         }
 
         _ => {}

--- a/harfrust/tests/shaping/regressions.rs
+++ b/harfrust/tests/shaping/regressions.rs
@@ -10,8 +10,11 @@ fn font_path(name: &str) -> PathBuf {
         .join(name)
 }
 
+// This test uses `TestGPOSThree.ttf`, which has a GPOS table.
+// It verifies that GPOS attachment offset propagation scales safely without integer overflow
+// for extremely long grapheme clusters (as fixed in commit 6bccd74).
 #[test]
-fn issue_384_overly_long_grapheme_cluster_does_not_overflow() {
+fn issue_384_overly_long_grapheme_cluster_gpos_does_not_overflow() {
     let font_data = fs::read(font_path("TestGPOSThree.ttf")).expect("failed to read test font");
     let font = FontRef::new(&font_data).expect("failed to parse test font");
     let data = ShaperData::new(&font);
@@ -27,4 +30,27 @@ fn issue_384_overly_long_grapheme_cluster_does_not_overflow() {
     buffer.guess_segment_properties();
 
     shaper.shape(buffer, ShapeOptions::new());
+}
+
+// Uses `Calculator-Regular.ttf` (no GPOS table) to verify fallback mark positioning.
+// A large scale factor amplifies mark heights, triggering fallback integer overflows
+// with a lower grapheme count of 5,000.
+#[test]
+fn issue_384_overly_long_grapheme_cluster_fallback_does_not_overflow() {
+    let font_data =
+        fs::read(font_path("Calculator-Regular.ttf")).expect("failed to read test font");
+    let font = FontRef::new(&font_data).expect("failed to parse test font");
+    let data = ShaperData::new(&font);
+    let shaper = data.shaper(&font).build();
+
+    let mut text = String::with_capacity(5002);
+    text.push('e');
+    text.extend(std::iter::repeat_n('\u{0301}', 5000));
+    text.push('X');
+
+    let mut buffer = UnicodeBuffer::new();
+    buffer.push_str(&text);
+    buffer.guess_segment_properties();
+
+    shaper.shape(buffer, ShapeOptions::new().scale(Some(10_000_000)));
 }


### PR DESCRIPTION
The fallback mark positioning shaper (position_marks in ot_shape_fallback.rs) accumulated mark heights using standard arithmetic operators (+= and -=). For extremely long grapheme clusters with tens of thousands of diacritics, these accumulations can overflow the bounds of 32-bit signed integers (i32), resulting in panics.

This patch updates all positioning calculations in position_mark to use safe saturating operations (saturating_add, saturating_sub). We also add a regression test case (issue_384_overly_long_grapheme_cluster_fallback_does_not_overflow) using a GPOS-less font (Calculator-Regular.ttf) and a large scale factor to reliably trigger and verify this behavior.

Fixes #394.

Assisted-by: Gemini