### PR TITLE
[trak] Keep tracking fractional

### DIFF
--- a/harfrust/src/hb/aat/layout_trak_table.rs
+++ b/harfrust/src/hb/aat/layout_trak_table.rs
@@ -27,9 +27,9 @@ pub fn apply(
     }
 
     let advance_to_add = if buffer.direction.is_horizontal() {
-        scale.scale_x(trak.get_h_tracking(ptem, 0.0))
+        scale.scale_x_f(trak.get_h_tracking(ptem, 0.0))
     } else {
-        scale.scale_y(trak.get_v_tracking(ptem, 0.0))
+        scale.scale_y_f(trak.get_v_tracking(ptem, 0.0))
     };
 
     foreach_grapheme!(buffer, start, end, {
@@ -44,21 +44,27 @@ pub fn apply(
 }
 
 trait TrakExt {
-    fn get_h_tracking(&self, ptem: f32, track: f32) -> i32;
-    fn get_v_tracking(&self, ptem: f32, track: f32) -> i32;
+    fn get_h_tracking(&self, ptem: f32, track: f32) -> f32;
+    fn get_v_tracking(&self, ptem: f32, track: f32) -> f32;
 }
 
 impl TrakExt for read_fonts::tables::trak::Trak<'_> {
-    fn get_h_tracking(&self, ptem: f32, track: f32) -> i32 {
-        self.horiz().transpose().ok().flatten().map_or(0, |t| {
-            t.get_tracking(self.offset_data(), ptem, track).round() as i32
-        })
+    // Keep tracking fractional; scale_x_f rounds once, matching HarfBuzz's
+    // em_scalef (the interpolated value is generally not a whole font unit).
+    fn get_h_tracking(&self, ptem: f32, track: f32) -> f32 {
+        self.horiz()
+            .transpose()
+            .ok()
+            .flatten()
+            .map_or(0.0, |t| t.get_tracking(self.offset_data(), ptem, track))
     }
 
-    fn get_v_tracking(&self, ptem: f32, track: f32) -> i32 {
-        self.vert().transpose().ok().flatten().map_or(0, |t| {
-            t.get_tracking(self.offset_data(), ptem, track).round() as i32
-        })
+    fn get_v_tracking(&self, ptem: f32, track: f32) -> f32 {
+        self.vert()
+            .transpose()
+            .ok()
+            .flatten()
+            .map_or(0.0, |t| t.get_tracking(self.offset_data(), ptem, track))
     }
 }
 


### PR DESCRIPTION
Follow-up to #403, applying the same fix to the AAT `trak` table.

## Problem

The `trak` tracking value is interpolated by point size and is generally not a
whole font unit, but `get_h_tracking` / `get_v_tracking` rounded it to an
integer before scaling. HarfBuzz keeps it fractional and rounds only once,
after scaling to output units (`get_h_tracking` is
`em_scalef_x(get_tracking())`).

## Fix

Return the fractional tracking and scale it with the `Scale::scale_x_f` /
`scale_y_f` helpers (added in #403).

## Testing

Comparing the `ot` and `harfrust` shapers on `SFNSItalic.ttf` (`"System
italic"`, size 20, weight 500) across point sizes 14–26 in 0.5 steps:

- **Before:** at sizes where the tracking interpolates to a fractional value
  (20.5, 21.5, 22.5, 23.5, 24.5, 25.0, 25.5) every glyph's advance differed
  from `ot` by up to ±0.5 font units (±0.0049px); integer-tracking sizes
  already matched.
- **After:** exact `0.000000px` match at every size.

`cargo test -p harfrust`: 6027 passed, 0 failed.
