### PR TITLE
[api] Gate the experimental shape() free function

### DIFF
--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -436,6 +436,7 @@ impl Scale {
 ///
 /// Will panic when debugging assertions are enabled if the buffer and plan have mismatched
 /// properties.
+#[cfg(feature = "experimental_font_api")]
 pub fn shape(
     font: &crate::font::FontInstance,
     mut buffer: UnicodeBuffer,


### PR DESCRIPTION
Small follow-up spotted during the 0.12.0 publish verification.

The `harfrust::shape` free function is re-exported only under the
`experimental_font_api` feature (`lib.rs`):

```rust
#[cfg(feature = "experimental_font_api")]
pub use hb::face::shape;
```

…but its definition in `hb/face.rs` was not gated. In a default-feature build
the re-export is compiled out while the function remains, so it is unreachable
and warns as dead code — which surfaces during `cargo publish` verification
(that builds with default features).

Gate the definition with the same `#[cfg(feature = "experimental_font_api")]`.
No functional change; the experimental API is unchanged, and there is no
cascade (its helpers stay reachable via other paths).

## Testing
- Default build: the dead_code warning is gone.
- `--features experimental_font_api`: compiles, API intact.
- `cargo test -p harfrust`: 6027 passed.
- `cargo fmt --check` clean.
