### PR TITLE
Guard cursive attachment against out-of-bounds attach_chain offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Guard GPOS cursive attachment against out-of-bounds `attach_chain` offsets
+  that could panic on buffers longer than 32767 glyphs (#411).
+
 ## [0.12.0] - 2026-07-03
 
 This release matches HarfBuzz [v14.2.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0),

--- a/harfrust/src/hb/ot/gpos/cursive.rs
+++ b/harfrust/src/hb/ot/gpos/cursive.rs
@@ -105,7 +105,14 @@ impl Apply for CursivePosFormat1<'_> {
         reverse_cursive_minor_offset(pos, child, direction, parent);
 
         pos[child].set_attach_type(attach_type::CURSIVE);
-        pos[child].set_attach_chain((parent as isize - child as isize) as i16);
+        let chain = parent as isize - child as isize;
+        pos[child].set_attach_chain(chain as i16);
+        // If the distance between the two glyphs does not fit in the i16 chain
+        // field it would be truncated to a bogus value; leave the glyph
+        // unattached instead of storing a poisoned chain. Matches HarfBuzz.
+        if isize::from(pos[child].attach_chain()) != chain {
+            pos[child].set_attach_chain(0);
+        }
 
         ctx.buffer.scratch_flags |= HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_ATTACHMENT;
         if direction.is_horizontal() {
@@ -145,8 +152,16 @@ fn reverse_cursive_minor_offset(
 
     pos[i].set_attach_chain(0);
 
+    let j = (i as isize + isize::from(chain)) as usize;
+
+    // The chain is an i16 distance that can be truncated for very long buffers,
+    // so `i + chain` may fall outside the buffer; stop instead of indexing out
+    // of bounds. Matches HarfBuzz's `if (j >= len) return;`.
+    if j >= pos.len() {
+        return;
+    }
+
     // Stop if we see new parent in the chain.
-    let j = (i as isize + isize::from(chain)) as _;
     if j == new_parent {
         return;
     }
@@ -161,4 +176,24 @@ fn reverse_cursive_minor_offset(
 
     pos[j].set_attach_chain(-chain);
     pos[j].set_attach_type(attach_type);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reverse_cursive_minor_offset_ignores_out_of_range_chain() {
+        // A truncated attach_chain can make `i + chain` point past the end of
+        // the buffer; reverse_cursive_minor_offset must not index out of
+        // bounds. See https://github.com/harfbuzz/harfrust/issues/410.
+        let mut pos = vec![GlyphPosition::default(); 4];
+        pos[0].set_attach_type(attach_type::CURSIVE);
+        pos[0].set_attach_chain(30000); // 0 + 30000 is far past the buffer end
+
+        reverse_cursive_minor_offset(&mut pos, 0, Direction::LeftToRight, 3);
+
+        // The out-of-range link is cleared and no other glyph is touched.
+        assert_eq!(pos[0].attach_chain(), 0);
+    }
 }


### PR DESCRIPTION
### Summary

Fixes #410. GPOS cursive attachment can panic with an out-of-bounds slice index, reachable from the public `shape()` API with a spec-valid font.

### Root cause

The cursive attachment chain is stored as an `i16` distance between two buffer positions:

```rust
pos[child].set_attach_chain((parent as isize - child as isize) as i16);
```

For a buffer longer than 32767 glyphs (e.g. an Arabic base followed by a very long run of marks skipped via `IgnoreMarks`, then another base) this distance overflows `i16` and is silently truncated. `reverse_cursive_minor_offset` then does:

```rust
let j = (i as isize + isize::from(chain)) as _;
// ... no bounds check ...
reverse_cursive_minor_offset(pos, j, direction, new_parent); // pos[j] indexed
```

so a truncated `chain` makes `j` fall outside the buffer and `pos[j]` panics with `index out of range`.

### Fix

This restores the two guards that HarfBuzz's `CursivePosFormat1` has and the port dropped:

1. **Store site** — if the distance does not fit in `i16`, leave the glyph unattached (chain `0`) instead of storing a truncated value. Mirrors upstream:
   ```cpp
   pos[child].attach_chain() = (int) parent - (int) child;
   if (pos[child].attach_chain() != (int) parent - (int) child)
     pos[child].attach_chain() = 0;
   ```
2. **`reverse_cursive_minor_offset`** — bound-check `j` against the buffer length before indexing. Mirrors upstream's `if (unlikely (j >= len)) return;`.

Both are the same class of overflow/bounds hardening as recently merged #400 / #395 / #391.

### Test

Added a unit test (`reverse_cursive_minor_offset_ignores_out_of_range_chain`) that poisons a glyph's chain so `i + chain` points past the buffer end and asserts the function returns without indexing out of bounds.

- Before the fix: panics `index out of bounds: the len is 4 but the index is 30000` at `cursive.rs`.
- After the fix: passes.

### Verification (local, in Docker)

- `cargo test -p harfrust` — 6027 integration + 206 unit tests pass, 0 failures (my new test included; no shaping regressions).
- `cargo fmt --all -- --check` — clean.
- The change is clippy-clean. (On a very recent `stable` toolchain clippy reports four pre-existing `question_mark` lints in `glyph_metrics.rs` / `unicode/mod.rs`, unrelated to this change; they are present on `main` without this patch.)

---

Disclosure: this fix was prepared with AI assistance (Claude). I reviewed it, cross-checked the two guards against HarfBuzz's `CursivePosFormat1.hh`, and verified the red-green test and full suite myself.
