### PR TITLE
Fix Clippy failures on newer toolchains

### DIFF
--- a/harfrust/src/hb/glyph_metrics.rs
+++ b/harfrust/src/hb/glyph_metrics.rs
@@ -196,10 +196,9 @@ impl<'a> GlyphMetrics<'a> {
         let gid = gid.into();
         let mut bearing = if let Some(hmtx) = self._hmtx.as_ref() {
             hmtx.side_bearing(gid).unwrap_or_default() as i32
-        } else if let Some(extents) = self.bounds(gid, coords) {
-            return Some(extents.x_min);
         } else {
-            return None;
+            let extents = self.bounds(gid, coords)?;
+            return Some(extents.x_min);
         };
         if !coords.is_empty() {
             if let Some(hvar) = self.hvar.as_ref() {
@@ -244,11 +243,8 @@ impl<'a> GlyphMetrics<'a> {
         coords: &[F2Dot14],
     ) -> Option<i32> {
         let gid = gid.into();
-        let mut bearing = if let Some(vmtx) = self.vmtx.as_ref() {
-            vmtx.side_bearing(gid).unwrap_or_default() as i32
-        } else {
-            return None;
-        };
+        let vmtx = self.vmtx.as_ref()?;
+        let mut bearing = vmtx.side_bearing(gid).unwrap_or_default() as i32;
         if !coords.is_empty() {
             if let Some(vvar) = self.vvar.as_ref() {
                 bearing += vvar.tsb_delta(gid, coords).unwrap_or_default().to_i32();

--- a/harfrust/src/hb/ot/contextual.rs
+++ b/harfrust/src/hb/ot/contextual.rs
@@ -539,10 +539,10 @@ struct ParsedRule<'a> {
 impl<'a> ParsedRule<'a> {
     /// Parse a SequenceRule or ClassSequenceRule.
     fn from_rule_data(data: FontData<'a>) -> Option<Self> {
-        let glyph_count: u16 = data.read_at(0).ok()?;
-        let record_count: u16 = data.read_at(2).ok()?;
-        let input_end = 4 + (glyph_count as usize).saturating_sub(1) * u16::RAW_BYTE_LEN;
-        let records_end = input_end + record_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
+        let glyph_count = usize::from(data.read_at::<u16>(0).ok()?);
+        let record_count = usize::from(data.read_at::<u16>(2).ok()?);
+        let input_end = 4 + glyph_count.saturating_sub(1) * u16::RAW_BYTE_LEN;
+        let records_end = input_end + record_count * SequenceLookupRecord::RAW_BYTE_LEN;
         Some(ParsedRule {
             input: data.read_array(4..input_end).ok()?,
             records: data.read_array(input_end..records_end).ok()?,
@@ -552,16 +552,14 @@ impl<'a> ParsedRule<'a> {
 
     /// Parse a ChainedSequenceRule or ChainedClassSequenceRule.
     fn from_chain_rule_data(data: FontData<'a>) -> Option<Self> {
-        let backtrack_count: u16 = data.read_at(0).ok()?;
-        let backtrack_end = 2 + backtrack_count as usize * u16::RAW_BYTE_LEN;
-        let input_count: u16 = data.read_at(backtrack_end).ok()?;
-        let input_end =
-            backtrack_end + 2 + (input_count as usize).saturating_sub(1) * u16::RAW_BYTE_LEN;
-        let lookahead_count: u16 = data.read_at(input_end).ok()?;
-        let lookahead_end = input_end + 2 + lookahead_count as usize * u16::RAW_BYTE_LEN;
-        let record_count: u16 = data.read_at(lookahead_end).ok()?;
-        let records_end =
-            lookahead_end + 2 + record_count as usize * SequenceLookupRecord::RAW_BYTE_LEN;
+        let backtrack_count = usize::from(data.read_at::<u16>(0).ok()?);
+        let backtrack_end = 2 + backtrack_count * u16::RAW_BYTE_LEN;
+        let input_count = usize::from(data.read_at::<u16>(backtrack_end).ok()?);
+        let input_end = backtrack_end + 2 + input_count.saturating_sub(1) * u16::RAW_BYTE_LEN;
+        let lookahead_count = usize::from(data.read_at::<u16>(input_end).ok()?);
+        let lookahead_end = input_end + 2 + lookahead_count * u16::RAW_BYTE_LEN;
+        let record_count = usize::from(data.read_at::<u16>(lookahead_end).ok()?);
+        let records_end = lookahead_end + 2 + record_count * SequenceLookupRecord::RAW_BYTE_LEN;
         Some(ParsedRule {
             backtrack: data.read_array(2..backtrack_end).ok()?,
             input: data.read_array(backtrack_end + 2..input_end).ok()?,
@@ -628,8 +626,8 @@ fn plain_rule_first_input(data: &FontData) -> Option<u16> {
 /// The input glyph count follows the variable-length backtrack sequence, and
 /// the input sequence follows it directly.
 fn chain_rule_first_input(data: &FontData) -> Option<u16> {
-    let backtrack_count: u16 = data.read_at(0).ok()?;
-    let count_pos = 2 + backtrack_count as usize * u16::RAW_BYTE_LEN;
+    let backtrack_count = usize::from(data.read_at::<u16>(0).ok()?);
+    let count_pos = 2 + backtrack_count * u16::RAW_BYTE_LEN;
     let input_count: u16 = data.read_at(count_pos).ok()?;
     if input_count <= 1 {
         return None;


### PR DESCRIPTION
## Summary

- rewrite optional glyph-metric fallbacks using the `?` operator, fixing the stable CI failure
- parse contextual rule counts as `usize` up front, fixing newer Clippy `needless_type_cast` diagnostics

## Testing

- `cargo +stable clippy --all-features --all-targets -- -D warnings`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo +1.85 build`
- `cargo +1.85 build --no-default-features --features=libm`
- `cargo +stable test`
- `cargo +stable test --features icu`

The MSRV remains Rust 1.85. This PR does not address or close #414.