### PR TITLE
[kern] Avoid rescanning skipped glyphs

### DIFF
--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -150,7 +150,7 @@ fn machine_kern<F>(
 
         let mut unsafe_to = 0;
         if !iter.next(Some(&mut unsafe_to)) {
-            i += 1;
+            i = unsafe_to;
             continue;
         }
 


### PR DESCRIPTION
## Summary

- resume legacy `kern` processing at the skipping iterator's reported boundary
- avoid repeatedly scanning a suffix of ignored GDEF marks
- preserve later kern-enabled feature ranges

This ports harfbuzz/harfbuzz#6143.

## Correctness

On a failed `next()`, `unsafe_to` is either one past a non-ignored glyph that
lacks the kern mask, or the buffer end. All intervening glyphs were ignored by
the iterator and cannot produce a kern pair before that same boundary. Moving
the outer index to `unsafe_to` therefore removes only unproductive iterations
and makes the skipping scans non-overlapping.

## Testing

- `cargo fmt --all --check`
- `cargo test --workspace --all-features` (6,253 tests)
