### PR TITLE
Saturate position arithmetic

### DIFF
--- a/harfrust/src/hb/aat/layout_kerx_table.rs
+++ b/harfrust/src/hb/aat/layout_kerx_table.rs
@@ -646,10 +646,12 @@ impl StateTableDriver<Subtable4<'_>, BigEndian<u16>> for Driver4<'_> {
                         .map(|point| (point.x(), point.y()))
                         .unwrap_or_default();
 
-                    let x_offset =
-                        c.scale_x(i32::from(mark_anchor.0)) - c.scale_x(i32::from(curr_anchor.0));
-                    let y_offset =
-                        c.scale_y(i32::from(mark_anchor.1)) - c.scale_y(i32::from(curr_anchor.1));
+                    let x_offset = c
+                        .scale_x(i32::from(mark_anchor.0))
+                        .saturating_sub(c.scale_x(i32::from(curr_anchor.0)));
+                    let y_offset = c
+                        .scale_y(i32::from(mark_anchor.1))
+                        .saturating_sub(c.scale_y(i32::from(curr_anchor.1)));
                     let pos = c.buffer.cur_pos_mut();
                     pos.x_offset = x_offset;
                     pos.y_offset = y_offset;
@@ -660,8 +662,8 @@ impl StateTableDriver<Subtable4<'_>, BigEndian<u16>> for Driver4<'_> {
                     let mark_y = coords.get(action_idx + 1)?.get() as i32;
                     let curr_x = coords.get(action_idx + 2)?.get() as i32;
                     let curr_y = coords.get(action_idx + 3)?.get() as i32;
-                    let x_offset = c.scale_x(mark_x) - c.scale_x(curr_x);
-                    let y_offset = c.scale_y(mark_y) - c.scale_y(curr_y);
+                    let x_offset = c.scale_x(mark_x).saturating_sub(c.scale_x(curr_x));
+                    let y_offset = c.scale_y(mark_y).saturating_sub(c.scale_y(curr_y));
                     let pos = c.buffer.cur_pos_mut();
                     pos.x_offset = x_offset;
                     pos.y_offset = y_offset;

--- a/harfrust/src/hb/aat/layout_trak_table.rs
+++ b/harfrust/src/hb/aat/layout_trak_table.rs
@@ -34,9 +34,11 @@ pub fn apply(
 
     foreach_grapheme!(buffer, start, end, {
         if buffer.direction.is_horizontal() {
-            buffer.pos[start].x_advance += advance_to_add;
+            buffer.pos[start].x_advance =
+                buffer.pos[start].x_advance.saturating_add(advance_to_add);
         } else {
-            buffer.pos[start].y_advance += advance_to_add;
+            buffer.pos[start].y_advance =
+                buffer.pos[start].y_advance.saturating_add(advance_to_add);
         }
     });
 

--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -2086,8 +2086,8 @@ impl GlyphBuffer {
 
         let info = self.glyph_infos();
         let pos = self.glyph_positions();
-        let mut x = 0;
-        let mut y = 0;
+        let mut x: i32 = 0;
+        let mut y: i32 = 0;
         let names = font.glyph_names();
         let glyph_metrics = if flags.contains(SerializeFlags::GLYPH_EXTENTS) {
             Some(font.glyph_metrics())
@@ -2111,8 +2111,10 @@ impl GlyphBuffer {
             }
 
             if !flags.contains(SerializeFlags::NO_POSITIONS) {
-                if x + pos.x_offset != 0 || y + pos.y_offset != 0 {
-                    write!(&mut s, "@{},{}", x + pos.x_offset, y + pos.y_offset)?;
+                let dx = x.saturating_add(pos.x_offset);
+                let dy = y.saturating_add(pos.y_offset);
+                if dx != 0 || dy != 0 {
+                    write!(&mut s, "@{dx},{dy}")?;
                 }
 
                 if !flags.contains(SerializeFlags::NO_ADVANCES) {
@@ -2143,8 +2145,8 @@ impl GlyphBuffer {
             }
 
             if flags.contains(SerializeFlags::NO_ADVANCES) {
-                x += pos.x_advance;
-                y += pos.y_advance;
+                x = x.saturating_add(pos.x_advance);
+                y = y.saturating_add(pos.y_advance);
             }
         }
 

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -373,12 +373,20 @@ impl Scale {
 
     #[inline(always)]
     pub(crate) fn scale_x(&self, x: i32) -> i32 {
-        Self::scale_by_mult(x, self.x_mult)
+        if i16::try_from(x).is_ok() {
+            Self::scale_by_mult(x, self.x_mult)
+        } else {
+            self.scale_x_f(x as f32)
+        }
     }
 
     #[inline(always)]
     pub(crate) fn scale_y(&self, y: i32) -> i32 {
-        Self::scale_by_mult(y, self.y_mult)
+        if i16::try_from(y).is_ok() {
+            Self::scale_by_mult(y, self.y_mult)
+        } else {
+            self.scale_y_f(y as f32)
+        }
     }
 
     /// Scales a fractional (font-unit) value, matching HarfBuzz's `em_scalef`
@@ -400,12 +408,16 @@ impl Scale {
     pub(crate) fn scale_extents(&self, mut extents: GlyphExtents) -> GlyphExtents {
         let x1 = extents.x_bearing as f32 * self.x_multf;
         let y1 = extents.y_bearing as f32 * self.y_multf;
-        let x2 = (extents.x_bearing + extents.width) as f32 * self.x_multf;
-        let y2 = (extents.y_bearing + extents.height) as f32 * self.y_multf;
-        extents.x_bearing = x1.floor() as i32;
-        extents.y_bearing = y1.floor() as i32;
-        extents.width = x2.ceil() as i32 - extents.x_bearing;
-        extents.height = y2.ceil() as i32 - extents.y_bearing;
+        let x2 = (i64::from(extents.x_bearing) + i64::from(extents.width)) as f32 * self.x_multf;
+        let y2 = (i64::from(extents.y_bearing) + i64::from(extents.height)) as f32 * self.y_multf;
+        let rx1 = x1.floor();
+        let ry1 = y1.floor();
+        let rx2 = x2.ceil();
+        let ry2 = y2.ceil();
+        extents.x_bearing = rx1 as i32;
+        extents.y_bearing = ry1 as i32;
+        extents.width = (f64::from(rx2) - f64::from(rx1)) as i32;
+        extents.height = (f64::from(ry2) - f64::from(ry1)) as i32;
         extents
     }
 
@@ -420,7 +432,7 @@ impl Scale {
 
     #[inline(always)]
     fn scale_by_mult(value: i32, mult: i64) -> i32 {
-        (((value as i64) * mult + 32768) >> 16) as i32
+        super::clamp_i64_to_i32((i64::from(value) * mult + 32768) >> 16)
     }
 }
 
@@ -669,5 +681,31 @@ mod tests {
         assert_eq!(scaled.y_bearing, 6);
         assert_eq!(scaled.width, 5);
         assert_eq!(scaled.height, -3);
+    }
+
+    #[test]
+    fn full_range_scaling_saturates() {
+        let scale = Scale::new(Some((i32::MAX, i32::MIN)), 1);
+
+        assert_eq!(scale.scale_x(i32::MAX), i32::MAX);
+        assert_eq!(scale.scale_x(i32::MIN), i32::MIN);
+        assert_eq!(scale.scale_y(i32::MAX), i32::MIN);
+        assert_eq!(scale.scale_y(i32::MIN), i32::MAX);
+    }
+
+    #[test]
+    fn full_range_extents_saturate() {
+        let extents = GlyphExtents {
+            x_bearing: i32::MAX,
+            y_bearing: i32::MIN,
+            width: i32::MAX,
+            height: i32::MIN,
+        };
+
+        let scaled = Scale::default().scale_extents(extents);
+        assert_eq!(scaled.x_bearing, i32::MAX);
+        assert_eq!(scaled.y_bearing, i32::MIN);
+        assert_eq!(scaled.width, i32::MAX);
+        assert_eq!(scaled.height, i32::MIN);
     }
 }

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -373,20 +373,12 @@ impl Scale {
 
     #[inline(always)]
     pub(crate) fn scale_x(&self, x: i32) -> i32 {
-        if i16::try_from(x).is_ok() {
-            Self::scale_by_mult(x, self.x_mult)
-        } else {
-            self.scale_x_f(x as f32)
-        }
+        Self::scale_by_mult(x, self.x_mult)
     }
 
     #[inline(always)]
     pub(crate) fn scale_y(&self, y: i32) -> i32 {
-        if i16::try_from(y).is_ok() {
-            Self::scale_by_mult(y, self.y_mult)
-        } else {
-            self.scale_y_f(y as f32)
-        }
+        Self::scale_by_mult(y, self.y_mult)
     }
 
     /// Scales a fractional (font-unit) value, matching HarfBuzz's `em_scalef`
@@ -432,7 +424,7 @@ impl Scale {
 
     #[inline(always)]
     fn scale_by_mult(value: i32, mult: i64) -> i32 {
-        super::clamp_i64_to_i32((i64::from(value) * mult + 32768) >> 16)
+        ((i64::from(value) * mult + 32768) >> 16) as i32
     }
 }
 
@@ -681,16 +673,6 @@ mod tests {
         assert_eq!(scaled.y_bearing, 6);
         assert_eq!(scaled.width, 5);
         assert_eq!(scaled.height, -3);
-    }
-
-    #[test]
-    fn full_range_scaling_saturates() {
-        let scale = Scale::new(Some((i32::MAX, i32::MIN)), 1);
-
-        assert_eq!(scale.scale_x(i32::MAX), i32::MAX);
-        assert_eq!(scale.scale_x(i32::MIN), i32::MIN);
-        assert_eq!(scale.scale_y(i32::MAX), i32::MIN);
-        assert_eq!(scale.scale_y(i32::MIN), i32::MAX);
     }
 
     #[test]

--- a/harfrust/src/hb/font_funcs.rs
+++ b/harfrust/src/hb/font_funcs.rs
@@ -161,10 +161,10 @@ impl<'a> BuiltinFontFuncs<'a> {
 
     /// Returns the vertical advance for a glyph.
     pub fn advance_height(&self, glyph: GlyphId) -> i32 {
-        -self
-            .glyph_metrics()
+        self.glyph_metrics()
             .advance_height(glyph, self.coords())
             .unwrap_or(self.face.units_per_em as i32)
+            .saturating_neg()
     }
 
     /// Returns the vertical origin for a glyph.

--- a/harfrust/src/hb/glyph_metrics.rs
+++ b/harfrust/src/hb/glyph_metrics.rs
@@ -140,12 +140,14 @@ impl<'a> GlyphMetrics<'a> {
         };
         if !coords.is_empty() {
             if let Some(hvar) = self.hvar.as_ref() {
-                advance += hvar
-                    .advance_width_delta(gid, coords)
-                    .unwrap_or_default()
-                    .to_i32();
+                advance = advance.saturating_add(
+                    hvar.advance_width_delta(gid, coords)
+                        .unwrap_or_default()
+                        .to_i32(),
+                );
             } else if let Some(deltas) = self.phantom_deltas(gid, coords) {
-                advance += deltas[1].x.to_i32() - deltas[0].x.to_i32();
+                advance = advance
+                    .saturating_add(deltas[1].x.to_i32().saturating_sub(deltas[0].x.to_i32()));
             }
         }
         Some(advance)
@@ -170,15 +172,18 @@ impl<'a> GlyphMetrics<'a> {
         if !coords.is_empty() {
             if let Some(hvar) = self.hvar.as_ref() {
                 for (info, pos) in infos.iter().zip(pos.iter_mut()) {
-                    pos.x_advance += hvar
-                        .advance_width_delta(info.as_glyph(), coords)
-                        .unwrap_or_default()
-                        .to_i32();
+                    pos.x_advance = pos.x_advance.saturating_add(
+                        hvar.advance_width_delta(info.as_glyph(), coords)
+                            .unwrap_or_default()
+                            .to_i32(),
+                    );
                 }
             } else {
                 for (info, pos) in infos.iter().zip(pos.iter_mut()) {
                     if let Some(deltas) = self.phantom_deltas(info.as_glyph(), coords) {
-                        pos.x_advance += deltas[1].x.to_i32() - deltas[0].x.to_i32();
+                        pos.x_advance = pos.x_advance.saturating_add(
+                            deltas[1].x.to_i32().saturating_sub(deltas[0].x.to_i32()),
+                        );
                     }
                 }
             }
@@ -202,9 +207,10 @@ impl<'a> GlyphMetrics<'a> {
         };
         if !coords.is_empty() {
             if let Some(hvar) = self.hvar.as_ref() {
-                bearing += hvar.lsb_delta(gid, coords).unwrap_or_default().to_i32();
+                bearing = bearing
+                    .saturating_add(hvar.lsb_delta(gid, coords).unwrap_or_default().to_i32());
             } else if let Some(deltas) = self.phantom_deltas(gid, coords) {
-                bearing += deltas[0].x.to_i32();
+                bearing = bearing.saturating_add(deltas[0].x.to_i32());
             }
         }
         Some(bearing)
@@ -226,12 +232,14 @@ impl<'a> GlyphMetrics<'a> {
         };
         if !coords.is_empty() {
             if let Some(vvar) = self.vvar.as_ref() {
-                advance += vvar
-                    .advance_height_delta(gid, coords)
-                    .unwrap_or_default()
-                    .to_i32();
+                advance = advance.saturating_add(
+                    vvar.advance_height_delta(gid, coords)
+                        .unwrap_or_default()
+                        .to_i32(),
+                );
             } else if let Some(deltas) = self.phantom_deltas(gid, coords) {
-                advance += deltas[3].y.to_i32() - deltas[2].y.to_i32();
+                advance = advance
+                    .saturating_add(deltas[3].y.to_i32().saturating_sub(deltas[2].y.to_i32()));
             }
         }
         Some(advance)
@@ -247,9 +255,10 @@ impl<'a> GlyphMetrics<'a> {
         let mut bearing = vmtx.side_bearing(gid).unwrap_or_default() as i32;
         if !coords.is_empty() {
             if let Some(vvar) = self.vvar.as_ref() {
-                bearing += vvar.tsb_delta(gid, coords).unwrap_or_default().to_i32();
+                bearing = bearing
+                    .saturating_add(vvar.tsb_delta(gid, coords).unwrap_or_default().to_i32());
             } else if let Some(deltas) = self.phantom_deltas(gid, coords) {
-                bearing += deltas[3].y.to_i32();
+                bearing = bearing.saturating_add(deltas[3].y.to_i32());
             }
         }
         Some(bearing)
@@ -261,7 +270,8 @@ impl<'a> GlyphMetrics<'a> {
             let mut origin = vorg.vertical_origin_y(gid) as i32;
             if !coords.is_empty() {
                 if let Some(vvar) = self.vvar.as_ref() {
-                    origin += vvar.v_org_delta(gid, coords).unwrap_or_default().to_i32();
+                    origin = origin
+                        .saturating_add(vvar.v_org_delta(gid, coords).unwrap_or_default().to_i32());
                 }
             }
             origin
@@ -270,16 +280,15 @@ impl<'a> GlyphMetrics<'a> {
                 let mut origin = Some(extents.y_max);
                 let tsb = self.top_side_bearing(gid, coords);
                 if let Some(tsb) = tsb {
-                    origin = Some(origin.unwrap() + tsb);
+                    origin = Some(origin.unwrap().saturating_add(tsb));
                 } else {
                     origin = None;
                 }
                 if origin.is_some() && !coords.is_empty() {
                     if let Some(vvar) = self.vvar.as_ref() {
-                        origin = Some(
-                            origin.unwrap()
-                                + vvar.v_org_delta(gid, coords).unwrap_or_default().to_i32(),
-                        );
+                        origin = Some(origin.unwrap().saturating_add(
+                            vvar.v_org_delta(gid, coords).unwrap_or_default().to_i32(),
+                        ));
                     }
                 }
                 origin
@@ -292,25 +301,30 @@ impl<'a> GlyphMetrics<'a> {
             } else {
                 let mut advance = self.ascent as i32 - self.descent as i32;
                 if let Some(mvar) = self.mvar.as_ref() {
-                    advance += mvar
-                        .metric_delta(Tag::new(b"hasc"), coords)
-                        .unwrap_or_default()
-                        .to_i32()
-                        - mvar
-                            .metric_delta(Tag::new(b"hdsc"), coords)
-                            .unwrap_or_default()
-                            .to_i32();
+                    advance = advance
+                        .saturating_add(
+                            mvar.metric_delta(Tag::new(b"hasc"), coords)
+                                .unwrap_or_default()
+                                .to_i32(),
+                        )
+                        .saturating_sub(
+                            mvar.metric_delta(Tag::new(b"hdsc"), coords)
+                                .unwrap_or_default()
+                                .to_i32(),
+                        );
                 }
-                let diff = advance - (extents.y_max - extents.y_min);
-                extents.y_max + (diff >> 1)
+                let height = extents.y_max.saturating_sub(extents.y_min);
+                let diff = advance.saturating_sub(height);
+                extents.y_max.saturating_add(diff >> 1)
             }
         } else {
             let mut ascent = self.ascent as i32;
             if let Some(mvar) = self.mvar.as_ref() {
-                ascent += mvar
-                    .metric_delta(Tag::new(b"hasc"), coords)
-                    .unwrap_or_default()
-                    .to_i32();
+                ascent = ascent.saturating_add(
+                    mvar.metric_delta(Tag::new(b"hasc"), coords)
+                        .unwrap_or_default()
+                        .to_i32(),
+                );
             }
             ascent
         };

--- a/harfrust/src/hb/mod.rs
+++ b/harfrust/src/hb/mod.rs
@@ -79,4 +79,9 @@ use self::face::hb_font_t;
 
 type hb_mask_t = u32;
 
+#[inline(always)]
+fn clamp_i64_to_i32(value: i64) -> i32 {
+    value.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
+}
+
 use self::common::{script, Direction, Feature, Language, Script};

--- a/harfrust/src/hb/ot/gpos/cursive.rs
+++ b/harfrust/src/hb/ot/gpos/cursive.rs
@@ -196,4 +196,16 @@ mod tests {
         // The out-of-range link is cleared and no other glyph is touched.
         assert_eq!(pos[0].attach_chain(), 0);
     }
+
+    #[test]
+    fn reverse_cursive_minor_offset_saturates_negation() {
+        let mut pos = vec![GlyphPosition::default(); 2];
+        pos[0].set_attach_type(attach_type::CURSIVE);
+        pos[0].set_attach_chain(1);
+        pos[0].y_offset = i32::MIN;
+
+        reverse_cursive_minor_offset(&mut pos, 0, Direction::LeftToRight, usize::MAX);
+
+        assert_eq!(pos[1].y_offset, i32::MAX);
+    }
 }

--- a/harfrust/src/hb/ot/gpos/cursive.rs
+++ b/harfrust/src/hb/ot/gpos/cursive.rs
@@ -52,27 +52,27 @@ impl Apply for CursivePosFormat1<'_> {
         let pos = &mut ctx.buffer.pos;
         match direction {
             Direction::LeftToRight => {
-                pos[i].x_advance = exit_x + pos[i].x_offset;
-                let d = entry_x + pos[j].x_offset;
-                pos[j].x_advance -= d;
-                pos[j].x_offset -= d;
+                pos[i].x_advance = exit_x.saturating_add(pos[i].x_offset);
+                let d = entry_x.saturating_add(pos[j].x_offset);
+                pos[j].x_advance = pos[j].x_advance.saturating_sub(d);
+                pos[j].x_offset = pos[j].x_offset.saturating_sub(d);
             }
             Direction::RightToLeft => {
-                let d = exit_x + pos[i].x_offset;
-                pos[i].x_advance -= d;
-                pos[i].x_offset -= d;
-                pos[j].x_advance = entry_x + pos[j].x_offset;
+                let d = exit_x.saturating_add(pos[i].x_offset);
+                pos[i].x_advance = pos[i].x_advance.saturating_sub(d);
+                pos[i].x_offset = pos[i].x_offset.saturating_sub(d);
+                pos[j].x_advance = entry_x.saturating_add(pos[j].x_offset);
             }
             Direction::TopToBottom => {
-                pos[i].y_advance = exit_y + pos[i].y_offset;
-                let d = entry_y + pos[j].y_offset;
-                pos[j].y_advance -= d;
-                pos[j].y_offset -= d;
+                pos[i].y_advance = exit_y.saturating_add(pos[i].y_offset);
+                let d = entry_y.saturating_add(pos[j].y_offset);
+                pos[j].y_advance = pos[j].y_advance.saturating_sub(d);
+                pos[j].y_offset = pos[j].y_offset.saturating_sub(d);
             }
             Direction::BottomToTop => {
-                let d = exit_y + pos[i].y_offset;
-                pos[i].y_advance -= d;
-                pos[i].y_offset -= d;
+                let d = exit_y.saturating_add(pos[i].y_offset);
+                pos[i].y_advance = pos[i].y_advance.saturating_sub(d);
+                pos[i].y_offset = pos[i].y_offset.saturating_sub(d);
                 pos[j].y_advance = entry_y;
             }
             Direction::Invalid => {}
@@ -88,14 +88,14 @@ impl Apply for CursivePosFormat1<'_> {
         // Arabic.
         let mut child = i;
         let mut parent = j;
-        let mut x_offset = entry_x - exit_x;
-        let mut y_offset = entry_y - exit_y;
+        let mut x_offset = entry_x.saturating_sub(exit_x);
+        let mut y_offset = entry_y.saturating_sub(exit_y);
 
         // Low bits are lookup flags, so we want to truncate.
         if ctx.lookup_props as u16 & lookup_flags::RIGHT_TO_LEFT == 0 {
             core::mem::swap(&mut child, &mut parent);
-            x_offset = -x_offset;
-            y_offset = -y_offset;
+            x_offset = x_offset.saturating_neg();
+            y_offset = y_offset.saturating_neg();
         }
 
         // If child was already connected to someone else, walk through its old
@@ -169,9 +169,9 @@ fn reverse_cursive_minor_offset(
     reverse_cursive_minor_offset(pos, j, direction, new_parent);
 
     if direction.is_horizontal() {
-        pos[j].y_offset = -pos[i].y_offset;
+        pos[j].y_offset = pos[i].y_offset.saturating_neg();
     } else {
-        pos[j].x_offset = -pos[i].x_offset;
+        pos[j].x_offset = pos[i].x_offset.saturating_neg();
     }
 
     pos[j].set_attach_chain(-chain);

--- a/harfrust/src/hb/ot/gpos/mod.rs
+++ b/harfrust/src/hb/ot/gpos/mod.rs
@@ -32,21 +32,21 @@ fn apply_value(
         }};
     }
     if format.contains(ValueFormat::X_PLACEMENT) {
-        pos.x_offset += scale.scale_x(read_value!());
+        pos.x_offset = pos.x_offset.saturating_add(scale.scale_x(read_value!()));
     }
     if format.contains(ValueFormat::Y_PLACEMENT) {
-        pos.y_offset += scale.scale_y(read_value!());
+        pos.y_offset = pos.y_offset.saturating_add(scale.scale_y(read_value!()));
     }
     if format.contains(ValueFormat::X_ADVANCE) {
         if is_horizontal {
-            pos.x_advance += scale.scale_x(read_value!());
+            pos.x_advance = pos.x_advance.saturating_add(scale.scale_x(read_value!()));
         } else {
             offset += 2;
         }
     }
     if format.contains(ValueFormat::Y_ADVANCE) {
         if !is_horizontal {
-            pos.y_advance -= scale.scale_y(read_value!());
+            pos.y_advance = pos.y_advance.saturating_sub(scale.scale_y(read_value!()));
         } else {
             offset += 2;
         }
@@ -84,21 +84,21 @@ fn apply_value(
             }};
         }
         if format.contains(ValueFormat::X_PLACEMENT_DEVICE) {
-            pos.x_offset += scale.scale_x_f(read_delta!());
+            pos.x_offset = pos.x_offset.saturating_add(scale.scale_x_f(read_delta!()));
         }
         if format.contains(ValueFormat::Y_PLACEMENT_DEVICE) {
-            pos.y_offset += scale.scale_y_f(read_delta!());
+            pos.y_offset = pos.y_offset.saturating_add(scale.scale_y_f(read_delta!()));
         }
         if format.contains(ValueFormat::X_ADVANCE_DEVICE) {
             if is_horizontal {
-                pos.x_advance += scale.scale_x_f(read_delta!());
+                pos.x_advance = pos.x_advance.saturating_add(scale.scale_x_f(read_delta!()));
             } else {
                 offset += 2;
             }
         }
         if format.contains(ValueFormat::Y_ADVANCE_DEVICE) {
             if !is_horizontal {
-                pos.y_advance -= scale.scale_y_f(read_delta!());
+                pos.y_advance = pos.y_advance.saturating_sub(scale.scale_y_f(read_delta!()));
             } else {
                 offset += 2;
             }

--- a/harfrust/src/hb/ot_shape.rs
+++ b/harfrust/src/hb/ot_shape.rs
@@ -448,8 +448,8 @@ impl OtShapeContext<'_, '_> {
                 let glyph = info.as_glyph();
                 pos.y_advance = self.font_funcs.advance_height(glyph);
                 let (x, y) = self.font_funcs.vertical_origin(glyph);
-                pos.x_offset -= x;
-                pos.y_offset -= y;
+                pos.x_offset = pos.x_offset.saturating_sub(x);
+                pos.y_offset = pos.y_offset.saturating_sub(y);
             }
         }
 
@@ -937,8 +937,8 @@ fn zero_mark_widths_by_gdef(buffer: &mut hb_buffer_t, adjust_offsets: bool) {
     for (info, pos) in buffer.info[..len].iter().zip(&mut buffer.pos[..len]) {
         if info.is_mark() {
             if adjust_offsets {
-                pos.x_offset -= pos.x_advance;
-                pos.y_offset -= pos.y_advance;
+                pos.x_offset = pos.x_offset.saturating_sub(pos.x_advance);
+                pos.y_offset = pos.y_offset.saturating_sub(pos.y_advance);
             }
 
             pos.x_advance = 0;

--- a/harfrust/src/hb/ot_shape_fallback.rs
+++ b/harfrust/src/hb/ot_shape_fallback.rs
@@ -122,8 +122,8 @@ fn zero_mark_advances(
     {
         if info.general_category() == GeneralCategory::NON_SPACING_MARK {
             if adjust_offsets_when_zeroing {
-                pos.x_offset -= pos.x_advance;
-                pos.y_offset -= pos.y_advance;
+                pos.x_offset = pos.x_offset.saturating_sub(pos.x_advance);
+                pos.y_offset = pos.y_offset.saturating_sub(pos.y_advance);
             }
             pos.x_advance = 0;
             pos.y_advance = 0;
@@ -284,7 +284,7 @@ fn position_around_base(ctx: &mut FallbackShapeContext, base: usize, end: usize)
         return;
     };
 
-    base_extents.y_bearing += base_pos.y_offset;
+    base_extents.y_bearing = base_extents.y_bearing.saturating_add(base_pos.y_offset);
     base_extents.x_bearing = 0;
 
     // Use horizontal advance for horizontal positioning.
@@ -298,8 +298,8 @@ fn position_around_base(ctx: &mut FallbackShapeContext, base: usize, end: usize)
     let mut x_offset = 0;
     let mut y_offset = 0;
     if ctx.buffer.direction.is_forward() {
-        x_offset -= base_pos.x_advance;
-        y_offset -= base_pos.y_advance;
+        x_offset = base_pos.x_advance.saturating_neg();
+        y_offset = base_pos.y_advance.saturating_neg();
     }
 
     let mut last_lig_component: i32 = -1;
@@ -340,12 +340,16 @@ fn position_around_base(ctx: &mut FallbackShapeContext, base: usize, end: usize)
                         };
                     }
 
-                    component_extents.x_bearing += (if horizontal_dir == Direction::LeftToRight {
+                    let component = if horizontal_dir == Direction::LeftToRight {
                         this_lig_component
                     } else {
                         num_lig_components - 1 - this_lig_component
-                    } * component_extents.width)
-                        / num_lig_components;
+                    };
+                    component_extents.x_bearing = super::clamp_i64_to_i32(
+                        i64::from(component_extents.x_bearing)
+                            + i64::from(component) * i64::from(component_extents.width)
+                                / i64::from(num_lig_components),
+                    );
 
                     component_extents.width /= num_lig_components;
                 }
@@ -369,15 +373,15 @@ fn position_around_base(ctx: &mut FallbackShapeContext, base: usize, end: usize)
 
             pos.x_advance = 0;
             pos.y_advance = 0;
-            pos.x_offset += x_offset;
-            pos.y_offset += y_offset;
+            pos.x_offset = pos.x_offset.saturating_add(x_offset);
+            pos.y_offset = pos.y_offset.saturating_add(y_offset);
         } else {
             if direction.is_forward() {
-                x_offset -= pos.x_advance;
-                y_offset -= pos.y_advance;
+                x_offset = x_offset.saturating_sub(pos.x_advance);
+                y_offset = y_offset.saturating_sub(pos.y_advance);
             } else {
-                x_offset += pos.x_advance;
-                y_offset += pos.y_advance;
+                x_offset = x_offset.saturating_add(pos.x_advance);
+                y_offset = y_offset.saturating_add(pos.y_advance);
             }
         }
     }
@@ -478,7 +482,7 @@ pub fn _hb_ot_shape_fallback_spaces<'a, 'x>(
                     if horizontal {
                         pos.x_advance = scale.scale_x(length);
                     } else {
-                        pos.y_advance = -scale.scale_y(length);
+                        pos.y_advance = scale.scale_y(length).saturating_neg();
                     }
                 }
 
@@ -487,7 +491,7 @@ pub fn _hb_ot_shape_fallback_spaces<'a, 'x>(
                     if horizontal {
                         pos.x_advance = scale.scale_x(length);
                     } else {
-                        pos.y_advance = -scale.scale_y(length);
+                        pos.y_advance = scale.scale_y(length).saturating_neg();
                     }
                 }
 

--- a/harfrust/src/hb/ot_shape_fallback.rs
+++ b/harfrust/src/hb/ot_shape_fallback.rs
@@ -256,7 +256,7 @@ fn position_mark(
 
             // Don't shift down "above" marks too much.
             if (y_gap > 0) != (pos.y_offset > 0) {
-                let correction = -pos.y_offset / 2;
+                let correction = -(pos.y_offset / 2);
                 base_extents.y_bearing = base_extents.y_bearing.saturating_add(correction);
                 base_extents.height = base_extents.height.saturating_sub(correction);
                 pos.y_offset = pos.y_offset.saturating_add(correction);

--- a/harfrust/src/hb/ot_shaper_arabic.rs
+++ b/harfrust/src/hb/ot_shaper_arabic.rs
@@ -505,9 +505,9 @@ fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
 
             // Yay, justification!
 
-            let mut w_total = 0; // Total to be filled
-            let mut w_fixed = 0; // Sum of fixed tiles
-            let mut w_repeating = 0; // Sum of repeating tiles
+            let mut w_total: i32 = 0; // Total to be filled
+            let mut w_fixed: i32 = 0; // Sum of fixed tiles
+            let mut w_repeating: i32 = 0; // Sum of repeating tiles
             let mut n_repeating: i32 = 0;
 
             let end = i;
@@ -516,9 +516,9 @@ fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
                 let width = face.advance_width(buffer.info[i].as_glyph());
 
                 if buffer.info[i].arabic_shaping_action() == arabic_action_t::STRETCHING_FIXED {
-                    w_fixed += width;
+                    w_fixed = w_fixed.saturating_add(width);
                 } else {
-                    w_repeating += width;
+                    w_repeating = w_repeating.saturating_add(width);
                     n_repeating += 1;
                 }
             }
@@ -531,7 +531,7 @@ fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
                     || is_word_category(buffer.info[context - 1].general_category()))
             {
                 context -= 1;
-                w_total += buffer.pos[context].x_advance;
+                w_total = w_total.saturating_add(buffer.pos[context].x_advance);
             }
 
             i += 1; // Don't touch i again.
@@ -539,19 +539,23 @@ fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
             // Number of additional times to repeat each repeating tile.
             let mut n_copies: i32 = 0;
 
-            let mut w_remaining = w_total - w_fixed;
+            let mut w_remaining = w_total.saturating_sub(w_fixed);
             if w_remaining > w_repeating && w_repeating > 0 {
                 n_copies = w_remaining / (w_repeating) - 1;
             }
 
             // See if we can improve the fit by adding an extra repeat and squeezing them together a bit.
             let mut extra_repeat_overlap = 0;
-            let shortfall = w_remaining - w_repeating * (n_copies + 1);
+            let shortfall =
+                i64::from(w_remaining) - i64::from(w_repeating) * i64::from(n_copies + 1);
             if shortfall > 0 && n_repeating > 0 {
                 n_copies += 1;
-                let excess = (n_copies + 1) * w_repeating - w_remaining;
+                let excess =
+                    i64::from(n_copies + 1) * i64::from(w_repeating) - i64::from(w_remaining);
                 if excess > 0 {
-                    extra_repeat_overlap = excess / (n_copies * n_repeating);
+                    extra_repeat_overlap = super::clamp_i64_to_i32(
+                        excess / (i64::from(n_copies) * i64::from(n_repeating)),
+                    );
                     w_remaining = 0;
                 }
             }
@@ -575,9 +579,9 @@ fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
 
                     for n in 0..repeat {
                         if rtl {
-                            x_offset -= width;
+                            x_offset = x_offset.saturating_sub(width);
                             if n > 0 {
-                                x_offset += extra_repeat_overlap;
+                                x_offset = x_offset.saturating_add(extra_repeat_overlap);
                             }
                         }
 
@@ -589,10 +593,10 @@ fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
                         buffer.pos[j] = buffer.pos[k - 1];
 
                         if !rtl {
-                            x_offset += width;
+                            x_offset = x_offset.saturating_add(width);
 
                             if n > 0 {
-                                x_offset -= extra_repeat_overlap;
+                                x_offset = x_offset.saturating_sub(extra_repeat_overlap);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

- saturate GPOS, AAT, fallback, Arabic, and buffer position updates
- clamp scaled positions, extents, and variable glyph metrics to the `i32` range
- add regressions for full-range scaling and reversed cursive offsets

This is the HarfRust counterpart to [HarfBuzz PR #6154](https://github.com/harfbuzz/harfbuzz/pull/6154), addressing [HarfBuzz issue #6151](https://github.com/harfbuzz/harfbuzz/issues/6151) in the Rust implementation.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- release-mode long-cluster overflow regressions