### PR TITLE
Lock icu_properties to 2.2.0

### DIFF
--- a/harfrust/Cargo.toml
+++ b/harfrust/Cargo.toml
@@ -17,7 +17,7 @@ bitflags = "2.9"
 bytemuck = { version = "1.22", features = ["extern_crate_alloc"] }
 core_maths = { version = "0.1", optional = true }
 smallvec = "1.14"
-icu_properties = { version = "2.2.0", optional = true }
+icu_properties = { version = "=2.2.0", optional = true }
 icu_normalizer = { version = "2.2.0", optional = true }
 
 [features]


### PR DESCRIPTION
The conversion to ICU4C values for `Script` and `CanonicalCombiningClass` have been deprecated leading to CI failures. For now, just lock the version until we decide how to resolve this.