### PR TITLE
Hot-loop discipline: block copies, slice scans, clone-free recursion

### DIFF
--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -627,6 +627,29 @@ impl hb_buffer_t {
         self.out_info_mut()[i] = info;
     }
 
+    /// Block-copies `info[src..src + count]` to `out_info[dst..dst + count]`.
+    /// The caller must have made room in the out buffer already.
+    #[inline]
+    fn copy_infos_to_out(&mut self, src: usize, dst: usize, count: usize) {
+        if self.have_separate_output {
+            let out: &mut [GlyphInfo] = bytemuck::cast_slice_mut(self.pos.as_mut_slice());
+            out[dst..dst + count].copy_from_slice(&self.info[src..src + count]);
+        } else {
+            self.info.copy_within(src..src + count, dst);
+        }
+    }
+
+    /// Block-copies `out_info[src..src + count]` to `info[dst..dst + count]`.
+    #[inline]
+    fn copy_out_to_infos(&mut self, src: usize, dst: usize, count: usize) {
+        if self.have_separate_output {
+            let out: &[GlyphInfo] = bytemuck::cast_slice(self.pos.as_slice());
+            self.info[dst..dst + count].copy_from_slice(&out[src..src + count]);
+        } else {
+            self.info.copy_within(src..src + count, dst);
+        }
+    }
+
     #[inline]
     pub fn cur(&self, i: usize) -> &GlyphInfo {
         &self.info[self.idx + i]
@@ -889,10 +912,11 @@ impl hb_buffer_t {
         self.merge_clusters(self.idx, self.idx + num_in);
 
         let orig_info = self.info[self.idx];
-        for i in 0..num_out {
-            let ii = self.out_len + i;
-            self.set_out_info(ii, orig_info);
-            self.out_info_mut()[ii].glyph_id = glyph_data[i];
+        let out_len = self.out_len;
+        let out = &mut self.out_info_mut()[out_len..out_len + num_out];
+        for (out_info, &glyph_id) in out.iter_mut().zip(&glyph_data[..num_out]) {
+            *out_info = orig_info;
+            out_info.glyph_id = glyph_id;
         }
 
         self.idx += num_in;
@@ -987,9 +1011,7 @@ impl hb_buffer_t {
                     return;
                 }
 
-                for i in 0..n {
-                    self.set_out_info(self.out_len + i, self.info[self.idx + i]);
-                }
+                self.copy_infos_to_out(self.idx, self.out_len, n);
             }
 
             self.out_len += n;
@@ -1414,9 +1436,7 @@ impl hb_buffer_t {
                 return false;
             }
 
-            for j in 0..count {
-                self.set_out_info(self.out_len + j, self.info[self.idx + j]);
-            }
+            self.copy_infos_to_out(self.idx, self.out_len, count);
 
             self.idx += count;
             self.out_len += count;
@@ -1440,9 +1460,7 @@ impl hb_buffer_t {
             self.idx -= count;
             self.out_len -= count;
 
-            for j in 0..count {
-                self.info[self.idx + j] = self.out_info()[self.out_len + j];
-            }
+            self.copy_out_to_infos(self.out_len, self.idx, count);
         }
 
         true
@@ -1480,9 +1498,7 @@ impl hb_buffer_t {
             debug_assert!(self.have_output);
 
             self.have_separate_output = true;
-            for i in 0..self.out_len {
-                self.set_out_info(i, self.info[i]);
-            }
+            self.copy_infos_to_out(0, 0, self.out_len);
         }
 
         true
@@ -1500,9 +1516,7 @@ impl hb_buffer_t {
             return false;
         }
 
-        for i in (0..(self.len - self.idx)).rev() {
-            self.info[self.idx + count + i] = self.info[self.idx + i];
-        }
+        self.info.copy_within(self.idx..self.len, self.idx + count);
 
         if self.idx + count > self.len {
             for info in &mut self.info[self.len..self.idx + count] {

--- a/harfrust/src/hb/ot_layout.rs
+++ b/harfrust/src/hb/ot_layout.rs
@@ -217,18 +217,31 @@ fn apply_forward(ctx: &mut OT::hb_ot_apply_context_t, lookup: &LookupInfo) -> bo
 
     let use_hot_subtable_cache = lookup.cache_enter(ctx);
 
+    // Loop-invariant: nested lookups save and restore lookup_props and the
+    // lookup mask (see hb_ot_apply_context_t::recurse), so these can be
+    // hoisted, letting the candidate scan below run over a slice without
+    // per-glyph bounds checks.
+    let face = ctx.face;
+    let lookup_mask = ctx.lookup_mask();
+    let lookup_props = ctx.lookup_props;
+
     while ctx.buffer.successful {
-        let mut j = ctx.buffer.idx;
-        while j < ctx.buffer.len && {
-            let info = &ctx.buffer.info[j];
-            !(lookup.digest.may_have(info.glyph_id)
-                && (info.mask & ctx.lookup_mask()) != 0
-                && check_glyph_property(ctx.face, info, ctx.lookup_props))
-        } {
+        let idx = ctx.buffer.idx;
+        let infos = &ctx.buffer.info[..ctx.buffer.len];
+        let mut j = idx;
+        while j < infos.len() {
+            let info = &infos[j];
+            if lookup.digest.may_have(info.glyph_id)
+                && (info.mask & lookup_mask) != 0
+                && check_glyph_property(face, info, lookup_props)
+            {
+                break;
+            }
             j += 1;
         }
-        if j > ctx.buffer.idx {
-            ctx.buffer.next_glyphs(j - ctx.buffer.idx);
+
+        if j > idx {
+            ctx.buffer.next_glyphs(j - idx);
         }
         if ctx.buffer.idx >= ctx.buffer.len {
             break;
@@ -256,18 +269,31 @@ fn apply_backward(ctx: &mut OT::hb_ot_apply_context_t, lookup: &LookupInfo) -> b
     let Some(table_data) = ctx.face.ot_tables.table_data(ctx.table_index) else {
         return false;
     };
-    loop {
-        let cur = ctx.buffer.cur(0);
-        ret |= lookup.digest.may_have(cur.glyph_id)
-            && (cur.mask & ctx.lookup_mask()) != 0
-            && check_glyph_property(ctx.face, cur, ctx.lookup_props)
-            && lookup.apply(ctx, table_data, false).is_some();
+    // Loop-invariant hoisting as in apply_forward; reverse lookups don't
+    // recurse, and in-place application cannot change the buffer length.
+    let face = ctx.face;
+    let lookup_mask = ctx.lookup_mask();
+    let lookup_props = ctx.lookup_props;
 
-        if ctx.buffer.idx == 0 {
+    loop {
+        let candidate = ctx.buffer.info[..=ctx.buffer.idx].iter().rposition(|info| {
+            lookup.digest.may_have(info.glyph_id)
+                && (info.mask & lookup_mask) != 0
+                && check_glyph_property(face, info, lookup_props)
+        });
+
+        let Some(idx) = candidate else {
+            ctx.buffer.idx = 0;
+            break;
+        };
+
+        ctx.buffer.idx = idx;
+        ret |= lookup.apply(ctx, table_data, false).is_some();
+
+        if idx == 0 {
             break;
         }
-
-        ctx.buffer.idx -= 1;
+        ctx.buffer.idx = idx - 1;
     }
     ret
 }

--- a/harfrust/src/hb/ot_layout_gsubgpos.rs
+++ b/harfrust/src/hb/ot_layout_gsubgpos.rs
@@ -952,8 +952,13 @@ pub mod OT {
             let saved_props = self.lookup_props;
             let saved_index = self.lookup_index;
 
-            self.match_positions.resize(self.match_positions_len, 0);
-            let saved_match_positions = self.match_positions.clone();
+            // The nested lookup never reads our match positions, so save by
+            // moving them out rather than cloning. The replacement must keep
+            // the len >= 1 invariant (match_input's count == 1 fast path
+            // writes match_positions[0] without resizing); it stays inline in
+            // the SmallVec, so no allocation happens here.
+            let saved_match_positions =
+                core::mem::replace(&mut self.match_positions, MatchPositions::from_elem(0, 1));
             let saved_match_positions_len = self.match_positions_len;
 
             self.lookup_index = sub_lookup_index;


### PR DESCRIPTION
Three stacked, independently-tested commits that tighten the hottest loops. Each passes the full test suite (6,267 tests) on its own.

## Changes

1. **[buffer] Replace per-element copy loops with block copies** — `move_to` (both branches), `shift_forward`, `make_room_for`, `next_glyphs`, and `replace_glyphs` copied glyph infos one element at a time, re-testing `have_separate_output`, redoing the bytemuck cast, and paying bounds checks per element. Now they use `copy_within`/`copy_from_slice`, matching the `memmove`s HarfBuzz uses.

   **This is also a semantic fix**: hb uses `memmove` in `move_to`'s rewind branch (hb-buffer.cc). When `info`/`out_info` share the array and a deletion gap is smaller than the rewind distance, the old ascending element copy re-read slots it had already overwritten, smearing glyphs. `copy_within` restores exact hb semantics.

2. **[layout] Scan for lookup candidates over slices in apply loops** — `apply_forward`/`apply_backward` now hoist `face`/`lookup_mask`/`lookup_props` into locals (sound: `recurse` saves and restores them) and scan with `position`/`rposition` over a slice, removing the per-glyph bounds check from the digest/mask/props test.

3. **[gsubgpos] Move match_positions on recursion instead of cloning** — `recurse()` cloned the `match_positions` SmallVec on every nested-lookup application; the child never reads the parent's positions, so it now gets a fresh inline SmallVec (`from_elem(0, 1)`, preserving the len ≥ 1 invariant that `match_input`'s single-glyph fast path relies on) and the parent's is restored by move. No allocation, no copy.

## Benchmarks

Instruction counts (perf stat on a corpus driver mirroring benches/shaping.rs; per-pass counts via a 10-rep/20-rep subtraction so startup and one-time cache building cancel; ~0.01% measurement variance):

| Target | Δ instructions/pass |
|---|---|
| Amiri / fa-thelittleprince | −4.5% |
| NotoNastaliqUrdu / fa-thelittleprince | −2.4% |
| Roboto / en-thelittleprince | −2.4% |
| SourceSerifVariable / react-dom | −1.8% |
| NotoNastaliqUrdu / fa-words | −0.7% |
| NotoSansDevanagari / hi-words | −0.3% |
| Roboto / en-words | +0.0% |

Wall-clock criterion A/B showed larger per-target numbers (−2% to −6%) but those fold code-layout noise into the delta; the instruction counts above are the honest measurement. Instruction-count bisection also caught (and led to fixing) an inlining regression in an earlier formulation of the layout commit: an Iterator::position-based scan grew apply_forward enough to shift LLVM's inlining in the apply path, costing +0.8% on Roboto/en-words; the manual-index-loop form in the final commit keeps the bounds-check elision without perturbing inlining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

