### PR TITLE
Defer context rule parsing behind input probes

### DIFF
--- a/harfrust/src/hb/ot/contextual.rs
+++ b/harfrust/src/hb/ot/contextual.rs
@@ -661,6 +661,75 @@ fn chain_rule_second_input(data: &FontData) -> Option<u16> {
     data.read_at(count_pos + 4).ok()
 }
 
+/// A chain rule with direct access to its raw data, for cheap positional
+/// probes without a full parse.
+trait ChainContextRule<'a>: ContextRule<'a> {
+    fn data(&self) -> FontData<'a>;
+}
+
+impl<'a> ChainContextRule<'a> for ChainedSequenceRule<'a> {
+    fn data(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
+impl<'a> ChainContextRule<'a> for ChainedClassSequenceRule<'a> {
+    fn data(&self) -> FontData<'a> {
+        self.offset_data()
+    }
+}
+
+/// Positional probes into a chain rule's raw data, reading only the values
+/// the rule pre-match needs instead of parsing the whole rule.
+struct ChainRuleProbe<'a> {
+    data: FontData<'a>,
+    count_pos: usize,
+    input_end: usize,
+    input_count: u16,
+}
+
+impl<'a> ChainRuleProbe<'a> {
+    fn new(data: FontData<'a>) -> Option<Self> {
+        let backtrack_count = usize::from(data.read_at::<u16>(0).ok()?);
+        let count_pos = 2 + backtrack_count * u16::RAW_BYTE_LEN;
+        let input_count: u16 = data.read_at(count_pos).ok()?;
+        let input_end =
+            count_pos + 2 + usize::from(input_count).saturating_sub(1) * u16::RAW_BYTE_LEN;
+        Some(Self {
+            data,
+            count_pos,
+            input_end,
+            input_count,
+        })
+    }
+
+    /// Matches `ParsedRule`: `input.len() + 1`, where the input array holds
+    /// `input_count - 1` values (saturating).
+    fn len_p1(&self) -> usize {
+        usize::from(self.input_count).max(1)
+    }
+
+    /// The input value at `index`. Callers must keep `index` within the
+    /// input array (`index + 1 < input_count`).
+    fn input(&self, index: usize) -> Option<u16> {
+        self.data
+            .read_at(self.count_pos + 2 + index * u16::RAW_BYTE_LEN)
+            .ok()
+    }
+
+    fn lookahead_len(&self) -> usize {
+        usize::from(self.data.read_at::<u16>(self.input_end).ok().unwrap_or(0))
+    }
+
+    /// The lookahead value at `index`. Callers must keep `index` within
+    /// `lookahead_len()`.
+    fn lookahead(&self, index: usize) -> Option<u16> {
+        self.data
+            .read_at(self.input_end + 2 + index * u16::RAW_BYTE_LEN)
+            .ok()
+    }
+}
+
 impl<'a> ContextRule<'a> for SequenceRule<'a> {
     fn parse(&self) -> ParsedRule<'a> {
         ParsedRule::from_rule_data(self.offset_data()).unwrap_or_default()
@@ -908,7 +977,7 @@ fn apply_chain_with_sequences<
 fn apply_chain_context_rules<
     'a,
     'b,
-    R: ContextRule<'a>,
+    R: ChainContextRule<'a>,
     F1: Fn(&mut GlyphInfo, u32) -> bool,
     F2: Fn(&mut GlyphInfo, u32) -> bool,
     F3: Fn(&mut GlyphInfo, u32) -> bool,
@@ -987,39 +1056,52 @@ where
         }
     }
     let mut rules_iter = rules.iter().filter_map(|r| r.ok());
-    let mut rule_box = rules_iter.next().map(|r| r.parse());
+    let mut rule_box = rules_iter.next();
     while let Some(rule) = rule_box {
-        let input = rule.input;
-        let lookahead = rule.lookahead;
-        let match_input = |info: &mut GlyphInfo, index: usize| {
-            input
-                .get(index)
-                .is_some_and(|v| match_funcs.1(info, u32::from(v.get())))
+        // Probe the values the pre-match needs without parsing the whole
+        // rule; most visited rules are rejected on these probes and never
+        // pay for a full parse.
+        let Some(probe) = ChainRuleProbe::new(rule.data()) else {
+            // Unreadable rule header; the full parse treats it as an empty
+            // rule, same as the parse-first code did.
+            if apply_chain_with_sequences(ctx, &rule.parse(), &match_funcs).is_some() {
+                if let Some(unsafe_to) = unsafe_to {
+                    ctx.buffer
+                        .unsafe_to_concat(Some(ctx.buffer.idx), Some(unsafe_to));
+                }
+                return Some(());
+            }
+            rule_box = rules_iter.next();
+            continue;
         };
-        let match_lookahead = |info: &mut GlyphInfo, index: usize| {
-            lookahead
-                .get(index)
-                .is_some_and(|v| match_funcs.2(info, u32::from(v.get())))
-        };
-        let len_p1 = input.len() + 1;
+        let len_p1 = probe.len_p1();
         let matched_first = if len_p1 > 1 {
-            match_input(&mut ctx.buffer.info[first], 0)
+            probe
+                .input(0)
+                .is_some_and(|v| match_funcs.1(&mut ctx.buffer.info[first], u32::from(v)))
         } else {
-            lookahead.is_empty() || match_lookahead(&mut ctx.buffer.info[first], 0)
+            probe.lookahead_len() == 0
+                || probe
+                    .lookahead(0)
+                    .is_some_and(|v| match_funcs.2(&mut ctx.buffer.info[first], u32::from(v)))
         };
         if matched_first {
             let matched_second = if let Some(second) = second {
                 if len_p1 > 2 {
-                    match_input(&mut ctx.buffer.info[second], 1)
+                    probe
+                        .input(1)
+                        .is_some_and(|v| match_funcs.1(&mut ctx.buffer.info[second], u32::from(v)))
                 } else {
-                    (lookahead.len() <= 2 - len_p1)
-                        || match_lookahead(&mut ctx.buffer.info[second], 2 - len_p1)
+                    (probe.lookahead_len() <= 2 - len_p1)
+                        || probe.lookahead(2 - len_p1).is_some_and(|v| {
+                            match_funcs.2(&mut ctx.buffer.info[second], u32::from(v))
+                        })
                 }
             } else {
                 true
             };
             if matched_second {
-                if apply_chain_with_sequences(ctx, &rule, &match_funcs).is_some() {
+                if apply_chain_with_sequences(ctx, &rule.parse(), &match_funcs).is_some() {
                     if let Some(unsafe_to) = unsafe_to {
                         ctx.buffer
                             .unsafe_to_concat(Some(ctx.buffer.idx), Some(unsafe_to));
@@ -1030,27 +1112,27 @@ where
                 unsafe_to = Some(unsafe_to2);
             }
 
-            rule_box = rules_iter.next().map(|r| r.parse());
+            rule_box = rules_iter.next();
         } else {
             if unsafe_to.is_none() {
                 unsafe_to = Some(unsafe_to1);
             }
 
-            if len_p1 > 1 {
+            let skip_key = if len_p1 > 1 { probe.input(0) } else { None };
+            if let Some(first_glyph_value) = skip_key {
                 // Skip ahead to next possible first glyph match.
-                let first_glyph_value = input.first().unwrap().get();
                 loop {
                     let Some(next_rule) = rules_iter.next() else {
                         rule_box = None;
                         break;
                     };
                     if next_rule.first_input() != Some(first_glyph_value) {
-                        rule_box = Some(next_rule.parse());
+                        rule_box = Some(next_rule);
                         break;
                     }
                 }
             } else {
-                rule_box = rules_iter.next().map(|r| r.parse());
+                rule_box = rules_iter.next();
             }
         }
     }

--- a/harfrust/src/hb/ot/contextual.rs
+++ b/harfrust/src/hb/ot/contextual.rs
@@ -606,6 +606,10 @@ trait ContextRule<'a>: FontRead<'a> {
     /// Much cheaper than a full parse; used by the skip-ahead loops, which
     /// discard most of the rules they visit.
     fn first_input(&self) -> Option<u16>;
+
+    /// The second glyph/class of the input sequence, or `None` if the input
+    /// sequence has fewer than two entries. Cheap like `first_input`.
+    fn second_input(&self) -> Option<u16>;
 }
 
 /// `first_input` for SequenceRule/ClassSequenceRule.
@@ -619,6 +623,16 @@ fn plain_rule_first_input(data: &FontData) -> Option<u16> {
         return None;
     }
     data.read_at(4).ok()
+}
+
+/// `second_input` for SequenceRule/ClassSequenceRule; see
+/// [`plain_rule_first_input`] for the layout.
+fn plain_rule_second_input(data: &FontData) -> Option<u16> {
+    let glyph_count: u16 = data.read_at(0).ok()?;
+    if glyph_count <= 2 {
+        return None;
+    }
+    data.read_at(6).ok()
 }
 
 /// `first_input` for ChainedSequenceRule/ChainedClassSequenceRule.
@@ -635,6 +649,18 @@ fn chain_rule_first_input(data: &FontData) -> Option<u16> {
     data.read_at(count_pos + 2).ok()
 }
 
+/// `second_input` for ChainedSequenceRule/ChainedClassSequenceRule; see
+/// [`chain_rule_first_input`] for the layout.
+fn chain_rule_second_input(data: &FontData) -> Option<u16> {
+    let backtrack_count = usize::from(data.read_at::<u16>(0).ok()?);
+    let count_pos = 2 + backtrack_count * u16::RAW_BYTE_LEN;
+    let input_count: u16 = data.read_at(count_pos).ok()?;
+    if input_count <= 2 {
+        return None;
+    }
+    data.read_at(count_pos + 4).ok()
+}
+
 impl<'a> ContextRule<'a> for SequenceRule<'a> {
     fn parse(&self) -> ParsedRule<'a> {
         ParsedRule::from_rule_data(self.offset_data()).unwrap_or_default()
@@ -642,6 +668,9 @@ impl<'a> ContextRule<'a> for SequenceRule<'a> {
 
     fn first_input(&self) -> Option<u16> {
         plain_rule_first_input(&self.offset_data())
+    }
+    fn second_input(&self) -> Option<u16> {
+        plain_rule_second_input(&self.offset_data())
     }
 }
 
@@ -653,6 +682,9 @@ impl<'a> ContextRule<'a> for ClassSequenceRule<'a> {
     fn first_input(&self) -> Option<u16> {
         plain_rule_first_input(&self.offset_data())
     }
+    fn second_input(&self) -> Option<u16> {
+        plain_rule_second_input(&self.offset_data())
+    }
 }
 
 impl<'a> ContextRule<'a> for ChainedSequenceRule<'a> {
@@ -663,6 +695,9 @@ impl<'a> ContextRule<'a> for ChainedSequenceRule<'a> {
     fn first_input(&self) -> Option<u16> {
         chain_rule_first_input(&self.offset_data())
     }
+    fn second_input(&self) -> Option<u16> {
+        chain_rule_second_input(&self.offset_data())
+    }
 }
 
 impl<'a> ContextRule<'a> for ChainedClassSequenceRule<'a> {
@@ -672,6 +707,9 @@ impl<'a> ContextRule<'a> for ChainedClassSequenceRule<'a> {
 
     fn first_input(&self) -> Option<u16> {
         chain_rule_first_input(&self.offset_data())
+    }
+    fn second_input(&self) -> Option<u16> {
+        chain_rule_second_input(&self.offset_data())
     }
 }
 
@@ -754,21 +792,19 @@ where
         }
     }
     let mut rules_iter = rules.iter().filter_map(|r| r.ok());
-    let mut rule_box = rules_iter.next().map(|r| r.parse());
+    let mut rule_box = rules_iter.next();
     while let Some(rule) = rule_box {
-        let inputs = rule.input;
-        let match_func2 = |info: &mut GlyphInfo, index| {
-            if let Some(value) = inputs.get(index as usize).map(|v| v.get()) {
-                match_func(info, u32::from(value))
-            } else {
-                false
-            }
-        };
-        if inputs.len() <= 1 || match_func2(&mut ctx.buffer.info[first], 0) {
+        // Probe the first two input values without parsing the whole rule;
+        // most visited rules are rejected on these probes and never pay for
+        // a full parse.
+        let first_value = rule.first_input();
+        if first_value.is_none_or(|v| match_func(&mut ctx.buffer.info[first], u32::from(v))) {
             if second.is_none()
-                || (inputs.len() <= 2 || match_func2(&mut ctx.buffer.info[second.unwrap()], 1))
+                || rule
+                    .second_input()
+                    .is_none_or(|v| match_func(&mut ctx.buffer.info[second.unwrap()], u32::from(v)))
             {
-                if rule.apply(ctx, &match_func).is_some() {
+                if rule.parse().apply(ctx, &match_func).is_some() {
                     if let Some(unsafe_to) = unsafe_to {
                         ctx.buffer
                             .unsafe_to_concat(Some(ctx.buffer.idx), Some(unsafe_to));
@@ -778,21 +814,21 @@ where
             } else {
                 unsafe_to = Some(unsafe_to2);
             }
-            rule_box = rules_iter.next().map(|r| r.parse());
+            rule_box = rules_iter.next();
         } else {
             if unsafe_to.is_none() {
                 unsafe_to = Some(unsafe_to1);
             }
 
             // Skip ahead to next possible first glyph match.
-            let first_glyph_value = inputs.first().unwrap().get();
+            let first_glyph_value = first_value.unwrap();
             loop {
                 let Some(next_rule) = rules_iter.next() else {
                     rule_box = None;
                     break;
                 };
                 if next_rule.first_input() != Some(first_glyph_value) {
-                    rule_box = Some(next_rule.parse());
+                    rule_box = Some(next_rule);
                     break;
                 }
             }


### PR DESCRIPTION
Stacked on #423. Two commits, each independently measured with instruction counts (perf stat on a corpus driver, 10/20-rep subtraction, ~0.01% variance) and independently green on the full test suite.

Class-based contextual lookups are where harfrust trails HarfBuzz the most: same-binary `hb-shape --shaper ot` vs `--shaper harfrust` measures NotoNastaliqUrdu/fa-words at roughly +36% instructions before this work. Both rule loops parsed every visited rule (`ParsedRule` re-reads five counts and validates four arrays) before rejecting most rules on the first one or two input values.

1. **Plain rule loop**: probe the first/second input values straight from rule data (`first_input`/new `second_input`) and parse only survivors. NotoNastaliqUrdu: **−7.4%** (fa-thelittleprince), **−6.6%** (fa-words); other targets unchanged.
2. **Chained rule loop**: same idea via a `ChainRuleProbe` that reads the backtrack/input counts once and serves input/lookahead values on demand (short-input rules pre-match on lookahead values, per the existing logic). On top of commit 1: **−1.5% / −1.8%** on NotoNastaliqUrdu; other targets unchanged.

Also tried and rejected by measurement, for the record: eager per-phase coverage resolution in the Format3 appliers (+10.7% on Amiri — those matchers are failure-dominated, so lazy per-position resolution is already right), and enabling the `rules.len() <= 4` fast-path TODO (+0.3% on NotoNastaliqUrdu — with commit 1 in place the probe loop beats the parse-everything path even for small rule sets, so the TODO comment's premise is now inverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)