### PR TITLE
Copy small counts inline instead of calling memmove

### DIFF
--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -627,26 +627,67 @@ impl hb_buffer_t {
         self.out_info_mut()[i] = info;
     }
 
+    /// Below this many elements, copy inline instead of calling memmove:
+    /// AAT state machines move a couple of glyphs at a time, and the call
+    /// plus memmove's size dispatch costs more cycles than the copy.
+    const SMALL_COPY: usize = 16;
+
     /// Block-copies `info[src..src + count]` to `out_info[dst..dst + count]`.
-    /// The caller must have made room in the out buffer already.
+    /// The caller must have made room in the out buffer already. In the
+    /// shared-array case the destination never starts past the source
+    /// (`dst <= src`), which makes the ascending inline copy overlap-safe.
     #[inline]
     fn copy_infos_to_out(&mut self, src: usize, dst: usize, count: usize) {
         if self.have_separate_output {
             let out: &mut [GlyphInfo] = bytemuck::cast_slice_mut(self.pos.as_mut_slice());
-            out[dst..dst + count].copy_from_slice(&self.info[src..src + count]);
+            if count < Self::SMALL_COPY {
+                // Deliberately not copy_from_slice: avoiding the memmove
+                // call for small counts is this fast path's entire point.
+                #[allow(clippy::manual_memcpy)]
+                for i in 0..count {
+                    out[dst + i] = self.info[src + i];
+                }
+            } else {
+                out[dst..dst + count].copy_from_slice(&self.info[src..src + count]);
+            }
         } else {
-            self.info.copy_within(src..src + count, dst);
+            debug_assert!(dst <= src);
+            if count < Self::SMALL_COPY {
+                for i in 0..count {
+                    self.info[dst + i] = self.info[src + i];
+                }
+            } else {
+                self.info.copy_within(src..src + count, dst);
+            }
         }
     }
 
     /// Block-copies `out_info[src..src + count]` to `info[dst..dst + count]`.
+    /// In the shared-array case the destination never starts before the
+    /// source (`dst >= src`), so the inline copy must run descending to keep
+    /// memmove semantics on overlap.
     #[inline]
     fn copy_out_to_infos(&mut self, src: usize, dst: usize, count: usize) {
         if self.have_separate_output {
             let out: &[GlyphInfo] = bytemuck::cast_slice(self.pos.as_slice());
-            self.info[dst..dst + count].copy_from_slice(&out[src..src + count]);
+            if count < Self::SMALL_COPY {
+                // Deliberately not copy_from_slice; see copy_infos_to_out.
+                #[allow(clippy::manual_memcpy)]
+                for i in 0..count {
+                    self.info[dst + i] = out[src + i];
+                }
+            } else {
+                self.info[dst..dst + count].copy_from_slice(&out[src..src + count]);
+            }
         } else {
-            self.info.copy_within(src..src + count, dst);
+            debug_assert!(dst >= src);
+            if count < Self::SMALL_COPY {
+                for i in (0..count).rev() {
+                    self.info[dst + i] = self.info[src + i];
+                }
+            } else {
+                self.info.copy_within(src..src + count, dst);
+            }
         }
     }
 
@@ -1516,7 +1557,16 @@ impl hb_buffer_t {
             return false;
         }
 
-        self.info.copy_within(self.idx..self.len, self.idx + count);
+        // Destination starts past the source; the inline copy runs
+        // descending to keep memmove semantics on overlap.
+        let moved = self.len - self.idx;
+        if moved < Self::SMALL_COPY {
+            for i in (0..moved).rev() {
+                self.info[self.idx + count + i] = self.info[self.idx + i];
+            }
+        } else {
+            self.info.copy_within(self.idx..self.len, self.idx + count);
+        }
 
         if self.idx + count > self.len {
             for info in &mut self.info[self.len..self.idx + count] {


### PR DESCRIPTION
Fixes the AAT regression #423 introduced, visible in Behdad's daily tracking as Devanagari Sangam MN/hi-words dropping from ~20% slower than HarfBuzz to ~30% slower.

**Diagnosis.** The regression was invisible to instruction counts (bit-flat across #423) but obvious in cycles: **+8.8%** on Devanagari Sangam MN/hi-words with instructions unchanged. The block-copy conversion replaced inline element loops with `copy_within`/`copy_from_slice`, which lower to out-of-line `memmove` calls for runtime-variable counts. AAT morx state machines drive `move_to` with 1-3 glyph rewinds thousands of times, and at those sizes a memmove call costs roughly the same instructions as the old loop but far more cycles (call overhead plus size-dispatch branch misses). MORX-36 won 2× from the same conversion because its rewinds are ~359 glyphs — the opposite regime.

**Fix.** Counts below 16 copy inline; larger counts keep the block copy. The inline paths preserve the memmove overlap semantics #423 established: forward copies into out_info have `dst <= src` in the shared-array case (ascending copy is safe), while the rewind copy-back and `shift_forward` have `dst >= src` (descending copy).

**Validation** (perf stat, r=5):
- Devanagari Sangam MN/hi-words cycles: 3.46G → **3.19G**, matching the pre-#423 3.18G; instructions flat throughout.
- GeezaPro/fa-thelittleprince: measured unregressed locally in both instructions and cycles across #423 (its small move on the tracking chart looks like scatter).
- OT bench suite: instruction-identical to main on all seven targets.
- TestMORXThirtysix A×65536: 0.075s, unchanged — large moves stay on the block path.
- Full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)