### PR TITLE
Charge move_to moves against max_ops

### DIFF
--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -1477,6 +1477,12 @@ impl hb_buffer_t {
                 return false;
             }
 
+            self.max_ops -= count as i32;
+            if self.max_ops < 0 {
+                self.successful = false;
+                return false;
+            }
+
             self.copy_infos_to_out(self.idx, self.out_len, count);
 
             self.idx += count;
@@ -1497,6 +1503,12 @@ impl hb_buffer_t {
             }
 
             debug_assert!(self.idx >= count);
+
+            self.max_ops -= count as i32;
+            if self.max_ops < 0 {
+                self.successful = false;
+                return false;
+            }
 
             self.idx -= count;
             self.out_len -= count;


### PR DESCRIPTION
Port of harfbuzz/harfbuzz@cf30f712e7 (harfbuzz#6191, now landed), closing the harfrust side of harfbuzz#6190: `move_to`'s two block copies — the forward copy into out_info and the rewind copy-back — were uncharged by `max_ops`, letting a crafted morx insertion subtable drive O(N²) copy work the budget never sees. Charge `count` in both branches, mirroring `shift_forward`'s failure pattern, placed exactly as upstream.

**Fully independent** of the AAT descriptor work (#428) and the pending fontations PRs — touches only `buffer.rs`, no read-fonts API involvement, mergeable on its own.

Validation: all 6,267 tests pass with no expectation changes (in-tree morx inputs fit the budget); TestMORXThirtysix output is byte-identical to the patched HarfBuzz at 1, 4096, and 65536 input characters — including the intended earlier truncation of its unbounded insertion expansion — and A×65536 still shapes in 0.073s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)