### PR TITLE
[aat] Add a fast-path to the state machine drivers

### DIFF
--- a/harfrust/src/hb/aat/layout_kerx_table.rs
+++ b/harfrust/src/hb/aat/layout_kerx_table.rs
@@ -376,8 +376,11 @@ fn apply_state_machine_kerning<T, E, Driver: StateTableDriver<T, E>>(
     aat::StateEntry<E>: KerxStateEntryExt,
 {
     let mut state = START_OF_TEXT;
+    // Condition 3 below, precomputed for the start-of-text state: no
+    // end-of-text action can fire if we stop while in the start state.
+    let start_state_safe_to_break_eot = (c.start_end_safe_to_break & (1 << START_OF_TEXT)) != 0;
     c.buffer.idx = 0;
-    loop {
+    'drive: loop {
         let class = if c.buffer.idx < c.buffer.len {
             get_class(
                 state_table,
@@ -393,6 +396,49 @@ fn apply_state_machine_kerning<T, E, Driver: StateTableDriver<T, E>>(
         };
 
         let next_state = entry.new_state;
+
+        // Fast path for when transitioning from start-state to start-state with
+        // no action and advancing. Do so as long as the class remains the same.
+        // This is common with runs of non-actionable glyphs.
+        if state == START_OF_TEXT
+            && next_state == START_OF_TEXT
+            && start_state_safe_to_break_eot
+            && !entry.is_actionable()
+            && entry.has_advance()
+        {
+            let old_class = class;
+            loop {
+                let _ = driver.transition(
+                    kind,
+                    &entry,
+                    subtable.is_cross_stream(),
+                    subtable.tuple_count(),
+                    c,
+                );
+                if c.buffer.idx >= c.buffer.len {
+                    break 'drive;
+                }
+                c.buffer.next_glyph();
+                c.buffer.max_ops -= 1;
+
+                let new_class = if c.buffer.idx < c.buffer.len {
+                    get_class(
+                        state_table,
+                        c.buffer.cur(0).as_glyph(),
+                        c.machine_class_cache.unwrap(),
+                    )
+                } else {
+                    u16::from(aat::class::END_OF_TEXT)
+                };
+                if new_class != old_class {
+                    break;
+                }
+            }
+            if c.buffer.idx >= c.buffer.len {
+                break 'drive;
+            }
+            continue 'drive;
+        }
 
         // Conditions under which it's guaranteed safe-to-break before current glyph:
         //

--- a/harfrust/src/hb/aat/layout_morx_table.rs
+++ b/harfrust/src/hb/aat/layout_morx_table.rs
@@ -229,8 +229,11 @@ fn drive<T: bytemuck::AnyBitPattern + FixedSize + core::fmt::Debug, Ctx: DriverC
             None
         }
     });
+    // Condition 3 below, precomputed for the start-of-text state: no
+    // end-of-text action can fire if we stop while in the start state.
+    let start_state_safe_to_break_eot = (ac.start_end_safe_to_break & (1 << START_OF_TEXT)) != 0;
     ac.buffer.idx = 0;
-    loop {
+    'drive: loop {
         // This block copied from NoncontextualSubtable::apply. Keep in sync.
         if let Some(range_flags) = ac.range_flags.as_ref() {
             if let Some(last_range) = last_range.as_mut() {
@@ -276,6 +279,43 @@ fn drive<T: bytemuck::AnyBitPattern + FixedSize + core::fmt::Debug, Ctx: DriverC
         };
 
         let next_state = entry.new_state;
+
+        // Fast path for when transitioning from start-state to start-state with
+        // no action and advancing. Do so as long as the class remains the same.
+        // This is common with runs of non-actionable glyphs.
+        if last_range.is_none()
+            && state == START_OF_TEXT
+            && next_state == START_OF_TEXT
+            && start_state_safe_to_break_eot
+            && !Ctx::is_actionable(&entry)
+            && Ctx::can_advance(&entry)
+        {
+            let old_class = class;
+            loop {
+                c.transition(&entry, ac);
+                if ac.buffer.idx >= ac.buffer.len || !ac.buffer.successful {
+                    break 'drive;
+                }
+                ac.buffer.next_glyph();
+
+                let new_class = if ac.buffer.idx < ac.buffer.len {
+                    get_class(
+                        machine,
+                        ac.buffer.cur(0).as_glyph(),
+                        ac.machine_class_cache.unwrap(),
+                    )
+                } else {
+                    u16::from(aat::class::END_OF_TEXT)
+                };
+                if new_class != old_class {
+                    break;
+                }
+            }
+            if ac.buffer.idx >= ac.buffer.len || !ac.buffer.successful {
+                break 'drive;
+            }
+            continue 'drive;
+        }
 
         // Conditions under which it's guaranteed safe-to-break before current glyph:
         //

--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -309,8 +309,11 @@ fn apply_state_machine_kerning(
     };
 
     let mut state = START_OF_TEXT;
+    // Condition 3 below, precomputed for the start-of-text state: no
+    // end-of-text action can fire if we stop while in the start state.
+    let start_state_safe_to_break_eot = (c.start_end_safe_to_break & (1 << START_OF_TEXT)) != 0;
     c.buffer.idx = 0;
-    loop {
+    'drive: loop {
         let class = if c.buffer.idx < c.buffer.len {
             get_class(
                 subtable,
@@ -326,6 +329,43 @@ fn apply_state_machine_kerning(
         };
 
         let next_state = entry.new_state;
+
+        // Fast path for when transitioning from start-state to start-state with
+        // no action and advancing. Do so as long as the class remains the same.
+        // This is common with runs of non-actionable glyphs.
+        if state == START_OF_TEXT
+            && next_state == START_OF_TEXT
+            && start_state_safe_to_break_eot
+            && !entry.is_actionable()
+            && entry.has_advance()
+        {
+            let old_class = class;
+            loop {
+                state_machine_transition(c, subtable, &entry, is_cross_stream, &mut driver);
+                if c.buffer.idx >= c.buffer.len {
+                    break 'drive;
+                }
+                c.buffer.max_ops -= 1;
+                c.buffer.next_glyph();
+
+                let new_class = if c.buffer.idx < c.buffer.len {
+                    get_class(
+                        subtable,
+                        c.buffer.cur(0).as_glyph(),
+                        c.machine_class_cache.unwrap(),
+                    )
+                } else {
+                    aat::class::END_OF_TEXT
+                };
+                if new_class != old_class {
+                    break;
+                }
+            }
+            if c.buffer.idx >= c.buffer.len {
+                break 'drive;
+            }
+            continue 'drive;
+        }
 
         // Conditions under which it's guaranteed safe-to-break before current glyph:
         //


### PR DESCRIPTION
Ports harfbuzz's AAT state-machine fast path (harfbuzz/harfbuzz#5667, Dec 2025 — landed after this driver was ported) to all three drive loops: morx `drive()`, kerx `apply_state_machine_kerning`, and the legacy kern machine.

When the machine transitions from start-of-text to start-of-text with no action while advancing — and the start state has no end-of-text action, precomputed as bit 0 of the existing `start_end_safe_to_break` mask — the driver consumes the whole run of same-class glyphs in a tight inner loop: per glyph it only calls `transition`, advances, and re-reads the (cached) class, skipping the state-entry lookup and the safe-to-break analysis (up to three entry lookups). Runs of glyphs the machine doesn't act on are the common case in real text.

Per-machine `max_ops` accounting is preserved exactly: morx charges only non-advancing transitions; kern/kerx charge every transition, fast path included.

Upstream this measured +12% on LucidaGrande and +6% on Menlo. Smoke check here: LucidaGrande/en-thelittleprince 5.97 ms → 5.49 ms (−8%) on the HarfBuzz parity harness, on top of the descriptor/parts stack. Outputs are byte-identical to the base branch on LucidaGrande, Menlo, GeezaPro, and Devanagari Sangam MN (full benchmark texts via hb-shape); full test suite passes.

Stacked on #428 and `perf/aat-subtable-parts` (which needs the now-merged googlefonts/fontations#2063 in a read-fonts release). Can be rebased to land separately if preferred — nothing here depends on the parts API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)