### PR TITLE
[ot-shape] Skip the post-morx digest update without GPOS

### DIFF
--- a/harfrust/src/hb/ot_shape.rs
+++ b/harfrust/src/hb/ot_shape.rs
@@ -413,7 +413,11 @@ impl OtShapeContext<'_, '_> {
 
         if self.plan.apply_morx {
             aat::layout::substitute(self.plan, self.face, self.buffer, self.features);
-            self.buffer.update_digest();
+            // The digest is only read by the OT lookup-apply loop; without
+            // GPOS ahead, nothing consumes it.
+            if self.plan.apply_gpos {
+                self.buffer.update_digest();
+            }
         } else {
             self.buffer.update_digest();
             ot_layout_gsub_table::substitute(self.plan, self.face, self.font_funcs, self.buffer);


### PR DESCRIPTION
The buffer digest is only consumed by the OT lookup-apply loop (the `may_intersect` gate in `ot_layout.rs`). After morx substitution it exists solely for a following GPOS pass; when positioning goes through kerx/kern instead (Menlo, LucidaGrande, GeezaPro, …), rebuilding it is wasted work. Fonts with morx + GPOS and no kerx still get the update.

Measured on the HarfBuzz parity harness: Menlo/en-thelittleprince 4.30 ms → 4.21 ms (−2%). Outputs byte-identical on Menlo, LucidaGrande, GeezaPro, and Devanagari Sangam MN full texts; full test suite passes.

Same fix applied to HarfBuzz, which this code was ported from, in harfbuzz/harfbuzz#6192 (−2% there too).

Stacked on #430; rebases cleanly to land separately if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)