### PR TITLE
[ot] Skip the per-subtable digest retest for single-subtable lookups

### DIFF
--- a/harfrust/src/hb/ot/lookup.rs
+++ b/harfrust/src/hb/ot/lookup.rs
@@ -255,6 +255,13 @@ impl LookupInfo {
         use_hot_subtable_cache: bool,
     ) -> Option<()> {
         let glyph = ctx.buffer.cur(0).glyph_id;
+        if let [subtable_info] = self.subtables.as_slice() {
+            // The lookup digest is the union of the subtable digests, so for
+            // a single subtable it equals this subtable's digest, which the
+            // caller has already tested; skip the redundant retest.
+            let is_cached = use_hot_subtable_cache && (self.subtable_cache_user_idx == Some(0));
+            return subtable_info.apply(ctx, table_data, is_cached);
+        }
         for (subtable_idx, subtable_info) in self.subtables.iter().enumerate() {
             if !subtable_info.digest.may_have(glyph) {
                 continue;


### PR DESCRIPTION
The lookup digest is the union of the subtable digests, and `apply_forward` tests it before applying a lookup. For single-subtable lookups — the overwhelming majority — the subtable's digest is identical to the lookup's, so the per-subtable `may_have` retest in `LookupInfo::apply` is always true. Dispatch single-subtable lookups straight to the subtable.

Same fix as harfbuzz/harfbuzz#6194 on the HarfBuzz side (found by profiling the two engines against each other — both had the redundancy). Unlike HarfBuzz, no invalid-subtable guard is needed here: `SubtableInfo::new` is fallible, so unreadable subtables never enter the subtables vec in the first place.

Instruction counts on the parity harness: **NotoNastaliqUrdu −2.2%, NotoSansDevanagari −1.6%, Roboto −1.4%, Amiri −1.1%**; outputs byte-identical to HarfBuzz on all four fonts; full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)