### PR TITLE
[kern] Set up the buffer glyph set in hb_ot_layout_kern

### DIFF
--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -39,6 +39,8 @@ pub fn hb_ot_layout_kern(
 ) -> Option<()> {
     let mut c = AatApplyContext::new(plan, face, scale, buffer);
 
+    c.setup_buffer_glyph_set();
+
     let (kern, subtable_caches) = c.face.aat_tables.kern.as_ref()?;
 
     let mut subtable_idx = 0;


### PR DESCRIPTION
HarfBuzz's legacy `kern` application goes through the shared `KerxTable::apply`, which builds the buffer glyph set so each subtable's applicability check is one set intersection. harfrust's `hb_ot_layout_kern` never called `setup_buffer_glyph_set`, so `buffer_intersects_machine` fell back to per-glyph `contains` scans against every subtable's first-set — twelve subtables per line on GeezaPro, the only benchmark font exercising the legacy kern path.

One line restores the parity behavior. GeezaPro/fa-thelittleprince on the clang-release parity rig: **instructions −3.6%, cycles −6.8%, wall 11.2 → 10.5 ms (−6.3%, Behdad-measured)**. Outputs byte-identical to HarfBuzz; full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)