### PR TITLE
[DO-NOT-MERGE] [buffer] Unsafe vector

### DIFF
--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -5,10 +5,11 @@ use crate::hb::glyph_metrics::GlyphMetrics;
 use crate::hb::glyph_names::GlyphNames;
 use crate::hb::set_digest::hb_set_digest_t;
 use crate::hb::tables::TableRanges;
+use crate::hb::unsafe_vec::UnsafeVec;
 use crate::unicode::{CharExt, Codepoint};
 use crate::U32Set;
 use crate::{script, BufferClusterLevel, BufferFlags, Direction, Language, Script, SerializeFlags};
-use alloc::{string::String, vec::Vec};
+use alloc::string::String;
 use core::cmp::min;
 use core::convert::TryFrom;
 use read_fonts::types::{F2Dot14, GlyphId, GlyphId16};
@@ -493,8 +494,8 @@ pub struct hb_buffer_t {
     pub len: usize,
     pub out_len: usize,
 
-    pub info: Vec<GlyphInfo>,
-    pub pos: Vec<GlyphPosition>,
+    pub info: UnsafeVec<GlyphInfo>,
+    pub pos: UnsafeVec<GlyphPosition>,
 
     // Text before / after the main buffer contents.
     // Always in Unicode, and ordered outward.
@@ -545,8 +546,8 @@ impl hb_buffer_t {
             idx: 0,
             len: 0,
             out_len: 0,
-            info: Vec::new(),
-            pos: Vec::new(),
+            info: UnsafeVec::new(),
+            pos: UnsafeVec::new(),
             have_separate_output: false,
             allocated_var_bits: 0,
             serial: 0,
@@ -907,8 +908,12 @@ impl hb_buffer_t {
 
         if self.have_separate_output {
             // Swap info and pos buffers.
-            let info: Vec<GlyphPosition> = bytemuck::cast_vec(core::mem::take(&mut self.info));
-            let pos: Vec<GlyphInfo> = bytemuck::cast_vec(core::mem::take(&mut self.pos));
+            let info: UnsafeVec<GlyphPosition> = UnsafeVec::from_vec(bytemuck::cast_vec(
+                core::mem::take(&mut self.info).into_vec(),
+            ));
+            let pos: UnsafeVec<GlyphInfo> = UnsafeVec::from_vec(bytemuck::cast_vec(
+                core::mem::take(&mut self.pos).into_vec(),
+            ));
             self.pos = info;
             self.info = pos;
             self.have_separate_output = false;

--- a/harfrust/src/hb/mod.rs
+++ b/harfrust/src/hb/mod.rs
@@ -45,6 +45,7 @@ mod ot_shape_normalize;
 pub mod ot_shape_plan;
 mod ot_shaper;
 mod ot_shaper_arabic;
+mod unsafe_vec;
 #[rustfmt::skip]
 mod ot_shaper_arabic_table;
 mod ot_shaper_hangul;

--- a/harfrust/src/hb/unsafe_vec.rs
+++ b/harfrust/src/hb/unsafe_vec.rs
@@ -1,0 +1,229 @@
+use alloc::vec::Vec;
+use core::fmt;
+use core::ops::{
+    Deref, DerefMut, Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo,
+    RangeToInclusive,
+};
+
+#[repr(transparent)]
+pub struct UnsafeVec<T> {
+    pub inner: Vec<T>,
+}
+
+impl<T> UnsafeVec<T> {
+    #[inline]
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+
+    #[inline]
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            inner: Vec::with_capacity(cap),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[inline]
+    pub fn push(&mut self, value: T) {
+        self.inner.push(value);
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self.inner.as_ptr()
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.inner.as_mut_ptr()
+    }
+
+    #[inline]
+    pub fn into_vec(self) -> Vec<T> {
+        self.inner
+    }
+
+    #[inline]
+    pub fn from_vec(v: Vec<T>) -> Self {
+        Self { inner: v }
+    }
+}
+
+impl<T> Default for UnsafeVec<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for UnsafeVec<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+/// Expose full Vec<T> API (resize/truncate/extend/etc.)
+impl<T> Deref for UnsafeVec<T> {
+    type Target = Vec<T>;
+    #[inline]
+    fn deref(&self) -> &Vec<T> {
+        &self.inner
+    }
+}
+impl<T> DerefMut for UnsafeVec<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Vec<T> {
+        &mut self.inner
+    }
+}
+
+/// Unchecked single-element indexing (UB if out of bounds)
+impl<T> Index<usize> for UnsafeVec<T> {
+    type Output = T;
+    #[inline]
+    fn index(&self, i: usize) -> &T {
+        unsafe { self.inner.get_unchecked(i) }
+    }
+}
+impl<T> IndexMut<usize> for UnsafeVec<T> {
+    #[inline]
+    fn index_mut(&mut self, i: usize) -> &mut T {
+        unsafe { self.inner.get_unchecked_mut(i) }
+    }
+}
+
+/// Unchecked range indexing (UB if invalid range)
+impl<T> Index<Range<usize>> for UnsafeVec<T> {
+    type Output = [T];
+    #[inline]
+    fn index(&self, r: Range<usize>) -> &[T] {
+        unsafe { core::slice::from_raw_parts(self.inner.as_ptr().add(r.start), r.end - r.start) }
+    }
+}
+impl<T> IndexMut<Range<usize>> for UnsafeVec<T> {
+    #[inline]
+    fn index_mut(&mut self, r: Range<usize>) -> &mut [T] {
+        unsafe {
+            core::slice::from_raw_parts_mut(self.inner.as_mut_ptr().add(r.start), r.end - r.start)
+        }
+    }
+}
+
+impl<T> Index<RangeFrom<usize>> for UnsafeVec<T> {
+    type Output = [T];
+    #[inline]
+    fn index(&self, r: RangeFrom<usize>) -> &[T] {
+        let len = self.inner.len();
+        unsafe { core::slice::from_raw_parts(self.inner.as_ptr().add(r.start), len - r.start) }
+    }
+}
+impl<T> IndexMut<RangeFrom<usize>> for UnsafeVec<T> {
+    #[inline]
+    fn index_mut(&mut self, r: RangeFrom<usize>) -> &mut [T] {
+        let len = self.inner.len();
+        unsafe {
+            core::slice::from_raw_parts_mut(self.inner.as_mut_ptr().add(r.start), len - r.start)
+        }
+    }
+}
+
+impl<T> Index<RangeTo<usize>> for UnsafeVec<T> {
+    type Output = [T];
+    #[inline]
+    fn index(&self, r: RangeTo<usize>) -> &[T] {
+        unsafe { core::slice::from_raw_parts(self.inner.as_ptr(), r.end) }
+    }
+}
+impl<T> IndexMut<RangeTo<usize>> for UnsafeVec<T> {
+    #[inline]
+    fn index_mut(&mut self, r: RangeTo<usize>) -> &mut [T] {
+        unsafe { core::slice::from_raw_parts_mut(self.inner.as_mut_ptr(), r.end) }
+    }
+}
+
+impl<T> Index<RangeFull> for UnsafeVec<T> {
+    type Output = [T];
+    #[inline]
+    fn index(&self, _: RangeFull) -> &[T] {
+        &self.inner
+    }
+}
+impl<T> IndexMut<RangeFull> for UnsafeVec<T> {
+    #[inline]
+    fn index_mut(&mut self, _: RangeFull) -> &mut [T] {
+        &mut self.inner
+    }
+}
+
+impl<T> Index<RangeInclusive<usize>> for UnsafeVec<T> {
+    type Output = [T];
+    #[inline]
+    fn index(&self, r: RangeInclusive<usize>) -> &[T] {
+        let start = *r.start();
+        let end_incl = *r.end();
+        unsafe { core::slice::from_raw_parts(self.inner.as_ptr().add(start), end_incl - start + 1) }
+    }
+}
+impl<T> IndexMut<RangeInclusive<usize>> for UnsafeVec<T> {
+    #[inline]
+    fn index_mut(&mut self, r: RangeInclusive<usize>) -> &mut [T] {
+        let start = *r.start();
+        let end_incl = *r.end();
+        unsafe {
+            core::slice::from_raw_parts_mut(
+                self.inner.as_mut_ptr().add(start),
+                end_incl - start + 1,
+            )
+        }
+    }
+}
+
+impl<T> Index<RangeToInclusive<usize>> for UnsafeVec<T> {
+    type Output = [T];
+    #[inline]
+    fn index(&self, r: RangeToInclusive<usize>) -> &[T] {
+        unsafe { core::slice::from_raw_parts(self.inner.as_ptr(), r.end + 1) }
+    }
+}
+impl<T> IndexMut<RangeToInclusive<usize>> for UnsafeVec<T> {
+    #[inline]
+    fn index_mut(&mut self, r: RangeToInclusive<usize>) -> &mut [T] {
+        unsafe { core::slice::from_raw_parts_mut(self.inner.as_mut_ptr(), r.end + 1) }
+    }
+}
+
+/// Iteration support: `for x in &v`, `for x in &mut v`, `for x in v`
+impl<'a, T> IntoIterator for &'a UnsafeVec<T> {
+    type Item = &'a T;
+    type IntoIter = core::slice::Iter<'a, T>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter()
+    }
+}
+impl<'a, T> IntoIterator for &'a mut UnsafeVec<T> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter_mut()
+    }
+}
+impl<T> IntoIterator for UnsafeVec<T> {
+    type Item = T;
+    type IntoIter = alloc::vec::IntoIter<T>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}

--- a/harfrust/src/lib.rs
+++ b/harfrust/src/lib.rs
@@ -5,7 +5,7 @@ A complete [harfbuzz](https://github.com/harfbuzz/harfbuzz) shaping algorithm po
 #![cfg_attr(not(feature = "std"), no_std)]
 // Forbidding unsafe code only applies to the lib
 // examples continue to use it, so this cannot be placed into Cargo.toml
-#![forbid(unsafe_code)]
+//#![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
 extern crate alloc;


### PR DESCRIPTION
Port of #314's `7ac58e2e` (UnsafeVec for buffer info/pos — unchecked single-element and range `Index` impls, de-checking every buffer index at once) onto #441, posted for numbers and discussion per Behdad's request. Not for shipping: lifts `forbid(unsafe_code)` and makes out-of-bounds buffer indexing UB in release builds (debug builds keep the stdlib's unsafe-precondition assertions, which the full test suite runs under).

Measurements (clang release rig, instructions/cycles vs the #441 head, single-process, outputs byte-identical on 4 AAT fonts + PingFang/CJK):

| Font | Δ instructions | Δ cycles |
|---|---|---|
| Menlo/en | **−5.0%** | −4.1% |
| Lucida Grande/en | **−4.7%** | −2.8% |
| Roboto/en | **−4.5%** | (noisy run) |
| GeezaPro/fa | **−2.9%** | −2.1% |
| Nastaliq/fa | **−2.6%** | −1.8% |
| Devanagari Sangam/hi | **−1.6%** | −1.6% |

With this, Menlo (67.0M vs 68.3M) and Lucida (88.3M vs 96.0M) are ahead of hb on instructions. Substantially stronger than the eight-site #319 port measured earlier (−1 to −2.5%), i.e. the win is spread across many indexing sites rather than concentrated in the hottest few.

Porting notes: `unsafe_vec.rs` switched to `core`/`alloc` imports; the `sync()` swap needs explicit `.into_vec()` around the bytemuck casts; #314's single.rs hunk was formatting-only and is dropped. Behdad's earlier stash ("Make range accesses safe again") suggests a variant worth measuring: checked ranges + unchecked single-element only.

*This PR was written by Claude (via Behdad's account).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)