### PR TITLE
[api] Expose Shaper::from_font_instance

### DIFF
--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -498,6 +498,15 @@ pub struct hb_font_t<'a> {
 }
 
 impl<'a> crate::Shaper<'a> {
+    /// Builds a shaper for the font instance, reusing the instance's
+    /// cached shaping data. The shaper borrows the instance; callers
+    /// that shape repeatedly can build it once and reuse it across
+    /// calls.
+    #[cfg(feature = "experimental_font_api")]
+    pub fn from_font_instance(font: &'a crate::font::FontInstance) -> Option<Self> {
+        Self::from_font(font)
+    }
+
     pub(crate) fn from_font(font: &'a crate::font::FontInstance) -> Option<Self> {
         let data = crate::font::_font_interop::_get_or_init_shaping_data(font, || {
             Box::new(ShaperData::from_font(font))


### PR DESCRIPTION
Lets callers that shape repeatedly build the `Shaper` — the per-call `OtTables`/`AatTables` view — once and reuse it, instead of reconstructing it inside `shape()` on every call. Experimental, gated like `shape()`.

Motivation: in the HarfBuzz bridge, the view reconstruction is ~800 instructions of dependent-load-heavy table parsing per shape call. Caching the shaper keyed on hb's variation-coords serial measures (clang release rig, harfrust shaper): **Roboto/en-words −6.2% instructions / −10.7% cycles**, Roboto/thelittleprince −1.0%/−4.2%, Devanagari Sangam/hi-words −2.4%/−4.4%, Menlo −1.4%/−2.8%, Lucida −1.1%/−2.1%, GeezaPro −0.4%/−0.6% — short-buffer workloads gain most. Outputs byte-identical throughout (including Roboto cross-engine vs hb-ot). The hb-side consumer PR follows once this is in a release.

*This PR was written by Claude (via Behdad's account).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)