### PR TITLE
[aat] Factor safe-to-break probes into the face cache

### DIFF
--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -52,7 +52,7 @@ pub struct AatApplyContext<'a> {
     pub(crate) second_set: Option<&'a U32Set>,
     pub(crate) machine_class_cache: Option<&'a ClassCache>,
     pub(crate) start_end_safe_to_break: u64,
-    pub(crate) safe_to_break_cache: Option<&'a SafeToBreakCache>,
+    pub(crate) safe_to_break_accel: Option<&'a SafeToBreakAccel>,
 }
 
 impl<'a> AatApplyContext<'a> {
@@ -76,7 +76,7 @@ impl<'a> AatApplyContext<'a> {
             second_set: None,
             machine_class_cache: None,
             start_end_safe_to_break: 0,
-            safe_to_break_cache: None,
+            safe_to_break_accel: None,
         }
     }
 
@@ -207,7 +207,7 @@ impl<'a> AatApplyContext<'a> {
 /// so instead of re-fetching those entries on every transition, look
 /// them up in two small per-machine tables built once per face:
 /// O(classes) + O(states) storage, typically a few hundred bytes.
-pub(crate) struct SafeToBreakCache {
+pub(crate) struct SafeToBreakAccel {
     n_classes: u32,
     /// Per class: `entry(START_OF_TEXT, class)` packed as 15 bits of
     /// new state with the advance bit on top when present and
@@ -231,9 +231,9 @@ pub(crate) fn pack_wouldbe(new_state: u16, advance: bool) -> u16 {
     new_state | ((advance as u16) << 15)
 }
 
-impl SafeToBreakCache {
+impl SafeToBreakAccel {
     pub(crate) fn empty() -> Self {
-        SafeToBreakCache {
+        SafeToBreakAccel {
             n_classes: 0,
             wouldbe: Vec::new(),
             eot_tail: Vec::new(),
@@ -318,7 +318,7 @@ impl SafeToBreakCache {
             }
         }
 
-        SafeToBreakCache {
+        SafeToBreakAccel {
             n_classes: n_classes as u32,
             wouldbe,
             eot_tail,
@@ -365,7 +365,7 @@ impl SafeToBreakCache {
             }
         }
 
-        SafeToBreakCache {
+        SafeToBreakAccel {
             n_classes: n_classes as u32,
             wouldbe,
             eot_tail,

--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -209,21 +209,27 @@ impl<'a> AatApplyContext<'a> {
 /// O(classes) + O(states) storage, typically a few hundred bytes.
 pub(crate) struct SafeToBreakCache {
     n_classes: u32,
-    /// Per class: `entry(START_OF_TEXT, class)` packed as
-    /// `new_state | advance << 16` when present and non-actionable,
-    /// `!0` otherwise — so condition 2c is a single compare.
-    wouldbe: Vec<u32>,
+    /// Per class: `entry(START_OF_TEXT, class)` packed as 15 bits of
+    /// new state with the advance bit on top when present and
+    /// non-actionable, `!0` otherwise — so condition 2c is a single
+    /// compare. Real machines' state counts fit 15 bits; the rare
+    /// entry that doesn't is stored as absent, which merely answers
+    /// condition 2c conservatively.
+    wouldbe: Vec<u16>,
     /// Condition-3 bits for states 64 and up; states below 64 keep
     /// using the `start_end_safe_to_break` word. Empty for machines
     /// with at most 64 states.
     eot_tail: Vec<u64>,
 }
 
-pub(crate) const WOULDBE_NONE: u32 = !0;
+pub(crate) const WOULDBE_NONE: u16 = !0;
 
 #[inline(always)]
-pub(crate) fn pack_wouldbe(new_state: u16, advance: bool) -> u32 {
-    new_state as u32 | ((advance as u32) << 16)
+pub(crate) fn pack_wouldbe(new_state: u16, advance: bool) -> u16 {
+    if new_state >= 0x7FFF {
+        return WOULDBE_NONE;
+    }
+    new_state | ((advance as u16) << 15)
 }
 
 impl SafeToBreakCache {
@@ -244,7 +250,8 @@ impl SafeToBreakCache {
         if class >= self.n_classes as usize {
             class = class::OUT_OF_BOUNDS as usize;
         }
-        self.wouldbe.get(class).copied() == Some(pack_wouldbe(next_state, advance))
+        let candidate = pack_wouldbe(next_state, advance);
+        candidate != WOULDBE_NONE && self.wouldbe.get(class).copied() == Some(candidate)
     }
 
     /// Condition 3 for states 64 and up: no end-of-text action can fire

--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -202,22 +202,21 @@ impl<'a> AatApplyContext<'a> {
 
 /// Per-face acceleration for the drive loops' safe-to-break computation.
 ///
-/// The data for every AAT state-machine subtable is stored in three packed
-/// vectors: 12 bytes of metadata per subtable, all condition-2c entries,
-/// and all condition-3 bits. This avoids two `Vec` allocations in every
-/// subtable cache while retaining O(classes) + O(states) storage.
+/// The data for every AAT state-machine subtable is stored in two packed
+/// vectors. Each top-level subtable cache carries a compact descriptor for
+/// its ranges. This avoids two `Vec` allocations in every subtable cache
+/// while retaining O(classes) + O(states) storage.
 #[derive(Default)]
 pub(crate) struct SafeToBreakAccel {
-    subtables: Vec<SafeToBreakSubtable>,
     wouldbe: Vec<u16>,
     eot_tail: Vec<u64>,
 }
 
-#[derive(Clone, Copy)]
-struct SafeToBreakSubtable {
-    n_classes: u32,
+#[derive(Clone, Copy, Default)]
+pub(crate) struct SafeToBreakSubtable {
     wouldbe_start: u32,
     eot_tail_start: u32,
+    info: u32,
 }
 
 /// The slice of [`SafeToBreakAccel`] belonging to the active subtable.
@@ -256,7 +255,7 @@ impl SafeToBreak<'_> {
         if class >= self.n_classes as usize {
             class = class::OUT_OF_BOUNDS as usize;
         }
-        self.wouldbe[class] == pack_wouldbe(next_state, advance)
+        self.wouldbe.get(class).copied() == Some(pack_wouldbe(next_state, advance))
     }
 
     /// Condition 3 for states 64 and up: no end-of-text action can fire
@@ -271,36 +270,28 @@ impl SafeToBreak<'_> {
 }
 
 impl SafeToBreakAccel {
-    /// Returns a view of the acceleration data for a subtable. Subtables are
-    /// registered in the same order as the three top-level cache arrays.
-    pub(crate) fn subtable(&self, index: usize) -> Option<SafeToBreak<'_>> {
-        let subtable = *self.subtables.get(index)?;
-        let next = self.subtables.get(index + 1);
-        let wouldbe_end = next.map_or(self.wouldbe.len(), |subtable| {
-            subtable.wouldbe_start as usize
-        });
-        let eot_tail_end = next.map_or(self.eot_tail.len(), |subtable| {
-            subtable.eot_tail_start as usize
-        });
+    /// Returns a view of the acceleration data described by a top-level
+    /// subtable cache.
+    pub(crate) fn subtable(&self, subtable: SafeToBreakSubtable) -> Option<SafeToBreak<'_>> {
+        let wouldbe_start = subtable.wouldbe_start as usize;
+        let wouldbe_end = wouldbe_start.checked_add(subtable.wouldbe_len())?;
+        let eot_tail_start = subtable.eot_tail_start as usize;
+        let eot_tail_end = eot_tail_start.checked_add(subtable.eot_tail_len())?;
 
         Some(SafeToBreak {
-            n_classes: subtable.n_classes,
-            wouldbe: self
-                .wouldbe
-                .get(subtable.wouldbe_start as usize..wouldbe_end)?,
-            eot_tail: self
-                .eot_tail
-                .get(subtable.eot_tail_start as usize..eot_tail_end)?,
+            n_classes: subtable.n_classes(),
+            wouldbe: self.wouldbe.get(wouldbe_start..wouldbe_end)?,
+            eot_tail: self.eot_tail.get(eot_tail_start..eot_tail_end)?,
         })
     }
 
-    /// Registers a subtable that does not contain a state machine.
-    pub(crate) fn add_empty(&mut self) {
-        self.subtables.push(SafeToBreakSubtable {
-            n_classes: 0,
+    /// Describes a subtable that does not contain a state machine.
+    pub(crate) fn empty_subtable(&self) -> SafeToBreakSubtable {
+        SafeToBreakSubtable {
             wouldbe_start: self.wouldbe.len() as u32,
             eot_tail_start: self.eot_tail.len() as u32,
-        });
+            info: 0,
+        }
     }
 
     /// Appends the data for an extended state table whose machine
@@ -313,13 +304,10 @@ impl SafeToBreakAccel {
         data: &[u8],
         is_actionable: &dyn Fn(&StateEntry<T>) -> bool,
         can_advance: &dyn Fn(&StateEntry<T>) -> bool,
-    ) {
+    ) -> SafeToBreakSubtable {
         let n_classes = machine.n_classes;
-        self.subtables.push(SafeToBreakSubtable {
-            n_classes: n_classes as u32,
-            wouldbe_start: self.wouldbe.len() as u32,
-            eot_tail_start: self.eot_tail.len() as u32,
-        });
+        let wouldbe_start = self.wouldbe.len();
+        let eot_tail_start = self.eot_tail.len();
 
         // Cover the OUT_OF_BOUNDS column the runtime clamp can select
         // even on degenerate machines; entry() applies the same clamp
@@ -366,6 +354,14 @@ impl SafeToBreakAccel {
                 }
             }
         }
+
+        SafeToBreakSubtable::new(
+            n_classes,
+            wouldbe_start,
+            self.wouldbe.len(),
+            eot_tail_start,
+            self.eot_tail.len(),
+        )
     }
 
     /// The legacy (`kern` Format1) counterpart of [`Self::build_extended`]:
@@ -376,13 +372,10 @@ impl SafeToBreakAccel {
         machine: &StateTable,
         is_actionable: &dyn Fn(&StateEntry) -> bool,
         can_advance: &dyn Fn(&StateEntry) -> bool,
-    ) {
+    ) -> SafeToBreakSubtable {
         let n_classes = machine.header.state_size() as usize;
-        self.subtables.push(SafeToBreakSubtable {
-            n_classes: n_classes as u32,
-            wouldbe_start: self.wouldbe.len() as u32,
-            eot_tail_start: self.eot_tail.len() as u32,
-        });
+        let wouldbe_start = self.wouldbe.len();
+        let eot_tail_start = self.eot_tail.len();
 
         let wouldbe_len = n_classes.max(class::OUT_OF_BOUNDS as usize + 1).min(1 << 8);
         self.wouldbe.reserve(wouldbe_len);
@@ -415,6 +408,61 @@ impl SafeToBreakAccel {
                 }
             }
         }
+
+        SafeToBreakSubtable::new(
+            n_classes,
+            wouldbe_start,
+            self.wouldbe.len(),
+            eot_tail_start,
+            self.eot_tail.len(),
+        )
+    }
+}
+
+impl SafeToBreakSubtable {
+    const N_CLASSES_MASK: u32 = (1 << 17) - 1;
+    const EOT_TAIL_SHIFT: u32 = 17;
+    const EOT_TAIL_MASK: u32 = (1 << 10) - 1;
+    const HAS_MACHINE: u32 = 1 << 27;
+
+    fn new(
+        n_classes: usize,
+        wouldbe_start: usize,
+        wouldbe_end: usize,
+        eot_tail_start: usize,
+        eot_tail_end: usize,
+    ) -> Self {
+        let n_classes = n_classes.min(1 << 16);
+        let wouldbe_len = n_classes
+            .max(class::OUT_OF_BOUNDS as usize + 1)
+            .min(1 << 16);
+        let eot_tail_len = eot_tail_end - eot_tail_start;
+        debug_assert_eq!(wouldbe_end - wouldbe_start, wouldbe_len);
+        debug_assert!(eot_tail_len <= Self::EOT_TAIL_MASK as usize);
+        Self {
+            wouldbe_start: wouldbe_start as u32,
+            eot_tail_start: eot_tail_start as u32,
+            info: n_classes as u32
+                | (eot_tail_len as u32) << Self::EOT_TAIL_SHIFT
+                | Self::HAS_MACHINE,
+        }
+    }
+
+    fn n_classes(self) -> u32 {
+        self.info & Self::N_CLASSES_MASK
+    }
+
+    fn wouldbe_len(self) -> usize {
+        if self.info & Self::HAS_MACHINE == 0 {
+            return 0;
+        }
+        (self.n_classes() as usize)
+            .max(class::OUT_OF_BOUNDS as usize + 1)
+            .min(1 << 16)
+    }
+
+    fn eot_tail_len(self) -> usize {
+        ((self.info >> Self::EOT_TAIL_SHIFT) & Self::EOT_TAIL_MASK) as usize
     }
 }
 
@@ -680,39 +728,29 @@ mod tests {
         let mut wouldbe = alloc::vec![WOULDBE_NONE; 8];
         wouldbe[class::OUT_OF_BOUNDS as usize] = pack_wouldbe(7, true);
         wouldbe[4 + class::OUT_OF_BOUNDS as usize] = pack_wouldbe(9, false);
+        let first_subtable = SafeToBreakSubtable::new(4, 0, 4, 0, 1);
+        let empty_subtable = SafeToBreakSubtable {
+            wouldbe_start: 4,
+            eot_tail_start: 1,
+            info: 0,
+        };
+        let last_subtable = SafeToBreakSubtable::new(4, 4, 8, 1, 2);
         let accel = SafeToBreakAccel {
-            subtables: alloc::vec![
-                SafeToBreakSubtable {
-                    n_classes: 4,
-                    wouldbe_start: 0,
-                    eot_tail_start: 0,
-                },
-                SafeToBreakSubtable {
-                    n_classes: 0,
-                    wouldbe_start: 4,
-                    eot_tail_start: 1,
-                },
-                SafeToBreakSubtable {
-                    n_classes: 4,
-                    wouldbe_start: 4,
-                    eot_tail_start: 1,
-                },
-            ],
             wouldbe,
             eot_tail: alloc::vec![1, 2],
         };
 
-        let first = accel.subtable(0).unwrap();
+        let first = accel.subtable(first_subtable).unwrap();
         assert!(first.wouldbe_matches(99, 7, true));
         assert!(first.eot_safe_high(64));
         assert!(!first.eot_safe_high(65));
         assert!(!first.eot_safe_high(128));
 
-        let empty = accel.subtable(1).unwrap();
+        let empty = accel.subtable(empty_subtable).unwrap();
         assert!(empty.wouldbe.is_empty());
         assert!(empty.eot_tail.is_empty());
 
-        let last = accel.subtable(2).unwrap();
+        let last = accel.subtable(last_subtable).unwrap();
         assert!(last.wouldbe_matches(99, 9, false));
         assert!(!last.eot_safe_high(64));
         assert!(last.eot_safe_high(65));

--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -212,9 +212,7 @@ pub(crate) struct SafeToBreakCache {
     /// Per class: `entry(START_OF_TEXT, class)` packed as 15 bits of
     /// new state with the advance bit on top when present and
     /// non-actionable, `!0` otherwise — so condition 2c is a single
-    /// compare. Real machines' state counts fit 15 bits; the rare
-    /// entry that doesn't is stored as absent, which merely answers
-    /// condition 2c conservatively.
+    /// compare. Real machines' state counts fit 15 bits.
     wouldbe: Vec<u16>,
     /// Condition-3 bits for states 64 and up; states below 64 keep
     /// using the `start_end_safe_to_break` word. Empty for machines
@@ -226,9 +224,10 @@ pub(crate) const WOULDBE_NONE: u16 = !0;
 
 #[inline(always)]
 pub(crate) fn pack_wouldbe(new_state: u16, advance: bool) -> u16 {
-    if new_state >= 0x7FFF {
-        return WOULDBE_NONE;
-    }
+    // States fit 15 bits in any real font. A pathological new state
+    // that doesn't can alias the sentinel and misreport condition 2c,
+    // which only perturbs unsafe-to-break flags -- not worth runtime
+    // checks on this path.
     new_state | ((advance as u16) << 15)
 }
 
@@ -250,8 +249,7 @@ impl SafeToBreakCache {
         if class >= self.n_classes as usize {
             class = class::OUT_OF_BOUNDS as usize;
         }
-        let candidate = pack_wouldbe(next_state, advance);
-        candidate != WOULDBE_NONE && self.wouldbe.get(class).copied() == Some(candidate)
+        self.wouldbe.get(class).copied() == Some(pack_wouldbe(next_state, advance))
     }
 
     /// Condition 3 for states 64 and up: no end-of-text action can fire

--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -52,7 +52,7 @@ pub struct AatApplyContext<'a> {
     pub(crate) second_set: Option<&'a U32Set>,
     pub(crate) machine_class_cache: Option<&'a ClassCache>,
     pub(crate) start_end_safe_to_break: u64,
-    pub(crate) safe_to_break_accel: Option<&'a SafeToBreakAccel>,
+    pub(crate) safe_to_break: SafeToBreak<'a>,
 }
 
 impl<'a> AatApplyContext<'a> {
@@ -76,7 +76,7 @@ impl<'a> AatApplyContext<'a> {
             second_set: None,
             machine_class_cache: None,
             start_end_safe_to_break: 0,
-            safe_to_break_accel: None,
+            safe_to_break: SafeToBreak::default(),
         }
     }
 
@@ -200,24 +200,39 @@ impl<'a> AatApplyContext<'a> {
     }
 }
 
-/// Per-machine acceleration for the drive loops' safe-to-break
-/// computation. The conditions factor by state and class: condition
-/// 2c's "wouldbe" probe (`entry(START_OF_TEXT, class)`) depends only on
-/// the class, and condition 3's end-of-text probe only on the state —
-/// so instead of re-fetching those entries on every transition, look
-/// them up in two small per-machine tables built once per face:
-/// O(classes) + O(states) storage, typically a few hundred bytes.
+/// Per-face acceleration for the drive loops' safe-to-break computation.
+///
+/// The data for every AAT state-machine subtable is stored in three packed
+/// vectors: 12 bytes of metadata per subtable, all condition-2c entries,
+/// and all condition-3 bits. This avoids two `Vec` allocations in every
+/// subtable cache while retaining O(classes) + O(states) storage.
+#[derive(Default)]
 pub(crate) struct SafeToBreakAccel {
+    subtables: Vec<SafeToBreakSubtable>,
+    wouldbe: Vec<u16>,
+    eot_tail: Vec<u64>,
+}
+
+#[derive(Clone, Copy)]
+struct SafeToBreakSubtable {
+    n_classes: u32,
+    wouldbe_start: u32,
+    eot_tail_start: u32,
+}
+
+/// The slice of [`SafeToBreakAccel`] belonging to the active subtable.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct SafeToBreak<'a> {
     n_classes: u32,
     /// Per class: `entry(START_OF_TEXT, class)` packed as 15 bits of
     /// new state with the advance bit on top when present and
     /// non-actionable, `!0` otherwise — so condition 2c is a single
     /// compare. Real machines' state counts fit 15 bits.
-    wouldbe: Vec<u16>,
+    wouldbe: &'a [u16],
     /// Condition-3 bits for states 64 and up; states below 64 keep
     /// using the `start_end_safe_to_break` word. Empty for machines
     /// with at most 64 states.
-    eot_tail: Vec<u64>,
+    eot_tail: &'a [u64],
 }
 
 pub(crate) const WOULDBE_NONE: u16 = !0;
@@ -231,15 +246,7 @@ pub(crate) fn pack_wouldbe(new_state: u16, advance: bool) -> u16 {
     new_state | ((advance as u16) << 15)
 }
 
-impl SafeToBreakAccel {
-    pub(crate) fn empty() -> Self {
-        SafeToBreakAccel {
-            n_classes: 0,
-            wouldbe: Vec::new(),
-            eot_tail: Vec::new(),
-        }
-    }
-
+impl SafeToBreak<'_> {
     /// Condition 2c: would starting from the start state on this class
     /// take a non-actionable transition to the same state, advancing
     /// the same way?
@@ -249,7 +256,7 @@ impl SafeToBreakAccel {
         if class >= self.n_classes as usize {
             class = class::OUT_OF_BOUNDS as usize;
         }
-        self.wouldbe.get(class).copied() == Some(pack_wouldbe(next_state, advance))
+        self.wouldbe[class] == pack_wouldbe(next_state, advance)
     }
 
     /// Condition 3 for states 64 and up: no end-of-text action can fire
@@ -261,18 +268,58 @@ impl SafeToBreakAccel {
             .get(ix / 64)
             .is_some_and(|word| word & (1 << (ix % 64)) != 0)
     }
+}
 
-    /// Builds the cache for an extended state table whose machine
+impl SafeToBreakAccel {
+    /// Returns a view of the acceleration data for a subtable. Subtables are
+    /// registered in the same order as the three top-level cache arrays.
+    pub(crate) fn subtable(&self, index: usize) -> Option<SafeToBreak<'_>> {
+        let subtable = *self.subtables.get(index)?;
+        let next = self.subtables.get(index + 1);
+        let wouldbe_end = next.map_or(self.wouldbe.len(), |subtable| {
+            subtable.wouldbe_start as usize
+        });
+        let eot_tail_end = next.map_or(self.eot_tail.len(), |subtable| {
+            subtable.eot_tail_start as usize
+        });
+
+        Some(SafeToBreak {
+            n_classes: subtable.n_classes,
+            wouldbe: self
+                .wouldbe
+                .get(subtable.wouldbe_start as usize..wouldbe_end)?,
+            eot_tail: self
+                .eot_tail
+                .get(subtable.eot_tail_start as usize..eot_tail_end)?,
+        })
+    }
+
+    /// Registers a subtable that does not contain a state machine.
+    pub(crate) fn add_empty(&mut self) {
+        self.subtables.push(SafeToBreakSubtable {
+            n_classes: 0,
+            wouldbe_start: self.wouldbe.len() as u32,
+            eot_tail_start: self.eot_tail.len() as u32,
+        });
+    }
+
+    /// Appends the data for an extended state table whose machine
     /// starts at the beginning of `data`. The predicates mirror the
     /// subtable kind's notion of actionable/advancing entries.
     #[inline(never)]
     pub(crate) fn build_extended<T: bytemuck::AnyBitPattern + FixedSize>(
+        &mut self,
         machine: &ExtendedStateTable<T>,
         data: &[u8],
         is_actionable: &dyn Fn(&StateEntry<T>) -> bool,
         can_advance: &dyn Fn(&StateEntry<T>) -> bool,
-    ) -> Self {
+    ) {
         let n_classes = machine.n_classes;
+        self.subtables.push(SafeToBreakSubtable {
+            n_classes: n_classes as u32,
+            wouldbe_start: self.wouldbe.len() as u32,
+            eot_tail_start: self.eot_tail.len() as u32,
+        });
 
         // Cover the OUT_OF_BOUNDS column the runtime clamp can select
         // even on degenerate machines; entry() applies the same clamp
@@ -282,93 +329,91 @@ impl SafeToBreakAccel {
         let wouldbe_len = n_classes
             .max(class::OUT_OF_BOUNDS as usize + 1)
             .min(1 << 16);
-        let mut wouldbe = Vec::with_capacity(wouldbe_len);
+        self.wouldbe.reserve(wouldbe_len);
         for class in 0..wouldbe_len {
-            wouldbe.push(match machine.entry(START_OF_TEXT, class as u16) {
-                Ok(entry) if !is_actionable(&entry) => {
-                    pack_wouldbe(entry.new_state, can_advance(&entry))
-                }
-                _ => WOULDBE_NONE,
-            });
+            self.wouldbe
+                .push(match machine.entry(START_OF_TEXT, class as u16) {
+                    Ok(entry) if !is_actionable(&entry) => {
+                        pack_wouldbe(entry.new_state, can_advance(&entry))
+                    }
+                    _ => WOULDBE_NONE,
+                });
         }
 
         // The state array runs from its offset to the end of the
         // subtable, matching how the table reader slices it; states
         // beyond it fail entry() and stay unsafe, like the probes they
         // replace.
-        let mut eot_tail = Vec::new();
         if n_classes > 0 {
             if let Ok(parts) = StateTableParts::read(FontData::new(data)) {
                 let n_cells = data.len().saturating_sub(parts.state_array_offset as usize)
                     / u16::RAW_BYTE_LEN;
                 let n_rows = n_cells.div_ceil(n_classes).min(u16::MAX as usize + 1);
                 if n_rows > 64 {
-                    eot_tail = alloc::vec![0u64; (n_rows - 64).div_ceil(64)];
+                    let eot_tail_start = self.eot_tail.len();
+                    self.eot_tail
+                        .resize(eot_tail_start + (n_rows - 64).div_ceil(64), 0);
                     for state in 64..n_rows {
                         if let Ok(entry) =
                             machine.entry(state as u16, u16::from(class::END_OF_TEXT))
                         {
                             if !is_actionable(&entry) {
                                 let ix = state - 64;
-                                eot_tail[ix / 64] |= 1 << (ix % 64);
+                                self.eot_tail[eot_tail_start + ix / 64] |= 1 << (ix % 64);
                             }
                         }
                     }
                 }
             }
         }
-
-        SafeToBreakAccel {
-            n_classes: n_classes as u32,
-            wouldbe,
-            eot_tail,
-        }
     }
 
-    /// The legacy (`kern` Format1) counterpart of [`build_extended`]:
+    /// The legacy (`kern` Format1) counterpart of [`Self::build_extended`]:
     /// one-byte state cells and u8 classes.
     #[inline(never)]
     pub(crate) fn build_legacy(
+        &mut self,
         machine: &StateTable,
         is_actionable: &dyn Fn(&StateEntry) -> bool,
         can_advance: &dyn Fn(&StateEntry) -> bool,
-    ) -> Self {
+    ) {
         let n_classes = machine.header.state_size() as usize;
+        self.subtables.push(SafeToBreakSubtable {
+            n_classes: n_classes as u32,
+            wouldbe_start: self.wouldbe.len() as u32,
+            eot_tail_start: self.eot_tail.len() as u32,
+        });
 
         let wouldbe_len = n_classes.max(class::OUT_OF_BOUNDS as usize + 1).min(1 << 8);
-        let mut wouldbe = Vec::with_capacity(wouldbe_len);
+        self.wouldbe.reserve(wouldbe_len);
         for class in 0..wouldbe_len {
-            wouldbe.push(match machine.entry(START_OF_TEXT, class as u8) {
-                Ok(entry) if !is_actionable(&entry) => {
-                    pack_wouldbe(entry.new_state, can_advance(&entry))
-                }
-                _ => WOULDBE_NONE,
-            });
+            self.wouldbe
+                .push(match machine.entry(START_OF_TEXT, class as u8) {
+                    Ok(entry) if !is_actionable(&entry) => {
+                        pack_wouldbe(entry.new_state, can_advance(&entry))
+                    }
+                    _ => WOULDBE_NONE,
+                });
         }
 
-        let mut eot_tail = Vec::new();
         if n_classes > 0 {
             if let Ok(state_array) = machine.header.state_array() {
                 let n_cells = state_array.data().len();
                 let n_rows = n_cells.div_ceil(n_classes).min(u16::MAX as usize + 1);
                 if n_rows > 64 {
-                    eot_tail = alloc::vec![0u64; (n_rows - 64).div_ceil(64)];
+                    let eot_tail_start = self.eot_tail.len();
+                    self.eot_tail
+                        .resize(eot_tail_start + (n_rows - 64).div_ceil(64), 0);
                     for state in 64..n_rows {
                         if let Ok(entry) = machine.entry(state as u16, class::END_OF_TEXT) {
                             if !is_actionable(&entry) {
                                 let ix = state - 64;
-                                eot_tail[ix / 64] |= 1 << (ix % 64);
+                                self.eot_tail[eot_tail_start + ix / 64] |= 1 << (ix % 64);
                             }
                         }
                     }
                 }
             }
-        }
-
-        SafeToBreakAccel {
-            n_classes: n_classes as u32,
-            wouldbe,
-            eot_tail,
         }
     }
 }
@@ -626,6 +671,52 @@ impl CollectGlyphs for Lookup10<'_> {
 mod tests {
     use super::*;
     use crate::{Direction, FontRef, ShapePlan, ShaperData, UnicodeBuffer};
+    use core::mem::size_of;
+
+    #[test]
+    fn safe_to_break_subtable_views_are_packed_and_bounded() {
+        assert_eq!(size_of::<SafeToBreakSubtable>(), 12);
+
+        let mut wouldbe = alloc::vec![WOULDBE_NONE; 8];
+        wouldbe[class::OUT_OF_BOUNDS as usize] = pack_wouldbe(7, true);
+        wouldbe[4 + class::OUT_OF_BOUNDS as usize] = pack_wouldbe(9, false);
+        let accel = SafeToBreakAccel {
+            subtables: alloc::vec![
+                SafeToBreakSubtable {
+                    n_classes: 4,
+                    wouldbe_start: 0,
+                    eot_tail_start: 0,
+                },
+                SafeToBreakSubtable {
+                    n_classes: 0,
+                    wouldbe_start: 4,
+                    eot_tail_start: 1,
+                },
+                SafeToBreakSubtable {
+                    n_classes: 4,
+                    wouldbe_start: 4,
+                    eot_tail_start: 1,
+                },
+            ],
+            wouldbe,
+            eot_tail: alloc::vec![1, 2],
+        };
+
+        let first = accel.subtable(0).unwrap();
+        assert!(first.wouldbe_matches(99, 7, true));
+        assert!(first.eot_safe_high(64));
+        assert!(!first.eot_safe_high(65));
+        assert!(!first.eot_safe_high(128));
+
+        let empty = accel.subtable(1).unwrap();
+        assert!(empty.wouldbe.is_empty());
+        assert!(empty.eot_tail.is_empty());
+
+        let last = accel.subtable(2).unwrap();
+        assert!(last.wouldbe_matches(99, 9, false));
+        assert!(!last.eot_safe_high(64));
+        assert!(last.eot_safe_high(65));
+    }
 
     #[test]
     fn output_deleted_glyph_at_end_of_text_marks_output() {

--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -294,9 +294,7 @@ impl SafeToBreakCache {
         let mut eot_tail = Vec::new();
         if n_classes > 0 {
             if let Ok(parts) = StateTableParts::read(FontData::new(data)) {
-                let n_cells = data
-                    .len()
-                    .saturating_sub(parts.state_array_offset as usize)
+                let n_cells = data.len().saturating_sub(parts.state_array_offset as usize)
                     / u16::RAW_BYTE_LEN;
                 let n_rows = n_cells.div_ceil(n_classes).min(u16::MAX as usize + 1);
                 if n_rows > 64 {
@@ -332,9 +330,7 @@ impl SafeToBreakCache {
     ) -> Self {
         let n_classes = machine.header.state_size() as usize;
 
-        let wouldbe_len = n_classes
-            .max(class::OUT_OF_BOUNDS as usize + 1)
-            .min(1 << 8);
+        let wouldbe_len = n_classes.max(class::OUT_OF_BOUNDS as usize + 1).min(1 << 8);
         let mut wouldbe = Vec::with_capacity(wouldbe_len);
         for class in 0..wouldbe_len {
             wouldbe.push(match machine.entry(START_OF_TEXT, class as u8) {

--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -215,8 +215,9 @@ pub(crate) struct SafeToBreakAccel {
 #[derive(Clone, Copy, Default)]
 pub(crate) struct SafeToBreakSubtable {
     wouldbe_start: u32,
+    wouldbe_end: u32,
     eot_tail_start: u32,
-    info: u32,
+    eot_tail_end: u32,
 }
 
 /// The slice of [`SafeToBreakAccel`] belonging to the active subtable.
@@ -274,12 +275,12 @@ impl SafeToBreakAccel {
     /// subtable cache.
     pub(crate) fn subtable(&self, subtable: SafeToBreakSubtable) -> Option<SafeToBreak<'_>> {
         let wouldbe_start = subtable.wouldbe_start as usize;
-        let wouldbe_end = wouldbe_start.checked_add(subtable.wouldbe_len())?;
+        let wouldbe_end = subtable.wouldbe_end as usize;
         let eot_tail_start = subtable.eot_tail_start as usize;
-        let eot_tail_end = eot_tail_start.checked_add(subtable.eot_tail_len())?;
+        let eot_tail_end = subtable.eot_tail_end as usize;
 
         Some(SafeToBreak {
-            n_classes: subtable.n_classes(),
+            n_classes: subtable.wouldbe_end - subtable.wouldbe_start,
             wouldbe: self.wouldbe.get(wouldbe_start..wouldbe_end)?,
             eot_tail: self.eot_tail.get(eot_tail_start..eot_tail_end)?,
         })
@@ -289,8 +290,9 @@ impl SafeToBreakAccel {
     pub(crate) fn empty_subtable(&self) -> SafeToBreakSubtable {
         SafeToBreakSubtable {
             wouldbe_start: self.wouldbe.len() as u32,
+            wouldbe_end: self.wouldbe.len() as u32,
             eot_tail_start: self.eot_tail.len() as u32,
-            info: 0,
+            eot_tail_end: self.eot_tail.len() as u32,
         }
     }
 
@@ -420,11 +422,6 @@ impl SafeToBreakAccel {
 }
 
 impl SafeToBreakSubtable {
-    const N_CLASSES_MASK: u32 = (1 << 17) - 1;
-    const EOT_TAIL_SHIFT: u32 = 17;
-    const EOT_TAIL_MASK: u32 = (1 << 10) - 1;
-    const HAS_MACHINE: u32 = 1 << 27;
-
     fn new(
         n_classes: usize,
         wouldbe_start: usize,
@@ -432,37 +429,16 @@ impl SafeToBreakSubtable {
         eot_tail_start: usize,
         eot_tail_end: usize,
     ) -> Self {
-        let n_classes = n_classes.min(1 << 16);
         let wouldbe_len = n_classes
             .max(class::OUT_OF_BOUNDS as usize + 1)
             .min(1 << 16);
-        let eot_tail_len = eot_tail_end - eot_tail_start;
         debug_assert_eq!(wouldbe_end - wouldbe_start, wouldbe_len);
-        debug_assert!(eot_tail_len <= Self::EOT_TAIL_MASK as usize);
         Self {
             wouldbe_start: wouldbe_start as u32,
+            wouldbe_end: wouldbe_end as u32,
             eot_tail_start: eot_tail_start as u32,
-            info: n_classes as u32
-                | (eot_tail_len as u32) << Self::EOT_TAIL_SHIFT
-                | Self::HAS_MACHINE,
+            eot_tail_end: eot_tail_end as u32,
         }
-    }
-
-    fn n_classes(self) -> u32 {
-        self.info & Self::N_CLASSES_MASK
-    }
-
-    fn wouldbe_len(self) -> usize {
-        if self.info & Self::HAS_MACHINE == 0 {
-            return 0;
-        }
-        (self.n_classes() as usize)
-            .max(class::OUT_OF_BOUNDS as usize + 1)
-            .min(1 << 16)
-    }
-
-    fn eot_tail_len(self) -> usize {
-        ((self.info >> Self::EOT_TAIL_SHIFT) & Self::EOT_TAIL_MASK) as usize
     }
 }
 
@@ -723,7 +699,7 @@ mod tests {
 
     #[test]
     fn safe_to_break_subtable_views_are_packed_and_bounded() {
-        assert_eq!(size_of::<SafeToBreakSubtable>(), 12);
+        assert_eq!(size_of::<SafeToBreakSubtable>(), 16);
 
         let mut wouldbe = alloc::vec![WOULDBE_NONE; 8];
         wouldbe[class::OUT_OF_BOUNDS as usize] = pack_wouldbe(7, true);
@@ -731,8 +707,9 @@ mod tests {
         let first_subtable = SafeToBreakSubtable::new(4, 0, 4, 0, 1);
         let empty_subtable = SafeToBreakSubtable {
             wouldbe_start: 4,
+            wouldbe_end: 4,
             eot_tail_start: 1,
-            info: 0,
+            eot_tail_end: 1,
         };
         let last_subtable = SafeToBreakSubtable::new(4, 4, 8, 1, 2);
         let accel = SafeToBreakAccel {

--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -7,8 +7,10 @@ use crate::hb::hb_mask_t;
 use crate::hb::ot_layout_gsubgpos::MappingCache;
 use crate::hb::ot_shape_plan::hb_ot_shape_plan_t;
 use crate::U32Set;
+use alloc::vec::Vec;
 use read_fonts::tables::aat::*;
 use read_fonts::types::{FixedSize, GlyphId};
+use read_fonts::FontData;
 
 pub const HB_BUFFER_SCRATCH_FLAG_AAT_HAS_DELETED: u32 = HB_BUFFER_SCRATCH_FLAG_SHAPER0;
 
@@ -50,6 +52,7 @@ pub struct AatApplyContext<'a> {
     pub(crate) second_set: Option<&'a U32Set>,
     pub(crate) machine_class_cache: Option<&'a ClassCache>,
     pub(crate) start_end_safe_to_break: u64,
+    pub(crate) safe_to_break_cache: Option<&'a SafeToBreakCache>,
 }
 
 impl<'a> AatApplyContext<'a> {
@@ -73,6 +76,7 @@ impl<'a> AatApplyContext<'a> {
             second_set: None,
             machine_class_cache: None,
             start_end_safe_to_break: 0,
+            safe_to_break_cache: None,
         }
     }
 
@@ -192,6 +196,178 @@ impl<'a> AatApplyContext<'a> {
         }
         if self.has_glyph_classes {
             self.buffer.info[i].set_glyph_props(self.face.ot_tables.glyph_props(glyph.into()));
+        }
+    }
+}
+
+/// Per-machine acceleration for the drive loops' safe-to-break
+/// computation. The conditions factor by state and class: condition
+/// 2c's "wouldbe" probe (`entry(START_OF_TEXT, class)`) depends only on
+/// the class, and condition 3's end-of-text probe only on the state —
+/// so instead of re-fetching those entries on every transition, look
+/// them up in two small per-machine tables built once per face:
+/// O(classes) + O(states) storage, typically a few hundred bytes.
+pub(crate) struct SafeToBreakCache {
+    n_classes: u32,
+    /// Per class: `entry(START_OF_TEXT, class)` packed as
+    /// `new_state | advance << 16` when present and non-actionable,
+    /// `!0` otherwise — so condition 2c is a single compare.
+    wouldbe: Vec<u32>,
+    /// Condition-3 bits for states 64 and up; states below 64 keep
+    /// using the `start_end_safe_to_break` word. Empty for machines
+    /// with at most 64 states.
+    eot_tail: Vec<u64>,
+}
+
+pub(crate) const WOULDBE_NONE: u32 = !0;
+
+#[inline(always)]
+pub(crate) fn pack_wouldbe(new_state: u16, advance: bool) -> u32 {
+    new_state as u32 | ((advance as u32) << 16)
+}
+
+impl SafeToBreakCache {
+    pub(crate) fn empty() -> Self {
+        SafeToBreakCache {
+            n_classes: 0,
+            wouldbe: Vec::new(),
+            eot_tail: Vec::new(),
+        }
+    }
+
+    /// Condition 2c: would starting from the start state on this class
+    /// take a non-actionable transition to the same state, advancing
+    /// the same way?
+    #[inline(always)]
+    pub(crate) fn wouldbe_matches(&self, class: u16, next_state: u16, advance: bool) -> bool {
+        let mut class = class as usize;
+        if class >= self.n_classes as usize {
+            class = class::OUT_OF_BOUNDS as usize;
+        }
+        self.wouldbe.get(class).copied() == Some(pack_wouldbe(next_state, advance))
+    }
+
+    /// Condition 3 for states 64 and up: no end-of-text action can fire
+    /// out of this state.
+    #[inline(always)]
+    pub(crate) fn eot_safe_high(&self, state: u16) -> bool {
+        let ix = (state - 64) as usize;
+        self.eot_tail
+            .get(ix / 64)
+            .is_some_and(|word| word & (1 << (ix % 64)) != 0)
+    }
+
+    /// Builds the cache for an extended state table whose machine
+    /// starts at the beginning of `data`. The predicates mirror the
+    /// subtable kind's notion of actionable/advancing entries.
+    #[inline(never)]
+    pub(crate) fn build_extended<T: bytemuck::AnyBitPattern + FixedSize>(
+        machine: &ExtendedStateTable<T>,
+        data: &[u8],
+        is_actionable: &dyn Fn(&StateEntry<T>) -> bool,
+        can_advance: &dyn Fn(&StateEntry<T>) -> bool,
+    ) -> Self {
+        let n_classes = machine.n_classes;
+
+        // Cover the OUT_OF_BOUNDS column the runtime clamp can select
+        // even on degenerate machines; entry() applies the same clamp
+        // internally, so the aliasing matches.
+        // Classes are u16 values, so columns past 0x10000 are
+        // unreachable and need no slots.
+        let wouldbe_len = n_classes
+            .max(class::OUT_OF_BOUNDS as usize + 1)
+            .min(1 << 16);
+        let mut wouldbe = Vec::with_capacity(wouldbe_len);
+        for class in 0..wouldbe_len {
+            wouldbe.push(match machine.entry(START_OF_TEXT, class as u16) {
+                Ok(entry) if !is_actionable(&entry) => {
+                    pack_wouldbe(entry.new_state, can_advance(&entry))
+                }
+                _ => WOULDBE_NONE,
+            });
+        }
+
+        // The state array runs from its offset to the end of the
+        // subtable, matching how the table reader slices it; states
+        // beyond it fail entry() and stay unsafe, like the probes they
+        // replace.
+        let mut eot_tail = Vec::new();
+        if n_classes > 0 {
+            if let Ok(parts) = StateTableParts::read(FontData::new(data)) {
+                let n_cells = data
+                    .len()
+                    .saturating_sub(parts.state_array_offset as usize)
+                    / u16::RAW_BYTE_LEN;
+                let n_rows = n_cells.div_ceil(n_classes).min(u16::MAX as usize + 1);
+                if n_rows > 64 {
+                    eot_tail = alloc::vec![0u64; (n_rows - 64).div_ceil(64)];
+                    for state in 64..n_rows {
+                        if let Ok(entry) =
+                            machine.entry(state as u16, u16::from(class::END_OF_TEXT))
+                        {
+                            if !is_actionable(&entry) {
+                                let ix = state - 64;
+                                eot_tail[ix / 64] |= 1 << (ix % 64);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        SafeToBreakCache {
+            n_classes: n_classes as u32,
+            wouldbe,
+            eot_tail,
+        }
+    }
+
+    /// The legacy (`kern` Format1) counterpart of [`build_extended`]:
+    /// one-byte state cells and u8 classes.
+    #[inline(never)]
+    pub(crate) fn build_legacy(
+        machine: &StateTable,
+        is_actionable: &dyn Fn(&StateEntry) -> bool,
+        can_advance: &dyn Fn(&StateEntry) -> bool,
+    ) -> Self {
+        let n_classes = machine.header.state_size() as usize;
+
+        let wouldbe_len = n_classes
+            .max(class::OUT_OF_BOUNDS as usize + 1)
+            .min(1 << 8);
+        let mut wouldbe = Vec::with_capacity(wouldbe_len);
+        for class in 0..wouldbe_len {
+            wouldbe.push(match machine.entry(START_OF_TEXT, class as u8) {
+                Ok(entry) if !is_actionable(&entry) => {
+                    pack_wouldbe(entry.new_state, can_advance(&entry))
+                }
+                _ => WOULDBE_NONE,
+            });
+        }
+
+        let mut eot_tail = Vec::new();
+        if n_classes > 0 {
+            if let Ok(state_array) = machine.header.state_array() {
+                let n_cells = state_array.data().len();
+                let n_rows = n_cells.div_ceil(n_classes).min(u16::MAX as usize + 1);
+                if n_rows > 64 {
+                    eot_tail = alloc::vec![0u64; (n_rows - 64).div_ceil(64)];
+                    for state in 64..n_rows {
+                        if let Ok(entry) = machine.entry(state as u16, class::END_OF_TEXT) {
+                            if !is_actionable(&entry) {
+                                let ix = state - 64;
+                                eot_tail[ix / 64] |= 1 << (ix % 64);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        SafeToBreakCache {
+            n_classes: n_classes as u32,
+            wouldbe,
+            eot_tail,
         }
     }
 }

--- a/harfrust/src/hb/aat/layout_kerx_table.rs
+++ b/harfrust/src/hb/aat/layout_kerx_table.rs
@@ -60,11 +60,11 @@ pub(crate) fn apply(c: &mut AatApplyContext) -> Option<()> {
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
+        c.safe_to_break = safe_to_break.subtable(subtable_cache.safe_to_break)?;
 
         if !c.buffer_intersects_machine() {
             continue;
         }
-        c.safe_to_break = safe_to_break.subtable(subtable_cache.safe_to_break)?;
 
         let reverse = c.buffer.direction.is_backward();
 

--- a/harfrust/src/hb/aat/layout_kerx_table.rs
+++ b/harfrust/src/hb/aat/layout_kerx_table.rs
@@ -1,6 +1,6 @@
 use super::layout::DELETED_GLYPH;
 use crate::hb::aat::layout_common::{
-    get_class, AatApplyContext, ClassCache, SafeToBreakCache, TypedCollectGlyphs, START_OF_TEXT,
+    get_class, AatApplyContext, ClassCache, SafeToBreakAccel, TypedCollectGlyphs, START_OF_TEXT,
 };
 use crate::hb::{
     buffer::*,
@@ -58,7 +58,7 @@ pub(crate) fn apply(c: &mut AatApplyContext) -> Option<()> {
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
-        c.safe_to_break_cache = Some(&subtable_cache.safe_to_break);
+        c.safe_to_break_accel = Some(&subtable_cache.safe_to_break);
 
         if !c.buffer_intersects_machine() {
             continue;
@@ -478,7 +478,7 @@ fn apply_state_machine_kerning<T, E, Driver: StateTableDriver<T, E>>(
                 state == START_OF_TEXT
                 || (!entry.has_advance() && next_state == START_OF_TEXT)
                 // 2c, 2c', 2c"
-                || c.safe_to_break_cache.unwrap().wouldbe_matches(class, next_state, entry.has_advance())
+                || c.safe_to_break_accel.unwrap().wouldbe_matches(class, next_state, entry.has_advance())
             ) &&
 
             // 3
@@ -486,7 +486,7 @@ fn apply_state_machine_kerning<T, E, Driver: StateTableDriver<T, E>>(
                 if state < 64 {
                     (c.start_end_safe_to_break & (1 << state)) != 0
                 } else {
-                    c.safe_to_break_cache.unwrap().eot_safe_high(state)
+                    c.safe_to_break_accel.unwrap().eot_safe_high(state)
                 }
             )
         ;
@@ -721,7 +721,7 @@ impl StateTableDriver<Subtable4<'_>, BigEndian<u16>> for Driver4<'_> {
 
 pub(crate) struct KerxSubtableCache {
     start_end_safe_to_break: u64,
-    safe_to_break: SafeToBreakCache,
+    safe_to_break: SafeToBreakAccel,
     first_set: U32Set,
     second_set: U32Set,
     class_cache: Box<ClassCache>,
@@ -730,7 +730,7 @@ pub(crate) struct KerxSubtableCache {
 impl KerxSubtableCache {
     pub(crate) fn new(subtable: &Subtable, num_glyphs: u32) -> Self {
         let mut start_end_safe_to_break = 0u64;
-        let mut safe_to_break = SafeToBreakCache::empty();
+        let mut safe_to_break = SafeToBreakAccel::empty();
         let mut first_set = U32Set::default();
         let mut second_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
@@ -740,7 +740,7 @@ impl KerxSubtableCache {
                 }
                 SubtableKind::Format1(format1) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(&format1.state_table);
-                    safe_to_break = SafeToBreakCache::build_extended(
+                    safe_to_break = SafeToBreakAccel::build_extended(
                         &format1.state_table,
                         subtable.data(),
                         &KerxStateEntryExt::is_actionable,
@@ -753,7 +753,7 @@ impl KerxSubtableCache {
                 }
                 SubtableKind::Format4(format4) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(&format4.state_table);
-                    safe_to_break = SafeToBreakCache::build_extended(
+                    safe_to_break = SafeToBreakAccel::build_extended(
                         &format4.state_table,
                         subtable.data(),
                         &KerxStateEntryExt::is_actionable,

--- a/harfrust/src/hb/aat/layout_kerx_table.rs
+++ b/harfrust/src/hb/aat/layout_kerx_table.rs
@@ -1,6 +1,7 @@
 use super::layout::DELETED_GLYPH;
 use crate::hb::aat::layout_common::{
-    get_class, AatApplyContext, ClassCache, SafeToBreakAccel, TypedCollectGlyphs, START_OF_TEXT,
+    get_class, AatApplyContext, ClassCache, SafeToBreakAccel, SafeToBreakSubtable,
+    TypedCollectGlyphs, START_OF_TEXT,
 };
 use crate::hb::{
     buffer::*,
@@ -31,7 +32,6 @@ pub(crate) fn apply(c: &mut AatApplyContext) -> Option<()> {
 
     let (kerx, subtable_caches) = c.face.aat_tables.kerx.as_ref()?;
     let safe_to_break = c.face.aat_tables.safe_to_break?;
-    let safe_to_break_start = c.face.aat_tables.kerx_safe_to_break_start;
 
     let mut subtable_idx = 0;
 
@@ -41,7 +41,6 @@ pub(crate) fn apply(c: &mut AatApplyContext) -> Option<()> {
             continue;
         };
 
-        let safe_to_break_index = safe_to_break_start.checked_add(subtable_idx)?;
         let subtable_cache = subtable_caches.get(subtable_idx);
         let Some(subtable_cache) = subtable_cache.as_ref() else {
             break;
@@ -61,11 +60,11 @@ pub(crate) fn apply(c: &mut AatApplyContext) -> Option<()> {
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
-        c.safe_to_break = safe_to_break.subtable(safe_to_break_index)?;
 
         if !c.buffer_intersects_machine() {
             continue;
         }
+        c.safe_to_break = safe_to_break.subtable(subtable_cache.safe_to_break)?;
 
         let reverse = c.buffer.direction.is_backward();
 
@@ -724,6 +723,7 @@ impl StateTableDriver<Subtable4<'_>, BigEndian<u16>> for Driver4<'_> {
 
 pub(crate) struct KerxSubtableCache {
     start_end_safe_to_break: u64,
+    safe_to_break: SafeToBreakSubtable,
     first_set: U32Set,
     second_set: U32Set,
     class_cache: Box<ClassCache>,
@@ -736,7 +736,7 @@ impl KerxSubtableCache {
         safe_to_break: &mut SafeToBreakAccel,
     ) -> Self {
         let mut start_end_safe_to_break = 0u64;
-        let mut has_safe_to_break = false;
+        let mut safe_to_break_subtable = safe_to_break.empty_subtable();
         let mut first_set = U32Set::default();
         let mut second_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
@@ -746,13 +746,12 @@ impl KerxSubtableCache {
                 }
                 SubtableKind::Format1(format1) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(&format1.state_table);
-                    safe_to_break.build_extended(
+                    safe_to_break_subtable = safe_to_break.build_extended(
                         &format1.state_table,
                         subtable.data(),
                         &KerxStateEntryExt::is_actionable,
                         &KerxStateEntryExt::has_advance,
                     );
-                    has_safe_to_break = true;
                     collect_initial_glyphs(&format1.state_table, &mut first_set, num_glyphs);
                 }
                 SubtableKind::Format2(format2) => {
@@ -760,13 +759,12 @@ impl KerxSubtableCache {
                 }
                 SubtableKind::Format4(format4) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(&format4.state_table);
-                    safe_to_break.build_extended(
+                    safe_to_break_subtable = safe_to_break.build_extended(
                         &format4.state_table,
                         subtable.data(),
                         &KerxStateEntryExt::is_actionable,
                         &KerxStateEntryExt::has_advance,
                     );
-                    has_safe_to_break = true;
                     collect_initial_glyphs(&format4.state_table, &mut first_set, num_glyphs);
                 }
                 SubtableKind::Format6(format6) => {
@@ -774,11 +772,9 @@ impl KerxSubtableCache {
                 }
             }
         }
-        if !has_safe_to_break {
-            safe_to_break.add_empty();
-        }
         KerxSubtableCache {
             start_end_safe_to_break,
+            safe_to_break: safe_to_break_subtable,
             first_set,
             second_set,
             class_cache: Box::new(ClassCache::new()),

--- a/harfrust/src/hb/aat/layout_kerx_table.rs
+++ b/harfrust/src/hb/aat/layout_kerx_table.rs
@@ -30,6 +30,8 @@ pub(crate) fn apply(c: &mut AatApplyContext) -> Option<()> {
     c.setup_buffer_glyph_set();
 
     let (kerx, subtable_caches) = c.face.aat_tables.kerx.as_ref()?;
+    let safe_to_break = c.face.aat_tables.safe_to_break?;
+    let safe_to_break_start = c.face.aat_tables.kerx_safe_to_break_start;
 
     let mut subtable_idx = 0;
 
@@ -39,6 +41,7 @@ pub(crate) fn apply(c: &mut AatApplyContext) -> Option<()> {
             continue;
         };
 
+        let safe_to_break_index = safe_to_break_start.checked_add(subtable_idx)?;
         let subtable_cache = subtable_caches.get(subtable_idx);
         let Some(subtable_cache) = subtable_cache.as_ref() else {
             break;
@@ -58,7 +61,7 @@ pub(crate) fn apply(c: &mut AatApplyContext) -> Option<()> {
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
-        c.safe_to_break_accel = Some(&subtable_cache.safe_to_break);
+        c.safe_to_break = safe_to_break.subtable(safe_to_break_index)?;
 
         if !c.buffer_intersects_machine() {
             continue;
@@ -478,7 +481,7 @@ fn apply_state_machine_kerning<T, E, Driver: StateTableDriver<T, E>>(
                 state == START_OF_TEXT
                 || (!entry.has_advance() && next_state == START_OF_TEXT)
                 // 2c, 2c', 2c"
-                || c.safe_to_break_accel.unwrap().wouldbe_matches(class, next_state, entry.has_advance())
+                || c.safe_to_break.wouldbe_matches(class, next_state, entry.has_advance())
             ) &&
 
             // 3
@@ -486,7 +489,7 @@ fn apply_state_machine_kerning<T, E, Driver: StateTableDriver<T, E>>(
                 if state < 64 {
                     (c.start_end_safe_to_break & (1 << state)) != 0
                 } else {
-                    c.safe_to_break_accel.unwrap().eot_safe_high(state)
+                    c.safe_to_break.eot_safe_high(state)
                 }
             )
         ;
@@ -721,16 +724,19 @@ impl StateTableDriver<Subtable4<'_>, BigEndian<u16>> for Driver4<'_> {
 
 pub(crate) struct KerxSubtableCache {
     start_end_safe_to_break: u64,
-    safe_to_break: SafeToBreakAccel,
     first_set: U32Set,
     second_set: U32Set,
     class_cache: Box<ClassCache>,
 }
 
 impl KerxSubtableCache {
-    pub(crate) fn new(subtable: &Subtable, num_glyphs: u32) -> Self {
+    pub(crate) fn new(
+        subtable: &Subtable,
+        num_glyphs: u32,
+        safe_to_break: &mut SafeToBreakAccel,
+    ) -> Self {
         let mut start_end_safe_to_break = 0u64;
-        let mut safe_to_break = SafeToBreakAccel::empty();
+        let mut has_safe_to_break = false;
         let mut first_set = U32Set::default();
         let mut second_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
@@ -740,12 +746,13 @@ impl KerxSubtableCache {
                 }
                 SubtableKind::Format1(format1) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(&format1.state_table);
-                    safe_to_break = SafeToBreakAccel::build_extended(
+                    safe_to_break.build_extended(
                         &format1.state_table,
                         subtable.data(),
                         &KerxStateEntryExt::is_actionable,
                         &KerxStateEntryExt::has_advance,
                     );
+                    has_safe_to_break = true;
                     collect_initial_glyphs(&format1.state_table, &mut first_set, num_glyphs);
                 }
                 SubtableKind::Format2(format2) => {
@@ -753,12 +760,13 @@ impl KerxSubtableCache {
                 }
                 SubtableKind::Format4(format4) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(&format4.state_table);
-                    safe_to_break = SafeToBreakAccel::build_extended(
+                    safe_to_break.build_extended(
                         &format4.state_table,
                         subtable.data(),
                         &KerxStateEntryExt::is_actionable,
                         &KerxStateEntryExt::has_advance,
                     );
+                    has_safe_to_break = true;
                     collect_initial_glyphs(&format4.state_table, &mut first_set, num_glyphs);
                 }
                 SubtableKind::Format6(format6) => {
@@ -766,9 +774,11 @@ impl KerxSubtableCache {
                 }
             }
         }
+        if !has_safe_to_break {
+            safe_to_break.add_empty();
+        }
         KerxSubtableCache {
             start_end_safe_to_break,
-            safe_to_break,
             first_set,
             second_set,
             class_cache: Box::new(ClassCache::new()),

--- a/harfrust/src/hb/aat/layout_kerx_table.rs
+++ b/harfrust/src/hb/aat/layout_kerx_table.rs
@@ -1,6 +1,6 @@
 use super::layout::DELETED_GLYPH;
 use crate::hb::aat::layout_common::{
-    get_class, AatApplyContext, ClassCache, TypedCollectGlyphs, START_OF_TEXT,
+    get_class, AatApplyContext, ClassCache, SafeToBreakCache, TypedCollectGlyphs, START_OF_TEXT,
 };
 use crate::hb::{
     buffer::*,
@@ -58,6 +58,7 @@ pub(crate) fn apply(c: &mut AatApplyContext) -> Option<()> {
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
+        c.safe_to_break_cache = Some(&subtable_cache.safe_to_break);
 
         if !c.buffer_intersects_machine() {
             continue;
@@ -476,22 +477,8 @@ fn apply_state_machine_kerning<T, E, Driver: StateTableDriver<T, E>>(
             (
                 state == START_OF_TEXT
                 || (!entry.has_advance() && next_state == START_OF_TEXT)
-                ||
-                {
-                    // 2c
-                    if let Ok(wouldbe_entry) = state_table.entry(START_OF_TEXT, class) {
-                        // 2c'
-                        !wouldbe_entry.is_actionable() &&
-
-                        // 2c"
-                        (
-                            next_state == wouldbe_entry.new_state &&
-                            entry.has_advance() == wouldbe_entry.has_advance()
-                        )
-                    } else {
-                        false
-                    }
-                }
+                // 2c, 2c', 2c"
+                || c.safe_to_break_cache.unwrap().wouldbe_matches(class, next_state, entry.has_advance())
             ) &&
 
             // 3
@@ -499,11 +486,7 @@ fn apply_state_machine_kerning<T, E, Driver: StateTableDriver<T, E>>(
                 if state < 64 {
                     (c.start_end_safe_to_break & (1 << state)) != 0
                 } else {
-                    if let Ok(end_entry) = state_table.entry(state, u16::from(aat::class::END_OF_TEXT)) {
-                        !end_entry.is_actionable()
-                    } else {
-                        false
-                    }
+                    c.safe_to_break_cache.unwrap().eot_safe_high(state)
                 }
             )
         ;
@@ -738,6 +721,7 @@ impl StateTableDriver<Subtable4<'_>, BigEndian<u16>> for Driver4<'_> {
 
 pub(crate) struct KerxSubtableCache {
     start_end_safe_to_break: u64,
+    safe_to_break: SafeToBreakCache,
     first_set: U32Set,
     second_set: U32Set,
     class_cache: Box<ClassCache>,
@@ -746,6 +730,7 @@ pub(crate) struct KerxSubtableCache {
 impl KerxSubtableCache {
     pub(crate) fn new(subtable: &Subtable, num_glyphs: u32) -> Self {
         let mut start_end_safe_to_break = 0u64;
+        let mut safe_to_break = SafeToBreakCache::empty();
         let mut first_set = U32Set::default();
         let mut second_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
@@ -755,6 +740,12 @@ impl KerxSubtableCache {
                 }
                 SubtableKind::Format1(format1) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(&format1.state_table);
+                    safe_to_break = SafeToBreakCache::build_extended(
+                        &format1.state_table,
+                        subtable.data(),
+                        &KerxStateEntryExt::is_actionable,
+                        &KerxStateEntryExt::has_advance,
+                    );
                     collect_initial_glyphs(&format1.state_table, &mut first_set, num_glyphs);
                 }
                 SubtableKind::Format2(format2) => {
@@ -762,6 +753,12 @@ impl KerxSubtableCache {
                 }
                 SubtableKind::Format4(format4) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(&format4.state_table);
+                    safe_to_break = SafeToBreakCache::build_extended(
+                        &format4.state_table,
+                        subtable.data(),
+                        &KerxStateEntryExt::is_actionable,
+                        &KerxStateEntryExt::has_advance,
+                    );
                     collect_initial_glyphs(&format4.state_table, &mut first_set, num_glyphs);
                 }
                 SubtableKind::Format6(format6) => {
@@ -771,6 +768,7 @@ impl KerxSubtableCache {
         }
         KerxSubtableCache {
             start_end_safe_to_break,
+            safe_to_break,
             first_set,
             second_set,
             class_cache: Box::new(ClassCache::new()),

--- a/harfrust/src/hb/aat/layout_morx_table.rs
+++ b/harfrust/src/hb/aat/layout_morx_table.rs
@@ -80,6 +80,7 @@ pub fn apply<'a>(c: &mut AatApplyContext<'a>, map: &'a AatMap) -> Option<()> {
     c.setup_buffer_glyph_set();
 
     let (morx, subtable_caches, descriptors) = c.face.aat_tables.morx.as_ref()?;
+    let safe_to_break = c.face.aat_tables.safe_to_break?;
     let morx_bytes = morx.offset_data().as_bytes();
 
     let mut last_chain_index = u32::MAX;
@@ -115,7 +116,7 @@ pub fn apply<'a>(c: &mut AatApplyContext<'a>, map: &'a AatMap) -> Option<()> {
         c.first_set = Some(&subtable_cache.glyph_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
-        c.safe_to_break_accel = Some(&subtable_cache.safe_to_break);
+        c.safe_to_break = safe_to_break.subtable(subtable_idx)?;
 
         if !c.buffer_intersects_machine() {
             continue;
@@ -355,7 +356,7 @@ fn drive<T: bytemuck::AnyBitPattern + FixedSize + core::fmt::Debug, Ctx: DriverC
                 state == START_OF_TEXT
                 || (!Ctx::can_advance(&entry) && next_state == START_OF_TEXT)
                 // 2c, 2c', 2c"
-                || ac.safe_to_break_accel.unwrap().wouldbe_matches(class, next_state, Ctx::can_advance(&entry))
+                || ac.safe_to_break.wouldbe_matches(class, next_state, Ctx::can_advance(&entry))
             ) &&
 
             // 3
@@ -363,7 +364,7 @@ fn drive<T: bytemuck::AnyBitPattern + FixedSize + core::fmt::Debug, Ctx: DriverC
                 if state < 64 {
                     (ac.start_end_safe_to_break & (1 << state)) != 0
                 } else {
-                    ac.safe_to_break_accel.unwrap().eot_safe_high(state)
+                    ac.safe_to_break.eot_safe_high(state)
                 }
             )
         ;
@@ -983,7 +984,6 @@ pub(crate) struct MorxSubtableDescriptor {
 
 pub(crate) struct MorxSubtableCache {
     start_end_safe_to_break: u64,
-    safe_to_break: SafeToBreakAccel,
     glyph_set: U32Set,
     class_cache: ClassCache,
     /// Pre-resolved subtable layout, so per-application dispatch rebuilds
@@ -1010,21 +1010,26 @@ impl MorxSubtableCache {
         }
     }
 
-    pub(crate) fn new(subtable: &Subtable, num_glyphs: u32) -> Self {
+    pub(crate) fn new(
+        subtable: &Subtable,
+        num_glyphs: u32,
+        safe_to_break: &mut SafeToBreakAccel,
+    ) -> Self {
         let mut start_end_safe_to_break = 0u64;
-        let mut safe_to_break = SafeToBreakAccel::empty();
+        let mut has_safe_to_break = false;
         let mut glyph_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
             match &kind {
                 SubtableKind::Rearrangement(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, RearrangementCtx>(table);
-                    safe_to_break = SafeToBreakAccel::build_extended(
+                    safe_to_break.build_extended(
                         table,
                         subtable.data(),
                         &RearrangementCtx::is_actionable,
                         &RearrangementCtx::can_advance,
                     );
+                    has_safe_to_break = true;
                     collect_initial_glyphs::<_, RearrangementCtx>(
                         table,
                         &mut glyph_set,
@@ -1034,12 +1039,13 @@ impl MorxSubtableCache {
                 SubtableKind::Contextual(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, ContextualCtx>(&table.state_table);
-                    safe_to_break = SafeToBreakAccel::build_extended(
+                    safe_to_break.build_extended(
                         &table.state_table,
                         subtable.data(),
                         &ContextualCtx::is_actionable,
                         &ContextualCtx::can_advance,
                     );
+                    has_safe_to_break = true;
                     collect_initial_glyphs::<_, ContextualCtx>(
                         &table.state_table,
                         &mut glyph_set,
@@ -1049,12 +1055,13 @@ impl MorxSubtableCache {
                 SubtableKind::Ligature(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, LigatureCtx>(&table.state_table);
-                    safe_to_break = SafeToBreakAccel::build_extended(
+                    safe_to_break.build_extended(
                         &table.state_table,
                         subtable.data(),
                         &LigatureCtx::is_actionable,
                         &LigatureCtx::can_advance,
                     );
+                    has_safe_to_break = true;
                     collect_initial_glyphs::<_, LigatureCtx>(
                         &table.state_table,
                         &mut glyph_set,
@@ -1067,12 +1074,13 @@ impl MorxSubtableCache {
                 SubtableKind::Insertion(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, InsertionCtx>(&table.state_table);
-                    safe_to_break = SafeToBreakAccel::build_extended(
+                    safe_to_break.build_extended(
                         &table.state_table,
                         subtable.data(),
                         &InsertionCtx::is_actionable,
                         &InsertionCtx::can_advance,
                     );
+                    has_safe_to_break = true;
                     collect_initial_glyphs::<_, InsertionCtx>(
                         &table.state_table,
                         &mut glyph_set,
@@ -1081,6 +1089,9 @@ impl MorxSubtableCache {
                 }
             }
         }
+        if !has_safe_to_break {
+            safe_to_break.add_empty();
+        }
         let parts = SubtableKind::parts(FontData::new(subtable.data()), subtable.coverage())
             .unwrap_or(SubtableParts {
                 format: 0xFF,
@@ -1088,7 +1099,6 @@ impl MorxSubtableCache {
             });
         MorxSubtableCache {
             start_end_safe_to_break,
-            safe_to_break,
             glyph_set,
             class_cache: ClassCache::new(),
             parts,

--- a/harfrust/src/hb/aat/layout_morx_table.rs
+++ b/harfrust/src/hb/aat/layout_morx_table.rs
@@ -1,7 +1,7 @@
 use super::layout::*;
 use super::map::{AatMap, AatMapBuilder, RangeFlags};
 use crate::hb::aat::layout_common::{
-    get_class, AatApplyContext, ClassCache, TypedCollectGlyphs, START_OF_TEXT,
+    get_class, AatApplyContext, ClassCache, SafeToBreakCache, TypedCollectGlyphs, START_OF_TEXT,
 };
 use crate::hb::ot_layout::MAX_CONTEXT_LENGTH;
 use crate::hb::{hb_font_t, GlyphInfo};
@@ -115,6 +115,7 @@ pub fn apply<'a>(c: &mut AatApplyContext<'a>, map: &'a AatMap) -> Option<()> {
         c.first_set = Some(&subtable_cache.glyph_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
+        c.safe_to_break_cache = Some(&subtable_cache.safe_to_break);
 
         if !c.buffer_intersects_machine() {
             continue;
@@ -353,22 +354,8 @@ fn drive<T: bytemuck::AnyBitPattern + FixedSize + core::fmt::Debug, Ctx: DriverC
             (
                 state == START_OF_TEXT
                 || (!Ctx::can_advance(&entry) && next_state == START_OF_TEXT)
-                ||
-                {
-                    // 2c
-                    if let Ok(wouldbe_entry) = machine.entry(START_OF_TEXT, class) {
-                        // 2c'
-                        !Ctx::is_actionable(&wouldbe_entry) &&
-
-                        // 2c"
-                        (
-                            next_state == wouldbe_entry.new_state &&
-                            Ctx::can_advance(&entry) == Ctx::can_advance(&wouldbe_entry)
-                        )
-                    } else {
-                        false
-                    }
-                }
+                // 2c, 2c', 2c"
+                || ac.safe_to_break_cache.unwrap().wouldbe_matches(class, next_state, Ctx::can_advance(&entry))
             ) &&
 
             // 3
@@ -376,11 +363,7 @@ fn drive<T: bytemuck::AnyBitPattern + FixedSize + core::fmt::Debug, Ctx: DriverC
                 if state < 64 {
                     (ac.start_end_safe_to_break & (1 << state)) != 0
                 } else {
-                    if let Ok(end_entry) = machine.entry(state, u16::from(aat::class::END_OF_TEXT)) {
-                        !Ctx::is_actionable(&end_entry)
-                    } else {
-                        false
-                    }
+                    ac.safe_to_break_cache.unwrap().eot_safe_high(state)
                 }
             )
         ;
@@ -1000,6 +983,7 @@ pub(crate) struct MorxSubtableDescriptor {
 
 pub(crate) struct MorxSubtableCache {
     start_end_safe_to_break: u64,
+    safe_to_break: SafeToBreakCache,
     glyph_set: U32Set,
     class_cache: ClassCache,
     /// Pre-resolved subtable layout, so per-application dispatch rebuilds
@@ -1028,12 +1012,19 @@ impl MorxSubtableCache {
 
     pub(crate) fn new(subtable: &Subtable, num_glyphs: u32) -> Self {
         let mut start_end_safe_to_break = 0u64;
+        let mut safe_to_break = SafeToBreakCache::empty();
         let mut glyph_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
             match &kind {
                 SubtableKind::Rearrangement(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, RearrangementCtx>(table);
+                    safe_to_break = SafeToBreakCache::build_extended(
+                        table,
+                        subtable.data(),
+                        &RearrangementCtx::is_actionable,
+                        &RearrangementCtx::can_advance,
+                    );
                     collect_initial_glyphs::<_, RearrangementCtx>(
                         table,
                         &mut glyph_set,
@@ -1043,6 +1034,12 @@ impl MorxSubtableCache {
                 SubtableKind::Contextual(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, ContextualCtx>(&table.state_table);
+                    safe_to_break = SafeToBreakCache::build_extended(
+                        &table.state_table,
+                        subtable.data(),
+                        &ContextualCtx::is_actionable,
+                        &ContextualCtx::can_advance,
+                    );
                     collect_initial_glyphs::<_, ContextualCtx>(
                         &table.state_table,
                         &mut glyph_set,
@@ -1052,6 +1049,12 @@ impl MorxSubtableCache {
                 SubtableKind::Ligature(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, LigatureCtx>(&table.state_table);
+                    safe_to_break = SafeToBreakCache::build_extended(
+                        &table.state_table,
+                        subtable.data(),
+                        &LigatureCtx::is_actionable,
+                        &LigatureCtx::can_advance,
+                    );
                     collect_initial_glyphs::<_, LigatureCtx>(
                         &table.state_table,
                         &mut glyph_set,
@@ -1064,6 +1067,12 @@ impl MorxSubtableCache {
                 SubtableKind::Insertion(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, InsertionCtx>(&table.state_table);
+                    safe_to_break = SafeToBreakCache::build_extended(
+                        &table.state_table,
+                        subtable.data(),
+                        &InsertionCtx::is_actionable,
+                        &InsertionCtx::can_advance,
+                    );
                     collect_initial_glyphs::<_, InsertionCtx>(
                         &table.state_table,
                         &mut glyph_set,
@@ -1079,6 +1088,7 @@ impl MorxSubtableCache {
             });
         MorxSubtableCache {
             start_end_safe_to_break,
+            safe_to_break,
             glyph_set,
             class_cache: ClassCache::new(),
             parts,

--- a/harfrust/src/hb/aat/layout_morx_table.rs
+++ b/harfrust/src/hb/aat/layout_morx_table.rs
@@ -1,7 +1,8 @@
 use super::layout::*;
 use super::map::{AatMap, AatMapBuilder, RangeFlags};
 use crate::hb::aat::layout_common::{
-    get_class, AatApplyContext, ClassCache, SafeToBreakAccel, TypedCollectGlyphs, START_OF_TEXT,
+    get_class, AatApplyContext, ClassCache, SafeToBreakAccel, SafeToBreakSubtable,
+    TypedCollectGlyphs, START_OF_TEXT,
 };
 use crate::hb::ot_layout::MAX_CONTEXT_LENGTH;
 use crate::hb::{hb_font_t, GlyphInfo};
@@ -116,11 +117,11 @@ pub fn apply<'a>(c: &mut AatApplyContext<'a>, map: &'a AatMap) -> Option<()> {
         c.first_set = Some(&subtable_cache.glyph_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
-        c.safe_to_break = safe_to_break.subtable(subtable_idx)?;
 
         if !c.buffer_intersects_machine() {
             continue;
         }
+        c.safe_to_break = safe_to_break.subtable(subtable_cache.safe_to_break)?;
 
         // Buffer contents is always in logical direction.  Determine if
         // we need to reverse before applying this subtable.  We reverse
@@ -984,6 +985,7 @@ pub(crate) struct MorxSubtableDescriptor {
 
 pub(crate) struct MorxSubtableCache {
     start_end_safe_to_break: u64,
+    safe_to_break: SafeToBreakSubtable,
     glyph_set: U32Set,
     class_cache: ClassCache,
     /// Pre-resolved subtable layout, so per-application dispatch rebuilds
@@ -1016,20 +1018,19 @@ impl MorxSubtableCache {
         safe_to_break: &mut SafeToBreakAccel,
     ) -> Self {
         let mut start_end_safe_to_break = 0u64;
-        let mut has_safe_to_break = false;
+        let mut safe_to_break_subtable = safe_to_break.empty_subtable();
         let mut glyph_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
             match &kind {
                 SubtableKind::Rearrangement(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, RearrangementCtx>(table);
-                    safe_to_break.build_extended(
+                    safe_to_break_subtable = safe_to_break.build_extended(
                         table,
                         subtable.data(),
                         &RearrangementCtx::is_actionable,
                         &RearrangementCtx::can_advance,
                     );
-                    has_safe_to_break = true;
                     collect_initial_glyphs::<_, RearrangementCtx>(
                         table,
                         &mut glyph_set,
@@ -1039,13 +1040,12 @@ impl MorxSubtableCache {
                 SubtableKind::Contextual(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, ContextualCtx>(&table.state_table);
-                    safe_to_break.build_extended(
+                    safe_to_break_subtable = safe_to_break.build_extended(
                         &table.state_table,
                         subtable.data(),
                         &ContextualCtx::is_actionable,
                         &ContextualCtx::can_advance,
                     );
-                    has_safe_to_break = true;
                     collect_initial_glyphs::<_, ContextualCtx>(
                         &table.state_table,
                         &mut glyph_set,
@@ -1055,13 +1055,12 @@ impl MorxSubtableCache {
                 SubtableKind::Ligature(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, LigatureCtx>(&table.state_table);
-                    safe_to_break.build_extended(
+                    safe_to_break_subtable = safe_to_break.build_extended(
                         &table.state_table,
                         subtable.data(),
                         &LigatureCtx::is_actionable,
                         &LigatureCtx::can_advance,
                     );
-                    has_safe_to_break = true;
                     collect_initial_glyphs::<_, LigatureCtx>(
                         &table.state_table,
                         &mut glyph_set,
@@ -1074,13 +1073,12 @@ impl MorxSubtableCache {
                 SubtableKind::Insertion(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, InsertionCtx>(&table.state_table);
-                    safe_to_break.build_extended(
+                    safe_to_break_subtable = safe_to_break.build_extended(
                         &table.state_table,
                         subtable.data(),
                         &InsertionCtx::is_actionable,
                         &InsertionCtx::can_advance,
                     );
-                    has_safe_to_break = true;
                     collect_initial_glyphs::<_, InsertionCtx>(
                         &table.state_table,
                         &mut glyph_set,
@@ -1089,9 +1087,6 @@ impl MorxSubtableCache {
                 }
             }
         }
-        if !has_safe_to_break {
-            safe_to_break.add_empty();
-        }
         let parts = SubtableKind::parts(FontData::new(subtable.data()), subtable.coverage())
             .unwrap_or(SubtableParts {
                 format: 0xFF,
@@ -1099,6 +1094,7 @@ impl MorxSubtableCache {
             });
         MorxSubtableCache {
             start_end_safe_to_break,
+            safe_to_break: safe_to_break_subtable,
             glyph_set,
             class_cache: ClassCache::new(),
             parts,

--- a/harfrust/src/hb/aat/layout_morx_table.rs
+++ b/harfrust/src/hb/aat/layout_morx_table.rs
@@ -117,11 +117,11 @@ pub fn apply<'a>(c: &mut AatApplyContext<'a>, map: &'a AatMap) -> Option<()> {
         c.first_set = Some(&subtable_cache.glyph_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
+        c.safe_to_break = safe_to_break.subtable(subtable_cache.safe_to_break)?;
 
         if !c.buffer_intersects_machine() {
             continue;
         }
-        c.safe_to_break = safe_to_break.subtable(subtable_cache.safe_to_break)?;
 
         // Buffer contents is always in logical direction.  Determine if
         // we need to reverse before applying this subtable.  We reverse

--- a/harfrust/src/hb/aat/layout_morx_table.rs
+++ b/harfrust/src/hb/aat/layout_morx_table.rs
@@ -1,7 +1,7 @@
 use super::layout::*;
 use super::map::{AatMap, AatMapBuilder, RangeFlags};
 use crate::hb::aat::layout_common::{
-    get_class, AatApplyContext, ClassCache, SafeToBreakCache, TypedCollectGlyphs, START_OF_TEXT,
+    get_class, AatApplyContext, ClassCache, SafeToBreakAccel, TypedCollectGlyphs, START_OF_TEXT,
 };
 use crate::hb::ot_layout::MAX_CONTEXT_LENGTH;
 use crate::hb::{hb_font_t, GlyphInfo};
@@ -115,7 +115,7 @@ pub fn apply<'a>(c: &mut AatApplyContext<'a>, map: &'a AatMap) -> Option<()> {
         c.first_set = Some(&subtable_cache.glyph_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
-        c.safe_to_break_cache = Some(&subtable_cache.safe_to_break);
+        c.safe_to_break_accel = Some(&subtable_cache.safe_to_break);
 
         if !c.buffer_intersects_machine() {
             continue;
@@ -355,7 +355,7 @@ fn drive<T: bytemuck::AnyBitPattern + FixedSize + core::fmt::Debug, Ctx: DriverC
                 state == START_OF_TEXT
                 || (!Ctx::can_advance(&entry) && next_state == START_OF_TEXT)
                 // 2c, 2c', 2c"
-                || ac.safe_to_break_cache.unwrap().wouldbe_matches(class, next_state, Ctx::can_advance(&entry))
+                || ac.safe_to_break_accel.unwrap().wouldbe_matches(class, next_state, Ctx::can_advance(&entry))
             ) &&
 
             // 3
@@ -363,7 +363,7 @@ fn drive<T: bytemuck::AnyBitPattern + FixedSize + core::fmt::Debug, Ctx: DriverC
                 if state < 64 {
                     (ac.start_end_safe_to_break & (1 << state)) != 0
                 } else {
-                    ac.safe_to_break_cache.unwrap().eot_safe_high(state)
+                    ac.safe_to_break_accel.unwrap().eot_safe_high(state)
                 }
             )
         ;
@@ -983,7 +983,7 @@ pub(crate) struct MorxSubtableDescriptor {
 
 pub(crate) struct MorxSubtableCache {
     start_end_safe_to_break: u64,
-    safe_to_break: SafeToBreakCache,
+    safe_to_break: SafeToBreakAccel,
     glyph_set: U32Set,
     class_cache: ClassCache,
     /// Pre-resolved subtable layout, so per-application dispatch rebuilds
@@ -1012,14 +1012,14 @@ impl MorxSubtableCache {
 
     pub(crate) fn new(subtable: &Subtable, num_glyphs: u32) -> Self {
         let mut start_end_safe_to_break = 0u64;
-        let mut safe_to_break = SafeToBreakCache::empty();
+        let mut safe_to_break = SafeToBreakAccel::empty();
         let mut glyph_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
             match &kind {
                 SubtableKind::Rearrangement(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, RearrangementCtx>(table);
-                    safe_to_break = SafeToBreakCache::build_extended(
+                    safe_to_break = SafeToBreakAccel::build_extended(
                         table,
                         subtable.data(),
                         &RearrangementCtx::is_actionable,
@@ -1034,7 +1034,7 @@ impl MorxSubtableCache {
                 SubtableKind::Contextual(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, ContextualCtx>(&table.state_table);
-                    safe_to_break = SafeToBreakCache::build_extended(
+                    safe_to_break = SafeToBreakAccel::build_extended(
                         &table.state_table,
                         subtable.data(),
                         &ContextualCtx::is_actionable,
@@ -1049,7 +1049,7 @@ impl MorxSubtableCache {
                 SubtableKind::Ligature(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, LigatureCtx>(&table.state_table);
-                    safe_to_break = SafeToBreakCache::build_extended(
+                    safe_to_break = SafeToBreakAccel::build_extended(
                         &table.state_table,
                         subtable.data(),
                         &LigatureCtx::is_actionable,
@@ -1067,7 +1067,7 @@ impl MorxSubtableCache {
                 SubtableKind::Insertion(table) => {
                     start_end_safe_to_break =
                         collect_start_end_safe_to_break::<_, InsertionCtx>(&table.state_table);
-                    safe_to_break = SafeToBreakCache::build_extended(
+                    safe_to_break = SafeToBreakAccel::build_extended(
                         &table.state_table,
                         subtable.data(),
                         &InsertionCtx::is_actionable,

--- a/harfrust/src/hb/aat/mod.rs
+++ b/harfrust/src/hb/aat/mod.rs
@@ -80,8 +80,6 @@ impl AatCache {
 #[derive(Clone, Default)]
 pub struct AatTables<'a> {
     pub(crate) safe_to_break: Option<&'a SafeToBreakAccel>,
-    pub(crate) kern_safe_to_break_start: usize,
-    pub(crate) kerx_safe_to_break_start: usize,
     pub morx: Option<(
         Morx<'a>,
         &'a [MorxSubtableCache],
@@ -137,8 +135,6 @@ impl<'a> AatTables<'a> {
         let feat = table_ranges.feat.resolve_table(font);
         Self {
             safe_to_break: Some(&cache.safe_to_break),
-            kern_safe_to_break_start: cache.morx.len(),
-            kerx_safe_to_break_start: cache.morx.len() + cache.kern.len(),
             morx,
             ankr,
             kern,
@@ -182,8 +178,6 @@ impl<'a> AatTables<'a> {
         let feat = font.feat().ok();
         Self {
             safe_to_break: Some(&cache.safe_to_break),
-            kern_safe_to_break_start: cache.morx.len(),
-            kerx_safe_to_break_start: cache.morx.len() + cache.kern.len(),
             morx,
             ankr,
             kern,

--- a/harfrust/src/hb/aat/mod.rs
+++ b/harfrust/src/hb/aat/mod.rs
@@ -5,6 +5,7 @@ pub mod layout_morx_table;
 pub mod layout_trak_table;
 pub mod map;
 
+use crate::hb::aat::layout_common::SafeToBreakAccel;
 use crate::hb::aat::layout_kerx_table::KerxSubtableCache;
 use crate::hb::aat::layout_morx_table::{MorxSubtableCache, MorxSubtableDescriptor};
 use crate::hb::kerning::KernSubtableCache;
@@ -18,6 +19,7 @@ use read_fonts::{
 
 #[derive(Default)]
 pub struct AatCache {
+    safe_to_break: SafeToBreakAccel,
     pub morx: Vec<MorxSubtableCache>,
     pub morx_descriptors: Vec<MorxSubtableDescriptor>,
     pub kern: Vec<KernSubtableCache>,
@@ -42,7 +44,8 @@ impl AatCache {
                     let Ok(subtable) = subtable else {
                         continue;
                     };
-                    let entry = MorxSubtableCache::new(&subtable, num_glyphs);
+                    let entry =
+                        MorxSubtableCache::new(&subtable, num_glyphs, &mut cache.safe_to_break);
                     cache.morx_descriptors.push(MorxSubtableCache::descriptor(
                         chain_index,
                         &subtable,
@@ -57,9 +60,8 @@ impl AatCache {
                 let Ok(subtable) = subtable else {
                     continue;
                 };
-                cache
-                    .kern
-                    .push(KernSubtableCache::new(&subtable, num_glyphs));
+                let entry = KernSubtableCache::new(&subtable, num_glyphs, &mut cache.safe_to_break);
+                cache.kern.push(entry);
             }
         }
         if let Ok(kerx) = font.kerx() {
@@ -67,9 +69,8 @@ impl AatCache {
                 let Ok(subtable) = subtable else {
                     continue;
                 };
-                cache
-                    .kerx
-                    .push(KerxSubtableCache::new(&subtable, num_glyphs));
+                let entry = KerxSubtableCache::new(&subtable, num_glyphs, &mut cache.safe_to_break);
+                cache.kerx.push(entry);
             }
         }
         cache
@@ -78,6 +79,9 @@ impl AatCache {
 
 #[derive(Clone, Default)]
 pub struct AatTables<'a> {
+    pub(crate) safe_to_break: Option<&'a SafeToBreakAccel>,
+    pub(crate) kern_safe_to_break_start: usize,
+    pub(crate) kerx_safe_to_break_start: usize,
     pub morx: Option<(
         Morx<'a>,
         &'a [MorxSubtableCache],
@@ -132,6 +136,9 @@ impl<'a> AatTables<'a> {
         let trak = table_ranges.trak.resolve_table(font);
         let feat = table_ranges.feat.resolve_table(font);
         Self {
+            safe_to_break: Some(&cache.safe_to_break),
+            kern_safe_to_break_start: cache.morx.len(),
+            kerx_safe_to_break_start: cache.morx.len() + cache.kern.len(),
             morx,
             ankr,
             kern,
@@ -174,6 +181,9 @@ impl<'a> AatTables<'a> {
         let trak = font.trak().ok();
         let feat = font.feat().ok();
         Self {
+            safe_to_break: Some(&cache.safe_to_break),
+            kern_safe_to_break_start: cache.morx.len(),
+            kerx_safe_to_break_start: cache.morx.len() + cache.kern.len(),
             morx,
             ankr,
             kern,

--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -70,11 +70,11 @@ pub fn hb_ot_layout_kern(
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
+        c.safe_to_break = safe_to_break.subtable(subtable_cache.safe_to_break)?;
 
         if !c.buffer_intersects_machine() {
             continue;
         }
-        c.safe_to_break = safe_to_break.subtable(subtable_cache.safe_to_break)?;
 
         let reverse = c.buffer.direction.is_backward();
         let is_cross_stream = subtable.is_cross_stream();

--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -8,7 +8,9 @@ use read_fonts::{
     types::{GlyphId, GlyphId16},
 };
 
-use super::aat::layout_common::{AatApplyContext, ClassCache, SafeToBreakAccel, START_OF_TEXT};
+use super::aat::layout_common::{
+    AatApplyContext, ClassCache, SafeToBreakAccel, SafeToBreakSubtable, START_OF_TEXT,
+};
 use super::aat::layout_kerx_table::SimpleKerning;
 use super::buffer::*;
 use super::face::Scale;
@@ -43,7 +45,6 @@ pub fn hb_ot_layout_kern(
 
     let (kern, subtable_caches) = c.face.aat_tables.kern.as_ref()?;
     let safe_to_break = c.face.aat_tables.safe_to_break?;
-    let safe_to_break_start = c.face.aat_tables.kern_safe_to_break_start;
 
     let mut subtable_idx = 0;
 
@@ -51,7 +52,6 @@ pub fn hb_ot_layout_kern(
     for subtable in kern.subtables() {
         let Ok(subtable) = subtable else { continue };
 
-        let safe_to_break_index = safe_to_break_start.checked_add(subtable_idx)?;
         let subtable_cache = subtable_caches.get(subtable_idx);
         let Some(subtable_cache) = subtable_cache.as_ref() else {
             break;
@@ -70,11 +70,11 @@ pub fn hb_ot_layout_kern(
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
-        c.safe_to_break = safe_to_break.subtable(safe_to_break_index)?;
 
         if !c.buffer_intersects_machine() {
             continue;
         }
+        c.safe_to_break = safe_to_break.subtable(subtable_cache.safe_to_break)?;
 
         let reverse = c.buffer.direction.is_backward();
         let is_cross_stream = subtable.is_cross_stream();
@@ -625,6 +625,7 @@ impl SimpleKerning for Subtable3<'_> {
 
 pub(crate) struct KernSubtableCache {
     start_end_safe_to_break: u64,
+    safe_to_break: SafeToBreakSubtable,
     first_set: U32Set,
     second_set: U32Set,
     class_cache: Box<ClassCache>,
@@ -637,7 +638,7 @@ impl KernSubtableCache {
         safe_to_break: &mut SafeToBreakAccel,
     ) -> Self {
         let mut start_end_safe_to_break = 0u64;
-        let mut has_safe_to_break = false;
+        let mut safe_to_break_subtable = safe_to_break.empty_subtable();
         let mut first_set = U32Set::default();
         let mut second_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
@@ -647,12 +648,11 @@ impl KernSubtableCache {
                 }
                 SubtableKind::Format1(format1) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(format1);
-                    safe_to_break.build_legacy(
+                    safe_to_break_subtable = safe_to_break.build_legacy(
                         format1,
                         &KernStateEntryExt::is_actionable,
                         &KernStateEntryExt::has_advance,
                     );
-                    has_safe_to_break = true;
                     collect_initial_glyphs(format1, &mut first_set, num_glyphs);
                 }
                 SubtableKind::Format2(format2) => {
@@ -663,11 +663,9 @@ impl KernSubtableCache {
                 }
             }
         }
-        if !has_safe_to_break {
-            safe_to_break.add_empty();
-        }
         KernSubtableCache {
             start_end_safe_to_break,
+            safe_to_break: safe_to_break_subtable,
             first_set,
             second_set,
             class_cache: Box::new(ClassCache::new()),

--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -8,7 +8,7 @@ use read_fonts::{
     types::{GlyphId, GlyphId16},
 };
 
-use super::aat::layout_common::{AatApplyContext, ClassCache, SafeToBreakCache, START_OF_TEXT};
+use super::aat::layout_common::{AatApplyContext, ClassCache, SafeToBreakAccel, START_OF_TEXT};
 use super::aat::layout_kerx_table::SimpleKerning;
 use super::buffer::*;
 use super::face::Scale;
@@ -67,7 +67,7 @@ pub fn hb_ot_layout_kern(
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
-        c.safe_to_break_cache = Some(&subtable_cache.safe_to_break);
+        c.safe_to_break_accel = Some(&subtable_cache.safe_to_break);
 
         if !c.buffer_intersects_machine() {
             continue;
@@ -407,7 +407,7 @@ fn apply_state_machine_kerning(
                 state == START_OF_TEXT
                 || (!entry.has_advance() && next_state == START_OF_TEXT)
                 // 2c, 2c', 2c"
-                || c.safe_to_break_cache.unwrap().wouldbe_matches(u16::from(class), next_state, entry.has_advance())
+                || c.safe_to_break_accel.unwrap().wouldbe_matches(u16::from(class), next_state, entry.has_advance())
             ) &&
 
             // 3
@@ -415,7 +415,7 @@ fn apply_state_machine_kerning(
                 if state < 64 {
                     (c.start_end_safe_to_break & (1 << state)) != 0
                 } else {
-                    c.safe_to_break_cache.unwrap().eot_safe_high(state)
+                    c.safe_to_break_accel.unwrap().eot_safe_high(state)
                 }
             )
         ;
@@ -622,7 +622,7 @@ impl SimpleKerning for Subtable3<'_> {
 
 pub(crate) struct KernSubtableCache {
     start_end_safe_to_break: u64,
-    safe_to_break: SafeToBreakCache,
+    safe_to_break: SafeToBreakAccel,
     first_set: U32Set,
     second_set: U32Set,
     class_cache: Box<ClassCache>,
@@ -631,7 +631,7 @@ pub(crate) struct KernSubtableCache {
 impl KernSubtableCache {
     pub(crate) fn new(subtable: &Subtable, num_glyphs: u32) -> Self {
         let mut start_end_safe_to_break = 0u64;
-        let mut safe_to_break = SafeToBreakCache::empty();
+        let mut safe_to_break = SafeToBreakAccel::empty();
         let mut first_set = U32Set::default();
         let mut second_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
@@ -641,7 +641,7 @@ impl KernSubtableCache {
                 }
                 SubtableKind::Format1(format1) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(format1);
-                    safe_to_break = SafeToBreakCache::build_legacy(
+                    safe_to_break = SafeToBreakAccel::build_legacy(
                         format1,
                         &KernStateEntryExt::is_actionable,
                         &KernStateEntryExt::has_advance,

--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -8,7 +8,7 @@ use read_fonts::{
     types::{GlyphId, GlyphId16},
 };
 
-use super::aat::layout_common::{AatApplyContext, ClassCache, START_OF_TEXT};
+use super::aat::layout_common::{AatApplyContext, ClassCache, SafeToBreakCache, START_OF_TEXT};
 use super::aat::layout_kerx_table::SimpleKerning;
 use super::buffer::*;
 use super::face::Scale;
@@ -67,6 +67,7 @@ pub fn hb_ot_layout_kern(
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
+        c.safe_to_break_cache = Some(&subtable_cache.safe_to_break);
 
         if !c.buffer_intersects_machine() {
             continue;
@@ -405,22 +406,8 @@ fn apply_state_machine_kerning(
             (
                 state == START_OF_TEXT
                 || (!entry.has_advance() && next_state == START_OF_TEXT)
-                ||
-                {
-                    // 2c
-                    if let Ok(wouldbe_entry) = subtable.entry(START_OF_TEXT, class) {
-                        // 2c'
-                        !wouldbe_entry.is_actionable() &&
-
-                        // 2c"
-                        (
-                            next_state == wouldbe_entry.new_state &&
-                            entry.has_advance() == wouldbe_entry.has_advance()
-                        )
-                    } else {
-                        false
-                    }
-                }
+                // 2c, 2c', 2c"
+                || c.safe_to_break_cache.unwrap().wouldbe_matches(u16::from(class), next_state, entry.has_advance())
             ) &&
 
             // 3
@@ -428,11 +415,7 @@ fn apply_state_machine_kerning(
                 if state < 64 {
                     (c.start_end_safe_to_break & (1 << state)) != 0
                 } else {
-                    if let Ok(end_entry) = subtable.entry(state, aat::class::END_OF_TEXT) {
-                        !end_entry.is_actionable()
-                    } else {
-                        false
-                    }
+                    c.safe_to_break_cache.unwrap().eot_safe_high(state)
                 }
             )
         ;
@@ -639,6 +622,7 @@ impl SimpleKerning for Subtable3<'_> {
 
 pub(crate) struct KernSubtableCache {
     start_end_safe_to_break: u64,
+    safe_to_break: SafeToBreakCache,
     first_set: U32Set,
     second_set: U32Set,
     class_cache: Box<ClassCache>,
@@ -647,6 +631,7 @@ pub(crate) struct KernSubtableCache {
 impl KernSubtableCache {
     pub(crate) fn new(subtable: &Subtable, num_glyphs: u32) -> Self {
         let mut start_end_safe_to_break = 0u64;
+        let mut safe_to_break = SafeToBreakCache::empty();
         let mut first_set = U32Set::default();
         let mut second_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
@@ -656,6 +641,11 @@ impl KernSubtableCache {
                 }
                 SubtableKind::Format1(format1) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(format1);
+                    safe_to_break = SafeToBreakCache::build_legacy(
+                        format1,
+                        &KernStateEntryExt::is_actionable,
+                        &KernStateEntryExt::has_advance,
+                    );
                     collect_initial_glyphs(format1, &mut first_set, num_glyphs);
                 }
                 SubtableKind::Format2(format2) => {
@@ -668,6 +658,7 @@ impl KernSubtableCache {
         }
         KernSubtableCache {
             start_end_safe_to_break,
+            safe_to_break,
             first_set,
             second_set,
             class_cache: Box::new(ClassCache::new()),

--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -42,6 +42,8 @@ pub fn hb_ot_layout_kern(
     c.setup_buffer_glyph_set();
 
     let (kern, subtable_caches) = c.face.aat_tables.kern.as_ref()?;
+    let safe_to_break = c.face.aat_tables.safe_to_break?;
+    let safe_to_break_start = c.face.aat_tables.kern_safe_to_break_start;
 
     let mut subtable_idx = 0;
 
@@ -49,6 +51,7 @@ pub fn hb_ot_layout_kern(
     for subtable in kern.subtables() {
         let Ok(subtable) = subtable else { continue };
 
+        let safe_to_break_index = safe_to_break_start.checked_add(subtable_idx)?;
         let subtable_cache = subtable_caches.get(subtable_idx);
         let Some(subtable_cache) = subtable_cache.as_ref() else {
             break;
@@ -67,7 +70,7 @@ pub fn hb_ot_layout_kern(
         c.second_set = Some(&subtable_cache.second_set);
         c.machine_class_cache = Some(&subtable_cache.class_cache);
         c.start_end_safe_to_break = subtable_cache.start_end_safe_to_break;
-        c.safe_to_break_accel = Some(&subtable_cache.safe_to_break);
+        c.safe_to_break = safe_to_break.subtable(safe_to_break_index)?;
 
         if !c.buffer_intersects_machine() {
             continue;
@@ -407,7 +410,7 @@ fn apply_state_machine_kerning(
                 state == START_OF_TEXT
                 || (!entry.has_advance() && next_state == START_OF_TEXT)
                 // 2c, 2c', 2c"
-                || c.safe_to_break_accel.unwrap().wouldbe_matches(u16::from(class), next_state, entry.has_advance())
+                || c.safe_to_break.wouldbe_matches(u16::from(class), next_state, entry.has_advance())
             ) &&
 
             // 3
@@ -415,7 +418,7 @@ fn apply_state_machine_kerning(
                 if state < 64 {
                     (c.start_end_safe_to_break & (1 << state)) != 0
                 } else {
-                    c.safe_to_break_accel.unwrap().eot_safe_high(state)
+                    c.safe_to_break.eot_safe_high(state)
                 }
             )
         ;
@@ -622,16 +625,19 @@ impl SimpleKerning for Subtable3<'_> {
 
 pub(crate) struct KernSubtableCache {
     start_end_safe_to_break: u64,
-    safe_to_break: SafeToBreakAccel,
     first_set: U32Set,
     second_set: U32Set,
     class_cache: Box<ClassCache>,
 }
 
 impl KernSubtableCache {
-    pub(crate) fn new(subtable: &Subtable, num_glyphs: u32) -> Self {
+    pub(crate) fn new(
+        subtable: &Subtable,
+        num_glyphs: u32,
+        safe_to_break: &mut SafeToBreakAccel,
+    ) -> Self {
         let mut start_end_safe_to_break = 0u64;
-        let mut safe_to_break = SafeToBreakAccel::empty();
+        let mut has_safe_to_break = false;
         let mut first_set = U32Set::default();
         let mut second_set = U32Set::default();
         if let Ok(kind) = subtable.kind() {
@@ -641,11 +647,12 @@ impl KernSubtableCache {
                 }
                 SubtableKind::Format1(format1) => {
                     start_end_safe_to_break = collect_start_end_safe_to_break(format1);
-                    safe_to_break = SafeToBreakAccel::build_legacy(
+                    safe_to_break.build_legacy(
                         format1,
                         &KernStateEntryExt::is_actionable,
                         &KernStateEntryExt::has_advance,
                     );
+                    has_safe_to_break = true;
                     collect_initial_glyphs(format1, &mut first_set, num_glyphs);
                 }
                 SubtableKind::Format2(format2) => {
@@ -656,9 +663,11 @@ impl KernSubtableCache {
                 }
             }
         }
+        if !has_safe_to_break {
+            safe_to_break.add_empty();
+        }
         KernSubtableCache {
             start_end_safe_to_break,
-            safe_to_break,
             first_set,
             second_set,
             class_cache: Box::new(ClassCache::new()),


### PR DESCRIPTION
The AAT drive loops currently re-fetch up to two state-table entries per transition. Both probes factor by one axis, so this precomputes their results once per face:

- `wouldbe`: one packed `u16` per class for condition 2c.
- `eot_tail`: one bit per state at or above 64 for condition 3.

The storage is entirely face-level and independent of the experimental `Shaper` API:

- `AatCache` owns two packed vectors containing data for every morx, kern, and kerx state-machine subtable.
- Each existing top-level subtable cache contains its own 16-byte descriptor with explicit start/end pairs for both vectors.
- The apply loops resolve the slice view before the glyph-intersection scan, keeping the range loads off the immediate drive-loop dependency chain.
- The transition loops retain the packed comparison and no longer unwrap an optional acceleration object on each access.

## Previous attempts

This supersedes both closed attempts:

- #441 put 12-byte descriptors in a third centralized vector. Selecting every subtable required another indexed metadata lookup, reading the following descriptor, and validating two ranges on every shape call.
- #444 pre-resolved 40-byte slice views in `AatTables`. That removed repeated setup when combined with #443 and harfbuzz/harfbuzz#6199, but depended on the experimental cached-`Shaper` work and duplicated the views per constructed Shaper.

The first revision of this PR used a packed 12-byte descriptor. Although it retired fewer instructions, unpacking its lengths immediately before the drive loop reduced IPC enough to lose in elapsed-time measurements. The current 16-byte descriptor stores both range ends explicitly and resolves the view before scanning the buffer glyph set.

## Comparison with #441

Using the clang release HarfBuzz `main` build and `hb-shape -O "" -n 100 --shaper harfrust` (five-run `perf stat` averages), current #445 versus the final centralized-SoA commit from #441:

| Workload | instructions | cycles |
|---|---:|---:|
| Menlo / en-thelittleprince | -0.52% | -5.43% |
| Lucida Grande / en-thelittleprince | -0.61% | -3.35% |
| Geeza Pro / fa-thelittleprince | -0.29% | -0.59% |
| Devanagari Sangam / hi-words | -0.87% | -1.26% |

Cycle measurements are non-interleaved local results and should be confirmed independently. Output hashes match #441 for all four workloads.

The face cache uses 16 bytes of descriptor storage and two shared allocations instead of 56 bytes plus two allocations per subtable.

Validation:

- `cargo test` (6,268 tests)
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo build --no-default-features --features=libm`