### PR TITLE
[shape] Cache reusable table metadata

### DIFF
--- a/harfrust/src/hb/aat/mod.rs
+++ b/harfrust/src/hb/aat/mod.rs
@@ -8,7 +8,7 @@ pub mod map;
 use crate::hb::aat::layout_kerx_table::KerxSubtableCache;
 use crate::hb::aat::layout_morx_table::{MorxSubtableCache, MorxSubtableDescriptor};
 use crate::hb::kerning::KernSubtableCache;
-use crate::hb::ot::OtTables;
+use crate::hb::ot::OtCache;
 use crate::hb::tables::TableRanges;
 use alloc::vec::Vec;
 use read_fonts::{
@@ -22,17 +22,45 @@ pub struct AatCache {
     pub morx_descriptors: Vec<MorxSubtableDescriptor>,
     pub kern: Vec<KernSubtableCache>,
     pub kerx: Vec<KerxSubtableCache>,
+    has_morx: bool,
+    has_morx_from_tables: bool,
+    has_ankr: bool,
+    has_kern: bool,
+    has_kerx: bool,
+    pub(crate) has_trak: bool,
+    has_feat: bool,
 }
 
 impl AatCache {
     #[allow(unused)]
-    pub fn new<'a>(font: &impl TableProvider<'a>) -> Self {
+    pub fn new<'a>(font: &impl TableProvider<'a>, ot_cache: &OtCache) -> Self {
         let mut cache = Self::default();
         let num_glyphs = font
             .maxp()
             .map(|maxp| maxp.num_glyphs() as u32)
             .unwrap_or_default();
-        if let Ok(morx) = font.morx() {
+        let morx = font.morx().ok();
+        let kern = font.kern().ok();
+        let kerx = font.kerx().ok();
+        let morx_len = morx
+            .as_ref()
+            .map_or(0, |table| table.offset_data().len() as u32);
+        cache.has_morx =
+            morx.is_some() && !is_morx_blocklisted(morx_len, ot_cache.gsub_len, ot_cache.gdef_len);
+        let active_gdef_len = if ot_cache.has_gdef {
+            ot_cache.gdef_len
+        } else {
+            0
+        };
+        cache.has_morx_from_tables =
+            morx.is_some() && !is_morx_blocklisted(morx_len, ot_cache.gsub_len, active_gdef_len);
+        cache.has_ankr = font.ankr().is_ok();
+        cache.has_kern = kern.is_some();
+        cache.has_kerx = kerx.is_some();
+        cache.has_trak = font.trak().is_ok();
+        cache.has_feat = font.feat().is_ok();
+
+        if let Some(morx) = morx.filter(|_| cache.has_morx || cache.has_morx_from_tables) {
             let morx_base = morx.offset_data().as_bytes().as_ptr() as usize;
             for (chain_index, chain) in morx.chains().iter().enumerate() {
                 let Ok(chain) = chain else {
@@ -52,7 +80,7 @@ impl AatCache {
                 }
             }
         }
-        if let Ok(kern) = font.kern() {
+        if let Some(kern) = kern {
             for subtable in kern.subtables() {
                 let Ok(subtable) = subtable else {
                     continue;
@@ -62,7 +90,7 @@ impl AatCache {
                     .push(KernSubtableCache::new(&subtable, num_glyphs));
             }
         }
-        if let Ok(kerx) = font.kerx() {
+        if let Some(kerx) = kerx {
             for subtable in kerx.subtables().iter() {
                 let Ok(subtable) = subtable else {
                     continue;
@@ -105,13 +133,7 @@ fn is_morx_blocklisted(morx_len: u32, gsub_len: u32, gdef_len: u32) -> bool {
 
 impl<'a> AatTables<'a> {
     pub fn new(font: &FontRef<'a>, cache: &'a AatCache, table_ranges: &TableRanges) -> Self {
-        let morx = if is_morx_blocklisted(
-            table_ranges.morx.len(),
-            table_ranges.gsub.len(),
-            table_ranges.gdef.len(),
-        ) {
-            None
-        } else {
+        let morx = if cache.has_morx {
             table_ranges.morx.resolve_table(font).map(|table| {
                 (
                     table,
@@ -119,18 +141,31 @@ impl<'a> AatTables<'a> {
                     cache.morx_descriptors.as_slice(),
                 )
             })
+        } else {
+            None
         };
-        let ankr = table_ranges.ankr.resolve_table(font);
-        let kern = table_ranges
-            .kern
-            .resolve_table(font)
+        let ankr = cache
+            .has_ankr
+            .then(|| table_ranges.ankr.resolve_table(font))
+            .flatten();
+        let kern = cache
+            .has_kern
+            .then(|| table_ranges.kern.resolve_table(font))
+            .flatten()
             .map(|table| (table, cache.kern.as_slice()));
-        let kerx = table_ranges
-            .kerx
-            .resolve_table(font)
+        let kerx = cache
+            .has_kerx
+            .then(|| table_ranges.kerx.resolve_table(font))
+            .flatten()
             .map(|table| (table, cache.kerx.as_slice()));
-        let trak = table_ranges.trak.resolve_table(font);
-        let feat = table_ranges.feat.resolve_table(font);
+        let trak = cache
+            .has_trak
+            .then(|| table_ranges.trak.resolve_table(font))
+            .flatten();
+        let feat = cache
+            .has_feat
+            .then(|| table_ranges.feat.resolve_table(font))
+            .flatten();
         Self {
             morx,
             ankr,
@@ -141,38 +176,31 @@ impl<'a> AatTables<'a> {
         }
     }
 
-    pub fn from_tables(
-        font: &impl TableProvider<'a>,
-        ot_tables: &OtTables,
-        cache: &'a AatCache,
-    ) -> Self {
-        let morx = if let Ok(morx) = font.morx() {
-            let gsub_len = ot_tables
-                .gsub
-                .as_ref()
-                .map_or(0, |table| table.table.offset_data().len() as u32);
-            let gdef_len = ot_tables
-                .gdef
-                .table
-                .as_ref()
-                .map_or(0, |table| table.offset_data().len() as u32);
-            if is_morx_blocklisted(morx.offset_data().len() as u32, gsub_len, gdef_len) {
-                None
-            } else {
-                Some((
+    pub fn from_tables(font: &impl TableProvider<'a>, cache: &'a AatCache) -> Self {
+        let morx = cache
+            .has_morx_from_tables
+            .then(|| font.morx().ok())
+            .flatten()
+            .map(|morx| {
+                (
                     morx,
                     cache.morx.as_slice(),
                     cache.morx_descriptors.as_slice(),
-                ))
-            }
-        } else {
-            None
-        };
-        let ankr = font.ankr().ok();
-        let kern = font.kern().ok().map(|table| (table, cache.kern.as_slice()));
-        let kerx = font.kerx().ok().map(|table| (table, cache.kerx.as_slice()));
-        let trak = font.trak().ok();
-        let feat = font.feat().ok();
+                )
+            });
+        let ankr = cache.has_ankr.then(|| font.ankr().ok()).flatten();
+        let kern = cache
+            .has_kern
+            .then(|| font.kern().ok())
+            .flatten()
+            .map(|table| (table, cache.kern.as_slice()));
+        let kerx = cache
+            .has_kerx
+            .then(|| font.kerx().ok())
+            .flatten()
+            .map(|table| (table, cache.kerx.as_slice()));
+        let trak = cache.has_trak.then(|| font.trak().ok()).flatten();
+        let feat = cache.has_feat.then(|| font.feat().ok()).flatten();
         Self {
             morx,
             ankr,

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -39,7 +39,7 @@ impl ShaperData {
     /// Creates new cached shaper data for the given font.
     pub fn new(font: &FontRef) -> Self {
         let ot_cache = OtCache::new(font);
-        let aat_cache = AatCache::new(font);
+        let aat_cache = AatCache::new(font, &ot_cache);
         let table_ranges = TableRanges::new(font);
         let cmap_cache = cmap_cache_t::new();
         let apply_trak = font.trak().is_ok() && font.stat().is_ok();
@@ -55,7 +55,7 @@ impl ShaperData {
     fn from_font(font: &crate::font::Font) -> Self {
         let tables = font.tables();
         let ot_cache = OtCache::new(&tables);
-        let aat_cache = AatCache::new(&tables);
+        let aat_cache = AatCache::new(&tables, &ot_cache);
         let table_ranges = TableRanges::from_tables(&tables);
         let cmap_cache = cmap_cache_t::new();
         let apply_trak = tables.trak_data().is_some() && tables.stat_data().is_some();
@@ -510,11 +510,15 @@ impl<'a> crate::Shaper<'a> {
             descent: data.table_ranges.descent,
         };
         let coords = font.normalized_coords();
-        let feature_variations = font.feature_variations();
-        let feature_variations = [feature_variations.gsub(), feature_variations.gpos()];
+        let feature_variations = if coords.is_empty() {
+            [None; 2]
+        } else {
+            let feature_variations = font.feature_variations();
+            [feature_variations.gsub(), feature_variations.gpos()]
+        };
         let tables = font.tables();
         let ot_tables = OtTables::from_tables(&tables, &data.ot_cache, coords, feature_variations);
-        let aat_tables = AatTables::from_tables(&tables, &ot_tables, &data.aat_cache);
+        let aat_tables = AatTables::from_tables(&tables, &data.aat_cache);
         Some(Self {
             font: FontKind::FontInstance(font, metrics),
             units_per_em: data.table_ranges.units_per_em,
@@ -659,6 +663,47 @@ pub struct GlyphExtents {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Tag;
+    use core::cell::Cell;
+    use read_fonts::{FontData, TableProvider};
+
+    struct CountingProvider<'a> {
+        font: FontRef<'a>,
+        loads: Cell<usize>,
+    }
+
+    impl<'a> TableProvider<'a> for CountingProvider<'a> {
+        fn data_for_tag(&self, tag: Tag) -> Option<FontData<'a>> {
+            self.loads.set(self.loads.get() + 1);
+            self.font.data_for_tag(tag)
+        }
+    }
+
+    #[test]
+    fn cached_table_disposition_skips_missing_tables() {
+        let font = FontRef::new(include_bytes!("../../benches/fonts/Roboto-Regular.ttf")).unwrap();
+        let provider = CountingProvider {
+            font,
+            loads: Cell::new(0),
+        };
+        let ot_cache = OtCache::new(&provider);
+        let aat_cache = AatCache::new(&provider, &ot_cache);
+
+        provider.loads.set(0);
+        let ot_tables = OtTables::from_tables(&provider, &ot_cache, &[], [None; 2]);
+        let aat_tables = AatTables::from_tables(&provider, &aat_cache);
+
+        assert!(ot_tables.gsub.is_some());
+        assert!(ot_tables.gpos.is_some());
+        assert!(ot_tables.gdef.table.is_some());
+        assert!(aat_tables.morx.is_none());
+        assert!(aat_tables.ankr.is_none());
+        assert!(aat_tables.kern.is_none());
+        assert!(aat_tables.kerx.is_none());
+        assert!(aat_tables.trak.is_none());
+        assert!(aat_tables.feat.is_none());
+        assert_eq!(provider.loads.get(), 3);
+    }
 
     #[test]
     fn extents_scale_from_corners_like_harfbuzz() {

--- a/harfrust/src/hb/ot/mod.rs
+++ b/harfrust/src/hb/ot/mod.rs
@@ -17,8 +17,8 @@ use read_fonts::{
         varc::{Condition, CoverageTable},
         variations::{DeltaSetIndex, ItemVariationStore},
     },
-    types::{BigEndian, F2Dot14, GlyphId, Offset32},
-    FontData, FontRef, ReadError, ResolveOffset, TableProvider,
+    types::{BigEndian, F2Dot14, GlyphId},
+    FontData, FontRead, FontRef, ReadError, TableProvider,
 };
 
 pub mod contextual;
@@ -30,7 +30,12 @@ pub struct OtCache {
     pub gsub: LookupCache,
     pub gpos: LookupCache,
     pub gdef_glyph_props_cache: MappingCache,
-    pub gdef_mark_set_bitmaps: Vec<MarkGlyphSetBitmap>,
+    gdef: GdefCache,
+    has_gsub: bool,
+    has_gpos: bool,
+    pub(crate) has_gdef: bool,
+    pub(crate) gsub_len: u32,
+    pub(crate) gdef_len: u32,
 }
 
 const MARK_GLYPH_SET_PAGE_BITS: u32 = 512;
@@ -118,31 +123,107 @@ impl MarkGlyphSetBitmap {
 
 impl OtCache {
     pub fn new<'a>(font: &impl TableProvider<'a>) -> Self {
-        let gsub = font
-            .gsub()
-            .map(|t| LookupCache::new(&t))
+        let gsub_table = font.gsub().ok();
+        let gpos_table = font.gpos().ok();
+        let gdef_table = font.gdef().ok();
+        let gsub_len = gsub_table
+            .as_ref()
+            .map_or(0, |table| table.offset_data().len() as u32);
+        let gpos_len = gpos_table
+            .as_ref()
+            .map_or(0, |table| table.offset_data().len() as u32);
+        let gdef_len = gdef_table
+            .as_ref()
+            .map_or(0, |table| table.offset_data().len() as u32);
+        let has_gdef = gdef_table.is_some() && !is_gdef_blocklisted(gdef_len, gsub_len, gpos_len);
+        let gsub = gsub_table
+            .as_ref()
+            .map(LookupCache::new)
             .unwrap_or_default();
-        let gpos = font
-            .gpos()
-            .map(|t| LookupCache::new(&t))
+        let gpos = gpos_table
+            .as_ref()
+            .map(LookupCache::new)
             .unwrap_or_default();
-        let mut gdef_mark_set_bitmaps = Vec::new();
-        if let Ok(gdef) = font.gdef() {
-            if let Some(Ok(mark_sets)) = gdef.mark_glyph_sets_def() {
-                gdef_mark_set_bitmaps.extend(mark_sets.coverages().iter().map(|set| {
-                    set.ok().map_or_else(
-                        || MarkGlyphSetBitmap::Digest(hb_set_digest_t::default()),
-                        |coverage| MarkGlyphSetBitmap::from_coverage(&coverage),
-                    )
-                }));
-            }
-        }
+        let gdef = gdef_table
+            .as_ref()
+            .filter(|_| has_gdef)
+            .map(GdefCache::new)
+            .unwrap_or_default();
         Self {
             gsub,
             gpos,
             gdef_glyph_props_cache: MappingCache::new(),
-            gdef_mark_set_bitmaps,
+            gdef,
+            has_gsub: gsub_table.is_some(),
+            has_gpos: gpos_table.is_some(),
+            has_gdef,
+            gsub_len,
+            gdef_len,
         }
+    }
+}
+
+#[derive(Default)]
+struct GdefCache {
+    classes: Option<ClassDefInfo>,
+    mark_classes: Option<ClassDefInfo>,
+    mark_set_offsets: Vec<u32>,
+    mark_set_bitmaps: Vec<MarkGlyphSetBitmap>,
+    item_var_store_offset: u32,
+}
+
+impl GdefCache {
+    fn new(gdef: &Gdef) -> Self {
+        let data = gdef.offset_data();
+        let classes = ClassDefInfo::new(
+            &data,
+            gdef.glyph_class_def_offset().offset().to_u32() as u16,
+        );
+        let mark_classes = ClassDefInfo::new(
+            &data,
+            gdef.mark_attach_class_def_offset().offset().to_u32() as u16,
+        );
+        let mut mark_set_offsets = Vec::new();
+        let mut mark_set_bitmaps = Vec::new();
+        if let Some((base, Ok(mark_sets))) = gdef
+            .mark_glyph_sets_def_offset()
+            .map(|offset| offset.offset().to_u32())
+            .zip(gdef.mark_glyph_sets_def())
+        {
+            mark_set_offsets.extend(
+                mark_sets
+                    .coverage_offsets()
+                    .iter()
+                    .map(|offset| base.saturating_add(offset.get().to_u32())),
+            );
+            mark_set_bitmaps.extend(mark_sets.coverages().iter().map(|set| {
+                set.ok().map_or_else(
+                    || MarkGlyphSetBitmap::Digest(hb_set_digest_t::default()),
+                    |coverage| MarkGlyphSetBitmap::from_coverage(&coverage),
+                )
+            }));
+        }
+        let item_var_store_offset = gdef
+            .item_var_store_offset()
+            .map(|offset| offset.offset().to_u32())
+            .unwrap_or_default();
+        Self {
+            classes,
+            mark_classes,
+            mark_set_offsets,
+            mark_set_bitmaps,
+            item_var_store_offset,
+        }
+    }
+
+    fn item_var_store<'a>(&self, gdef: &Gdef<'a>) -> Option<ItemVariationStore<'a>> {
+        if self.item_var_store_offset == 0 {
+            return None;
+        }
+        let data = gdef
+            .offset_data()
+            .split_off(self.item_var_store_offset as usize)?;
+        ItemVariationStore::read(data).ok()
     }
 }
 
@@ -179,27 +260,11 @@ impl crate::hb::ot_layout::LayoutTable for GposTable<'_> {
 #[derive(Clone, Default)]
 pub struct GdefTable<'a> {
     pub(crate) table: Option<Gdef<'a>>,
-    classes: Option<ClassDef<'a>>,
-    mark_classes: Option<ClassDef<'a>>,
-    mark_sets: Option<(FontData<'a>, &'a [BigEndian<Offset32>])>,
 }
 
 impl<'a> GdefTable<'a> {
     fn new(gdef: Gdef<'a>) -> Self {
-        let classes = gdef.glyph_class_def().transpose().ok().flatten();
-        let mark_classes = gdef.mark_attach_class_def().transpose().ok().flatten();
-        let mark_sets = gdef
-            .mark_glyph_sets_def()
-            .transpose()
-            .ok()
-            .flatten()
-            .map(|sets| (sets.offset_data(), sets.coverage_offsets()));
-        Self {
-            table: Some(gdef),
-            classes,
-            mark_classes,
-            mark_sets,
-        }
+        Self { table: Some(gdef) }
     }
 }
 
@@ -210,6 +275,7 @@ pub struct OtTables<'a> {
     pub gdef: GdefTable<'a>,
     pub gdef_glyph_props_cache: &'a MappingCache,
     pub gdef_mark_set_bitmaps: &'a [MarkGlyphSetBitmap],
+    gdef_cache: &'a GdefCache,
     pub coords: &'a [F2Dot14],
     pub var_store: Option<ItemVariationStore<'a>>,
     pub feature_variations: [Option<u32>; 2],
@@ -237,28 +303,19 @@ impl<'a> OtTables<'a> {
                 table,
                 lookups: &cache.gpos,
             });
-        let coords = if coords.iter().any(|coord| *coord != F2Dot14::ZERO) {
-            coords
-        } else {
-            &[]
-        };
-        let gdef = if is_gdef_blocklisted(
-            table_offsets.gdef.len(),
-            table_offsets.gsub.len(),
-            table_offsets.gpos.len(),
-        ) {
-            GdefTable::default()
-        } else {
+        let gdef = if cache.has_gdef {
             table_offsets
                 .gdef
                 .resolve_table(font)
                 .map(GdefTable::new)
                 .unwrap_or_default()
+        } else {
+            GdefTable::default()
         };
         let var_store = if !coords.is_empty() {
             gdef.table
                 .as_ref()
-                .and_then(|gdef| gdef.item_var_store().transpose().ok().flatten())
+                .and_then(|gdef| cache.gdef.item_var_store(gdef))
         } else {
             None
         };
@@ -267,7 +324,8 @@ impl<'a> OtTables<'a> {
             gpos,
             gdef,
             gdef_glyph_props_cache: &cache.gdef_glyph_props_cache,
-            gdef_mark_set_bitmaps: &cache.gdef_mark_set_bitmaps,
+            gdef_mark_set_bitmaps: &cache.gdef.mark_set_bitmaps,
+            gdef_cache: &cache.gdef,
             var_store,
             coords,
             feature_variations,
@@ -280,40 +338,32 @@ impl<'a> OtTables<'a> {
         coords: &'a [F2Dot14],
         feature_variations: [Option<u32>; 2],
     ) -> Self {
-        let gsub = font.gsub().ok().map(|table| GsubTable {
-            table,
-            lookups: &cache.gsub,
-        });
-        let gpos = font.gpos().ok().map(|table| GposTable {
-            table,
-            lookups: &cache.gpos,
-        });
-        let coords = if coords.iter().any(|coord| *coord != F2Dot14::ZERO) {
-            coords
-        } else {
-            &[]
-        };
-        let gdef = if let Ok(gdef) = font.gdef() {
-            let gsub_len = gsub
-                .as_ref()
-                .map(|t| t.table.offset_data().len() as u32)
-                .unwrap_or_default();
-            let gpos_len = gpos
-                .as_ref()
-                .map(|t| t.table.offset_data().len() as u32)
-                .unwrap_or_default();
-            if is_gdef_blocklisted(gdef.offset_data().len() as u32, gsub_len, gpos_len) {
-                GdefTable::default()
-            } else {
-                GdefTable::new(gdef)
-            }
-        } else {
-            GdefTable::default()
-        };
+        let gsub = cache
+            .has_gsub
+            .then(|| font.gsub().ok())
+            .flatten()
+            .map(|table| GsubTable {
+                table,
+                lookups: &cache.gsub,
+            });
+        let gpos = cache
+            .has_gpos
+            .then(|| font.gpos().ok())
+            .flatten()
+            .map(|table| GposTable {
+                table,
+                lookups: &cache.gpos,
+            });
+        let gdef = cache
+            .has_gdef
+            .then(|| font.gdef().ok())
+            .flatten()
+            .map(GdefTable::new)
+            .unwrap_or_default();
         let var_store = if !coords.is_empty() {
             gdef.table
                 .as_ref()
-                .and_then(|gdef| gdef.item_var_store().transpose().ok().flatten())
+                .and_then(|gdef| cache.gdef.item_var_store(gdef))
         } else {
             None
         };
@@ -322,7 +372,8 @@ impl<'a> OtTables<'a> {
             gpos,
             gdef,
             gdef_glyph_props_cache: &cache.gdef_glyph_props_cache,
-            gdef_mark_set_bitmaps: &cache.gdef_mark_set_bitmaps,
+            gdef_mark_set_bitmaps: &cache.gdef.mark_set_bitmaps,
+            gdef_cache: &cache.gdef,
             var_store,
             coords,
             feature_variations,
@@ -330,21 +381,27 @@ impl<'a> OtTables<'a> {
     }
 
     pub fn has_glyph_classes(&self) -> bool {
-        self.gdef.classes.is_some()
+        self.gdef_cache.classes.is_some()
     }
 
     pub fn glyph_class(&self, glyph_id: u32) -> u16 {
-        self.gdef
+        self.gdef_cache
             .classes
             .as_ref()
-            .map_or(0, |class_def| class_def.get(glyph_id))
+            .zip(self.gdef.table.as_ref())
+            .map_or(0, |(class_def, gdef)| {
+                class_def.class(&gdef.offset_data(), GlyphId::new(glyph_id))
+            })
     }
 
     pub fn glyph_mark_attachment_class(&self, glyph_id: u32) -> u16 {
-        self.gdef
+        self.gdef_cache
             .mark_classes
             .as_ref()
-            .map_or(0, |class_def| class_def.get(glyph_id))
+            .zip(self.gdef.table.as_ref())
+            .map_or(0, |(class_def, gdef)| {
+                class_def.class(&gdef.offset_data(), GlyphId::new(glyph_id))
+            })
     }
 
     pub(crate) fn glyph_props(&self, glyph: GlyphId) -> u16 {
@@ -372,10 +429,12 @@ impl<'a> OtTables<'a> {
     #[inline(never)]
     pub fn is_mark_glyph_gdef(&self, glyph_id: u32, set_index: u16) -> bool {
         self.gdef
-            .mark_sets
+            .table
             .as_ref()
-            .and_then(|(data, offsets)| Some((data, offsets.get(set_index as usize)?.get())))
-            .and_then(|(data, offset)| offset.resolve::<CoverageTable>(*data).ok())
+            .and_then(|gdef| {
+                let offset = *self.gdef_cache.mark_set_offsets.get(set_index as usize)? as usize;
+                CoverageTable::read(gdef.offset_data().split_off(offset)?).ok()
+            })
             .is_some_and(|coverage| coverage.get(glyph_id).is_some())
     }
 

--- a/harfrust/src/hb/tables.rs
+++ b/harfrust/src/hb/tables.rs
@@ -259,10 +259,6 @@ impl TableRange {
     pub fn resolve_table<'a, T: FontRead<'a, Args = ()>>(self, font: &FontRef<'a>) -> Option<T> {
         T::read(self.resolve_data(font)?).ok()
     }
-
-    pub fn len(self) -> u32 {
-        self.1
-    }
 }
 
 fn find_best_cmap_subtable<'a>(


### PR DESCRIPTION
This follows the API-preserving direction suggested in [the discussion on #443](https://github.com/harfbuzz/harfrust/pull/443#issuecomment-5387863619): keep the existing `shape(&FontInstance, ...)` API, but move font-invariant work from per-call `OtTables`/`AatTables` materialization into `OtCache` and `AatCache`.

Specifically:

- memoize GSUB/GPOS/GDEF and AAT table disposition (missing, present, or blocklisted), avoiding provider calls for known-missing tables on every shape;
- memoize both morx blocklist results required by the `FontRef` and font-model paths;
- cache compact GDEF class descriptors plus absolute mark-set and variation-store offsets, instead of reparsing those GDEF subtables for every shape;
- skip the feature-variation atomic path for the canonical default instance (empty normalized coordinates);
- keep materializing borrowed wrappers for present top-level tables, so there is no public API change, self-reference, unsafe code, or coordinated HarfBuzz/fontations rollout.

A regression test verifies that materializing the views for an OT font loads only its three present OT tables and does not touch the six known-missing AAT tables.

### Performance

Clang release `~/hb/b`, HarfBuzz main `b04cd416f3`, five `perf stat` repetitions per case:

```
hb-shape -O '' -n 100 --shaper harfrust --text-file TEXT FONT
```

| Font / text | instructions | cycles |
|---|---:|---:|
| Menlo / en-thelittleprince | **-2.685%** | **-3.301%** |
| LucidaGrande / en-thelittleprince | **-2.001%** | **-2.427%** |
| GeezaPro / fa-thelittleprince | **-0.883%** | **-2.115%** |
| Devanagari Sangam MN / hi-words | **-0.614%** | **-0.986%** |
| Roboto / en-thelittleprince | **-1.815%** | **-2.678%** |
| Roboto / en-words | **-3.408%** | **-2.915%** |
| Source Serif Variable / react-dom | **-2.331%** | **-3.053%** |
| Noto Sans Devanagari / hi-words | **-1.018%** | **-3.786%** |
| Amiri / fa-thelittleprince | -0.021% | +0.244% |
| Noto Nastaliq Urdu / fa-thelittleprince | +0.095% | **-1.116%** |
| Noto Nastaliq Urdu / fa-words | -0.031% | **-0.784%** |

Instruction counts were deterministic; the small Amiri cycle increase is within the noise of the non-interleaved runs. This recovers a meaningful portion of #443/#6199's cached-`Shaper` benefit without requiring either API change.

### Validation

- `cargo test -p harfrust --all-features` — 6,269 tests pass
- `cargo clippy -p harfrust --all-features --all-targets -- -D warnings`
- `cargo build -p harfrust --no-default-features --features=libm`
- HarfBuzz `test-shape-harfrust` — 4 subtests pass
- serialized outputs for all eleven benchmark pairs are byte-identical to `main`
