### PR TITLE
[shape] Add an in-place reusable buffer API

### DIFF
--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -2234,6 +2234,49 @@ impl GlyphBuffer {
     }
 }
 
+/// A scoped view of shaping results in a reusable [`UnicodeBuffer`].
+///
+/// The buffer is cleared automatically when this view is dropped, preserving
+/// the `UnicodeBuffer` type-state while allowing its allocation-bearing state
+/// to remain in place during shaping.
+#[cfg(feature = "experimental_font_api")]
+pub struct GlyphBufferRef<'a>(pub(crate) &'a mut hb_buffer_t);
+
+#[cfg(feature = "experimental_font_api")]
+impl GlyphBufferRef<'_> {
+    /// Returns the number of glyphs in the buffer.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len
+    }
+
+    /// Returns `true` if the buffer contains no glyphs.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the glyph infos.
+    #[inline]
+    pub fn glyph_infos(&self) -> &[GlyphInfo] {
+        &self.0.info[..self.0.len]
+    }
+
+    /// Returns the glyph positions.
+    #[inline]
+    pub fn glyph_positions(&self) -> &[GlyphPosition] {
+        &self.0.pos[..self.0.len]
+    }
+}
+
+#[cfg(feature = "experimental_font_api")]
+impl Drop for GlyphBufferRef<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        self.0.clear();
+    }
+}
+
 pub trait SerializerFont {
     fn coords(&self) -> &[F2Dot14];
     fn glyph_names(&self) -> GlyphNames<'_>;

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -19,6 +19,8 @@ use super::ot_layout::TableIndex;
 use super::ot_shape::OtShapeContext;
 use crate::hb::aat::AatCache;
 use crate::hb::tables::TableRanges;
+#[cfg(feature = "experimental_font_api")]
+use crate::GlyphBufferRef;
 use crate::{script, Feature, GlyphBuffer, NormalizedCoord, ShapePlan, UnicodeBuffer, Variation};
 
 pub use super::font_funcs::{
@@ -468,6 +470,33 @@ pub fn shape(
     GlyphBuffer(buffer)
 }
 
+/// Shapes a reusable buffer in place and returns a scoped view of the results.
+///
+/// The returned view borrows `buffer` and clears it when dropped. This avoids
+/// moving the buffer's allocation-bearing state into and out of a
+/// [`GlyphBuffer`], while leaving `buffer` ready for reuse afterward.
+///
+/// If a plan is provided, it is up to the caller to ensure that the shape plan
+/// matches the properties of the provided buffer.
+#[cfg(feature = "experimental_font_api")]
+pub fn shape_in_place<'a>(
+    font: &crate::font::FontInstance,
+    buffer: &'a mut UnicodeBuffer,
+    mut options: ShapeOptions<'_>,
+) -> GlyphBufferRef<'a> {
+    if let Some(hb_font) = hb_font_t::from_font(font).as_ref() {
+        if options.scale.is_none() {
+            if let Some(ppem) = font.size() {
+                options = options.scale(Some((ppem * 65536.0) as i32));
+            }
+        }
+        hb_font.shape_buffer(&mut buffer.0, options);
+    } else {
+        buffer.clear();
+    }
+    GlyphBufferRef(&mut buffer.0)
+}
+
 // This will go away completely when we drop the old API.
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
@@ -745,5 +774,50 @@ mod tests {
         assert_eq!(scaled.y_bearing, i32::MIN);
         assert_eq!(scaled.width, i32::MAX);
         assert_eq!(scaled.height, i32::MIN);
+    }
+
+    #[cfg(feature = "experimental_font_api")]
+    #[test]
+    fn shape_in_place_matches_shape_and_clears_on_drop() {
+        use crate::font::{Font, FontInstance};
+
+        fn text_buffer() -> UnicodeBuffer {
+            let mut buffer = UnicodeBuffer::new();
+            buffer.push_str("office");
+            buffer.guess_segment_properties();
+            buffer
+        }
+
+        let font = Font::new(
+            &include_bytes!("../../benches/fonts/Roboto-Regular.ttf")[..],
+            0,
+        )
+        .unwrap();
+        let instance = FontInstance::builder(&font).build();
+        let expected = shape(&instance, text_buffer(), ShapeOptions::default());
+
+        let mut buffer = text_buffer();
+        {
+            let glyphs = shape_in_place(&instance, &mut buffer, ShapeOptions::default());
+            assert_eq!(glyphs.len(), expected.len());
+            for (actual, expected) in glyphs.glyph_infos().iter().zip(expected.glyph_infos()) {
+                assert_eq!(actual.glyph_id, expected.glyph_id);
+                assert_eq!(actual.mask, expected.mask);
+                assert_eq!(actual.cluster, expected.cluster);
+                assert_eq!(actual.vars, expected.vars);
+            }
+            for (actual, expected) in glyphs
+                .glyph_positions()
+                .iter()
+                .zip(expected.glyph_positions())
+            {
+                assert_eq!(actual.x_advance, expected.x_advance);
+                assert_eq!(actual.y_advance, expected.y_advance);
+                assert_eq!(actual.x_offset, expected.x_offset);
+                assert_eq!(actual.y_offset, expected.y_offset);
+                assert_eq!(actual.var, expected.var);
+            }
+        }
+        assert!(buffer.is_empty());
     }
 }

--- a/harfrust/src/lib.rs
+++ b/harfrust/src/lib.rs
@@ -27,7 +27,7 @@ pub use read_fonts::{
 };
 
 #[cfg(feature = "experimental_font_api")]
-pub use hb::face::shape;
+pub use hb::face::{shape, shape_in_place};
 
 /// Font related types.
 pub mod font {
@@ -45,6 +45,8 @@ pub mod font {
     pub(crate) use read_fonts::model::*;
 }
 
+#[cfg(feature = "experimental_font_api")]
+pub use hb::buffer::GlyphBufferRef;
 pub use hb::buffer::{GlyphBuffer, GlyphFlags, GlyphInfo, GlyphPosition, UnicodeBuffer};
 pub use hb::common::{script, Direction, Feature, Language, Script, Variation};
 pub use hb::face::{


### PR DESCRIPTION
Adds shape_in_place() under experimental_font_api while preserving the existing shape() API.

The new API borrows a UnicodeBuffer, shapes its allocation-bearing state in place, and returns a scoped GlyphBufferRef. The guard exposes the result slices and clears the buffer on drop, so the caller retains the UnicodeBuffer type-state and can immediately reuse its allocations.

This is intended for reusable FFI caches such as the HarfBuzz bridge. It avoids moving the 304-byte internal buffer out of and back into a Box on every shape.

With the corresponding HarfBuzz bridge change, measured against the same cached-buffer baseline:

- Roboto prince: -0.33% instructions, -0.51% cycles
- Roboto words: -2.19% instructions, -3.94% cycles
- all eleven AAT/OT benchmark pairs improved or were neutral
- callgrind on Roboto words: about 301 fewer instructions per shape, including about 65 fewer memcpy instructions

Validation:

- cargo test -p harfrust --all-features (6,271 tests)
- cargo clippy -p harfrust --all-features --all-targets -- -D warnings
- HarfBuzz HarfRust API tests (4 subtests)
- output parity with the OT shaper on all eleven benchmark inputs