### PR TITLE
Release 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 This development version matches HarfBuzz [v14.3.1](https://github.com/harfbuzz/harfbuzz/releases/tag/14.3.1).
 
+## [0.13.2] - 2026-08-23
+
+This release matches HarfBuzz [v14.3.1](https://github.com/harfbuzz/harfbuzz/releases/tag/14.3.1),
+and has an MSRV (minimum supported Rust version) of 1.85.
+
+- Speed up contextual and chained-context lookup matching by probing raw rule
+  offsets and reusing parsed coverage tables (#437).
+- Skip the redundant per-subtable digest test for single-subtable lookups
+  (#438).
+- Set up glyph-set acceleration before applying legacy `kern` tables (#439).
+- Precompute and pack AAT state-machine safe-to-break probes in the face cache
+  (#445).
+- Cache reusable shaping table metadata and avoid moving shaper and buffer
+  temporaries on every shape (#446, #447).
+
 ## [0.13.1] - 2026-08-21
 
 This release matches HarfBuzz [v14.3.1](https://github.com/harfbuzz/harfbuzz/releases/tag/14.3.1),
@@ -271,7 +286,8 @@ This release matches HarfBuzz [v11.2.1][harfbuzz-11.2.1], and has an MSRV (minim
 HarfRust is a fork of RustyBuzz.
 See [their changelog](https://github.com/harfbuzz/rustybuzz/blob/main/CHANGELOG.md) for details of prior releases.
 
-[Unreleased]: https://github.com/harfbuzz/harfrust/compare/0.13.1...HEAD
+[Unreleased]: https://github.com/harfbuzz/harfrust/compare/0.13.2...HEAD
+[0.13.2]: https://github.com/harfbuzz/harfrust/compare/0.13.1...0.13.2
 [0.13.1]: https://github.com/harfbuzz/harfrust/compare/0.13.0...0.13.1
 [0.13.0]: https://github.com/harfbuzz/harfrust/compare/0.12.0...0.13.0
 [0.12.0]: https://github.com/harfbuzz/harfrust/compare/0.11.0...0.12.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["harfrust", "hr-shape", "fuzz"]
 resolver = "3"
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 rust-version = "1.85"  # should match https://github.com/googlefonts/fontations/blob/main/Cargo.toml
 description = "A complete HarfBuzz shaping algorithm port to Rust."
@@ -23,7 +23,7 @@ inherits = "release"
 
 [workspace.dependencies]
 read-fonts = { version = "0.43.2", default-features = false, features = ["experimental_font_api"] }
-harfrust = { version = "0.13.1", path = "./harfrust", default-features = false }
+harfrust = { version = "0.13.2", path = "./harfrust", default-features = false }
 
 [workspace.lints.rust]
 unused_qualifications = "warn"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ HarfRust started as a fork of [RustyBuzz](https://docs.rs/rustybuzz) to explore 
 multiple implementations of core font parsing for [`skrifa`](https://docs.rs/skrifa) consumers.
 Further context in https://github.com/googlefonts/fontations/issues/956.
 
-Matches HarfBuzz [v14.3.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.3.0).
+Matches HarfBuzz [v14.3.1](https://github.com/harfbuzz/harfbuzz/releases/tag/14.3.1).
 
 ## Why?
 


### PR DESCRIPTION
Prepare the 0.13.2 patch release.

This release contains the shaping-performance work landed since 0.13.1, keeps the HarfBuzz tracking version at 14.3.1 and MSRV at 1.85, updates both workspace version references, and fixes the stale HarfBuzz version in the README.

Validation:

- cargo semver-checks check-release -p harfrust: 196 checks passed
- cargo semver-checks check-release -p hr-shape: 196 checks passed
- cargo test --workspace --all-features: passed
- cargo publish --dry-run -p harfrust from a clean worktree: packaged and verified successfully

The hr-shape dry run is deferred until harfrust 0.13.2 is published, since its normalized package dependency correctly requires that version from crates.io.