### PR TITLE
[aat] Apply language-specific morph features

### DIFF
--- a/HARFBUZZ.md
+++ b/HARFBUZZ.md
@@ -48,40 +48,23 @@ locks the environment variables.
 $ HB_SHAPER_LIST=harfrust meson test -C build
 ```
 
-If all goes well, you should see lots of output, ending in:
+The exact totals change as HarfBuzz adds tests. As of August 24, 2026,
+the relevant shaping suites report:
 
 ```
-Ok:                 217
-Expected Fail:      0
-Fail:               2
-Unexpected Pass:    0
-Skipped:            0
-Timeout:            0
+shape+aots:                 800/800 passed
+shape+text-rendering-tests: 437/437 passed
+shape+in-house:             5012/5021 passed
 ```
-
-If you scroll up, you'd see that the two failing tests are:
-```
-214/219 harfbuzz:shape+text-rendering-tests / text-rendering-tests            FAIL             0.12s   432/435 subtests passed
-```
-and
-```
-218/219 harfbuzz:shape+in-house / in-house                                    FAIL             0.36s   4779/4800 subtests passed
-```
-
-This is pretty good. In total, there are 24 shaping tests failing.
-Those are mostly due to HarfRust not supporting some esoteric
-shaping features of HarfBuzz.
 
 To see specific failures, you can run inspect the test log:
 ```sh
 $ less build/meson-logs/testlog.txt
 ```
 
-Currently the following tests fail:
-- `SHBALI-3.tests`: Rounding differences with unusual UPEM.
-- `arabic-fallback-positioning.tests`: Not implemented.
-- `collections.tests`: `DFONT` format is not supported.
-- `vertical.tests`: Fallback based on glyph extents not supported.
+The nine remaining shaping failures are all in
+`arabic-fallback-shaping.tests`; HarfRust does not yet synthesize Arabic
+fallback lookups for fonts without the required OpenType substitutions.
 
 
 ## Running HarfBuzz's Benchmark Tests

--- a/harfrust/src/hb/aat/layout.rs
+++ b/harfrust/src/hb/aat/layout.rs
@@ -508,7 +508,7 @@ pub fn substitute(
 ) {
     let mut aat_map = map::AatMap::default();
     if !features.is_empty() {
-        let mut builder = map::AatMapBuilder::default();
+        let mut builder = map::AatMapBuilder::new(plan.language.as_ref());
         for feature in features {
             builder.add_feature(face, feature);
         }

--- a/harfrust/src/hb/aat/layout_morx_table.rs
+++ b/harfrust/src/hb/aat/layout_morx_table.rs
@@ -5,7 +5,8 @@ use crate::hb::aat::layout_common::{
     START_OF_TEXT,
 };
 use crate::hb::ot_layout::MAX_CONTEXT_LENGTH;
-use crate::hb::{hb_font_t, GlyphInfo};
+use crate::hb::tag::lang_matches;
+use crate::hb::{hb_font_t, GlyphInfo, Language};
 use crate::U32Set;
 use alloc::{vec, vec::Vec};
 use read_fonts::tables::aat::{self, ExtendedStateTable, NoPayload, StateEntry, StateTable};
@@ -66,10 +67,32 @@ pub fn compile_flags(face: &hb_font_t, builder: &AatMapBuilder, map: &mut AatMap
             })
             .is_ok()
     };
+    let language_matches = |setting: u16| {
+        let Some(index) = setting.checked_sub(1) else {
+            return false;
+        };
+        let Some(requested) = builder.language.as_ref() else {
+            return false;
+        };
+        let Some(ltag) = face.aat_tables.ltag.as_ref() else {
+            return false;
+        };
+        let Some(tag) = ltag
+            .tag_indices()
+            .find_map(|(tag_index, tag)| (tag_index == u32::from(index)).then_some(tag))
+        else {
+            return false;
+        };
+        let Some(language) = Language::new(tag) else {
+            return false;
+        };
+        lang_matches(requested.as_bytes(), language.as_bytes())
+    };
 
     fn compile_chain(
         chain: &impl MorphChain,
         has_feature: &impl Fn(u16, u16) -> bool,
+        language_matches: &impl Fn(u16) -> bool,
         chain_flags: &mut Vec<RangeFlags>,
         builder: &AatMapBuilder,
     ) {
@@ -93,8 +116,12 @@ pub fn compile_flags(face: &hb_font_t, builder: &AatMapBuilder, map: &mut AatMap
                         flags &= disable_flags;
                         flags |= enable_flags;
                     }
+                } else if feature_type == FEATURE_TYPE_LANGUAGE_TAG_TYPE as u16
+                    && language_matches(feature_setting)
+                {
+                    flags &= disable_flags;
+                    flags |= enable_flags;
                 }
-                // TODO: Port the following commit: https://github.com/harfbuzz/harfbuzz/commit/2124ad890
             },
         );
 
@@ -110,7 +137,13 @@ pub fn compile_flags(face: &hb_font_t, builder: &AatMapBuilder, map: &mut AatMap
         map.chain_flags.resize(chains.iter().count(), vec![]);
         for (chain, chain_flags) in chains.iter().zip(map.chain_flags.iter_mut()) {
             if let Ok(chain) = chain {
-                compile_chain(&chain, &has_feature, chain_flags, builder);
+                compile_chain(
+                    &chain,
+                    &has_feature,
+                    &language_matches,
+                    chain_flags,
+                    builder,
+                );
             }
         }
     } else {
@@ -118,7 +151,13 @@ pub fn compile_flags(face: &hb_font_t, builder: &AatMapBuilder, map: &mut AatMap
         map.chain_flags.resize(chains.iter().count(), vec![]);
         for (chain, chain_flags) in chains.iter().zip(map.chain_flags.iter_mut()) {
             if let Ok(chain) = chain {
-                compile_chain(&chain, &has_feature, chain_flags, builder);
+                compile_chain(
+                    &chain,
+                    &has_feature,
+                    &language_matches,
+                    chain_flags,
+                    builder,
+                );
             }
         }
     }

--- a/harfrust/src/hb/aat/map.rs
+++ b/harfrust/src/hb/aat/map.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 
 use super::layout::*;
-use crate::hb::{hb_font_t, hb_mask_t, hb_tag_t};
+use crate::hb::{hb_font_t, hb_mask_t, hb_tag_t, Language};
 
 /// HB: hb_aat_map_t
 ///
@@ -31,6 +31,7 @@ pub struct RangeFlags {
 /// See <https://github.com/harfbuzz/harfbuzz/blob/2c22a65f0cb99544c36580b9703a43b5dc97a9e1/src/hb-aat-map.hh#L49>
 #[doc(alias = "hb_aat_map_builder_t")]
 pub struct AatMapBuilder {
+    pub language: Option<Language>,
     pub current_features: Vec<FeatureInfo>,
     pub features: Vec<FeatureRange>,
     pub range_first: usize,
@@ -40,6 +41,7 @@ pub struct AatMapBuilder {
 impl Default for AatMapBuilder {
     fn default() -> Self {
         Self {
+            language: None,
             range_first: HB_FEATURE_GLOBAL_START as usize,
             range_last: HB_FEATURE_GLOBAL_END as usize,
             current_features: Vec::default(),
@@ -49,6 +51,13 @@ impl Default for AatMapBuilder {
 }
 
 impl AatMapBuilder {
+    pub fn new(language: Option<&Language>) -> Self {
+        Self {
+            language: language.cloned(),
+            ..Self::default()
+        }
+    }
+
     pub fn add_feature(&mut self, face: &hb_font_t, feature: &Feature) -> Option<()> {
         let feat = face.aat_tables.feat.as_ref()?;
 

--- a/harfrust/src/hb/aat/mod.rs
+++ b/harfrust/src/hb/aat/mod.rs
@@ -13,7 +13,10 @@ use crate::hb::ot::OtCache;
 use crate::hb::tables::TableRanges;
 use alloc::vec::Vec;
 use read_fonts::{
-    tables::{ankr::Ankr, feat::Feat, kern::Kern, kerx::Kerx, mort::Mort, morx::Morx, trak::Trak},
+    tables::{
+        ankr::Ankr, feat::Feat, kern::Kern, kerx::Kerx, ltag::Ltag, mort::Mort, morx::Morx,
+        trak::Trak,
+    },
     FontRef, TableProvider,
 };
 
@@ -35,6 +38,7 @@ pub struct AatCache {
     has_kerx: bool,
     pub(crate) has_trak: bool,
     has_feat: bool,
+    has_ltag: bool,
 }
 
 impl AatCache {
@@ -68,6 +72,7 @@ impl AatCache {
         cache.has_kerx = kerx.is_some();
         cache.has_trak = font.trak().is_ok();
         cache.has_feat = font.feat().is_ok();
+        cache.has_ltag = font.ltag().is_ok();
 
         if let Some(morx) = morx.filter(|_| cache.has_morx || cache.has_morx_from_tables) {
             let morx_base = morx.offset_data().as_bytes().as_ptr() as usize;
@@ -161,6 +166,7 @@ pub struct AatTables<'a> {
     pub kerx: Option<(Kerx<'a>, &'a [KerxSubtableCache])>,
     pub trak: Option<Trak<'a>>,
     pub feat: Option<Feat<'a>>,
+    pub ltag: Option<Ltag<'a>>,
 }
 
 use crate::algs::HB_CODEPOINT_ENCODE3 as encode3;
@@ -222,6 +228,10 @@ impl<'a> AatTables<'a> {
             .has_feat
             .then(|| table_ranges.feat.resolve_table(font))
             .flatten();
+        let ltag = cache
+            .has_ltag
+            .then(|| table_ranges.ltag.resolve_table(font))
+            .flatten();
         Self {
             safe_to_break: Some(&cache.safe_to_break),
             morx,
@@ -231,6 +241,7 @@ impl<'a> AatTables<'a> {
             kerx,
             trak,
             feat,
+            ltag,
         }
     }
 
@@ -270,6 +281,7 @@ impl<'a> AatTables<'a> {
             .map(|table| (table, cache.kerx.as_slice()));
         let trak = cache.has_trak.then(|| font.trak().ok()).flatten();
         let feat = cache.has_feat.then(|| font.feat().ok()).flatten();
+        let ltag = cache.has_ltag.then(|| font.ltag().ok()).flatten();
         Self {
             safe_to_break: Some(&cache.safe_to_break),
             morx,
@@ -279,6 +291,7 @@ impl<'a> AatTables<'a> {
             kerx,
             trak,
             feat,
+            ltag,
         }
     }
 }

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -711,6 +711,7 @@ mod tests {
         assert!(aat_tables.kerx.is_none());
         assert!(aat_tables.trak.is_none());
         assert!(aat_tables.feat.is_none());
+        assert!(aat_tables.ltag.is_none());
         assert_eq!(provider.loads.get(), 3);
     }
 

--- a/harfrust/src/hb/ot_shape.rs
+++ b/harfrust/src/hb/ot_shape.rs
@@ -36,7 +36,7 @@ impl<'a> hb_ot_shape_planner_t<'a> {
         language: Option<&Language>,
     ) -> Self {
         let ot_map = hb_ot_map_builder_t::new(face, script, language);
-        let aat_map = AatMapBuilder::default();
+        let aat_map = AatMapBuilder::new(language);
 
         let mut shaper = match script {
             Some(script) => hb_ot_shape_complex_categorize(

--- a/harfrust/src/hb/tables.rs
+++ b/harfrust/src/hb/tables.rs
@@ -15,6 +15,7 @@ use read_fonts::{
         kern::Kern,
         kerx::Kerx,
         loca::Loca,
+        ltag::Ltag,
         mort::Mort,
         morx::Morx,
         mvar::Mvar,
@@ -68,6 +69,7 @@ pub struct TableRanges {
     pub gpos: TableRange,
     pub mort: TableRange,
     pub morx: TableRange,
+    pub ltag: TableRange,
     pub kerx: TableRange,
     pub ankr: TableRange,
     pub kern: TableRange,
@@ -143,6 +145,7 @@ impl TableRanges {
         let gpos = offset(Gpos::TAG);
         let mort = offset(Mort::TAG);
         let morx = offset(Morx::TAG);
+        let ltag = offset(Ltag::TAG);
         let kerx = offset(Kerx::TAG);
         let ankr = offset(Ankr::TAG);
         let kern = offset(Kern::TAG);
@@ -173,6 +176,7 @@ impl TableRanges {
             gpos,
             mort,
             morx,
+            ltag,
             kerx,
             ankr,
             kern,
@@ -230,6 +234,7 @@ impl TableRanges {
             gpos: TableRange::default(),
             mort: TableRange::default(),
             morx: TableRange::default(),
+            ltag: TableRange::default(),
             kerx: TableRange::default(),
             ankr: TableRange::default(),
             kern: TableRange::default(),

--- a/harfrust/src/hb/tag.rs
+++ b/harfrust/src/hb/tag.rs
@@ -311,6 +311,15 @@ mod tests {
     #![allow(non_snake_case)]
 
     use super::*;
+
+    #[test]
+    fn language_matches() {
+        assert!(lang_matches(b"pl", b"pl"));
+        assert!(lang_matches(b"pl-pl", b"pl"));
+        assert!(!lang_matches(b"pl", b"pl-pl"));
+        assert!(!lang_matches(b"plx", b"pl"));
+        assert!(!lang_matches(b"en", b"pl"));
+    }
     use alloc::vec::Vec;
 
     fn new_tag_to_script(tag: hb_tag_t) -> Option<Script> {


### PR DESCRIPTION
Implements AAT language-tag feature selection for both `mort` and `morx` chains using the font's `ltag` table. Language matching follows HarfBuzz prefix semantics, including normalized BCP 47 subtags.

Also refreshes the stale HarfBuzz conformance totals.

This is stacked on #451 because that PR introduces the shared `mort`/`morx` chain compilation path.

Validation:
- `cargo test` (6,041 shaping tests)
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo +1.85 build -p harfrust --target thumbv7em-none-eabihf --no-default-features --features=libm`
- matches HarfBuzz on Big Caslon
- matches HarfBuzz on synthesized language-gated `mort` and `morx` tables for `pl`, `pl-PL`, and `en`