### PR TITLE
Remove private codes from `Script::from_iso15924_tag`

### DIFF
--- a/harfrust/src/hb/common.rs
+++ b/harfrust/src/hb/common.rs
@@ -356,12 +356,6 @@ impl Script {
         }
 
         Some(match &tag.to_be_bytes() {
-            // These graduated from the 'Q' private-area codes, but
-            // the old code is still aliased by Unicode, and the Qaai
-            // one in use by ICU.
-            b"Qaai" => script::INHERITED,
-            b"Qaac" => script::COPTIC,
-
             // Script variants from https://unicode.org/iso15924/
             b"Aran" => script::ARABIC,
             b"Cyrs" => script::CYRILLIC,


### PR DESCRIPTION
These private codes should not be used in interchange, which is what that constructor is.