### PR TITLE
Add a unified Buffer type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This development version matches HarfBuzz [v14.3.1](https://github.com/harfbuzz/
   `BufferContentType` describing whether it holds input characters or shaped
   glyphs, and is shaped in place with `Buffer::shape`. `UnicodeBuffer` and
   `GlyphBuffer` are unchanged, and convert to and from `Buffer`.
+- `Buffer::shape` returns `Result<(), ShapeError>`, reporting a buffer that
+  already holds glyphs, a buffer with no direction, a font with nothing to
+  shape with, a plan built for other properties, and shaping that ran past its
+  length, operation or nesting limits.
 
 ## [0.13.3] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 This development version matches HarfBuzz [v14.3.1](https://github.com/harfbuzz/harfbuzz/releases/tag/14.3.1).
 
+- Add a unified `Buffer` type, matching HarfBuzz's `hb_buffer_t`. It carries a
+  `BufferContentType` describing whether it holds input characters or shaped
+  glyphs, and is shaped in place with `Buffer::shape`. `UnicodeBuffer` and
+  `GlyphBuffer` are unchanged, and convert to and from `Buffer`.
+
 ## [0.13.3] - 2026-08-25
 
 This release matches HarfBuzz [v14.3.1](https://github.com/harfbuzz/harfbuzz/releases/tag/14.3.1),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ This development version matches HarfBuzz [v14.3.1](https://github.com/harfbuzz/
   `GlyphBuffer` are unchanged, and convert to and from `Buffer`.
 - `Buffer::shape` returns `Result<(), ShapeError>`, reporting a buffer that
   already holds glyphs, a buffer with no direction, a font with nothing to
-  shape with, a plan built for other properties, and shaping that ran past its
-  length, operation or nesting limits.
+  shape with, and a plan built for other properties. Running out of room is
+  reported through `Buffer::allocation_successful`, as before.
 
 ## [0.13.3] - 2026-08-25
 

--- a/harfrust/src/hb/aat/layout.rs
+++ b/harfrust/src/hb/aat/layout.rs
@@ -4,8 +4,7 @@ use super::map;
 use super::{layout_kerx_table, layout_morx_table, layout_trak_table};
 use crate::hb::aat::layout_common::{AatApplyContext, HB_BUFFER_SCRATCH_FLAG_AAT_HAS_DELETED};
 use crate::hb::{
-    buffer::hb_buffer_t, face::Scale, hb_font_t, hb_tag_t, ot_shape_plan::hb_ot_shape_plan_t,
-    GlyphInfo,
+    buffer::Buffer, face::Scale, hb_font_t, hb_tag_t, ot_shape_plan::hb_ot_shape_plan_t, GlyphInfo,
 };
 use crate::Feature;
 
@@ -503,7 +502,7 @@ pub const DELETED_GLYPH: u32 = 0xFFFF;
 pub fn substitute(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     features: &[Feature],
 ) {
     let mut aat_map = map::AatMap::default();
@@ -534,7 +533,7 @@ fn is_deleted_glyph(info: &GlyphInfo) -> bool {
 ///
 /// See <https://github.com/harfbuzz/harfbuzz/blob/2c22a65f0cb99544c36580b9703a43b5dc97a9e1/src/hb-aat-layout.cc#L337>
 #[doc(alias = "hb_aat_layout_remove_deleted_glyphs")]
-pub fn remove_deleted_glyphs(buffer: &mut hb_buffer_t) {
+pub fn remove_deleted_glyphs(buffer: &mut Buffer) {
     if (buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_AAT_HAS_DELETED) != 0 {
         buffer.delete_glyphs_inplace(is_deleted_glyph);
     }
@@ -544,12 +543,7 @@ pub fn remove_deleted_glyphs(buffer: &mut hb_buffer_t) {
 ///
 /// See <https://github.com/harfbuzz/harfbuzz/blob/2c22a65f0cb99544c36580b9703a43b5dc97a9e1/src/hb-aat-layout.cc#L363>
 #[doc(alias = "hb_aat_layout_position")]
-pub fn position(
-    plan: &hb_ot_shape_plan_t,
-    face: &hb_font_t,
-    scale: Scale,
-    buffer: &mut hb_buffer_t,
-) {
+pub fn position(plan: &hb_ot_shape_plan_t, face: &hb_font_t, scale: Scale, buffer: &mut Buffer) {
     let mut c = AatApplyContext::new(plan, face, scale, buffer);
     layout_kerx_table::apply(&mut c);
 }
@@ -563,7 +557,7 @@ pub fn track(
     face: &hb_font_t,
     scale: Scale,
     point_size: Option<f32>,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     layout_trak_table::apply(plan, face, scale, point_size, buffer);
 }

--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -1,6 +1,6 @@
 use super::layout::DELETED_GLYPH;
 use super::map::RangeFlags;
-use crate::hb::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_SHAPER0};
+use crate::hb::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_SHAPER0};
 use crate::hb::face::hb_font_t;
 use crate::hb::face::Scale;
 use crate::hb::hb_mask_t;
@@ -41,7 +41,7 @@ pub struct AatApplyContext<'a> {
     pub plan: &'a hb_ot_shape_plan_t,
     pub face: &'a hb_font_t<'a>,
     pub scale: Scale,
-    pub buffer: &'a mut hb_buffer_t,
+    pub buffer: &'a mut Buffer,
     pub has_glyph_classes: bool,
     pub range_flags: Option<&'a [RangeFlags]>,
     pub subtable_flags: hb_mask_t,
@@ -60,7 +60,7 @@ impl<'a> AatApplyContext<'a> {
         plan: &'a hb_ot_shape_plan_t,
         face: &'a hb_font_t<'a>,
         scale: Scale,
-        buffer: &'a mut hb_buffer_t,
+        buffer: &'a mut Buffer,
     ) -> Self {
         Self {
             plan,

--- a/harfrust/src/hb/aat/layout_trak_table.rs
+++ b/harfrust/src/hb/aat/layout_trak_table.rs
@@ -7,14 +7,14 @@ use read_fonts::tables::trak::TrackTableEntry;
 use read_fonts::types::{BigEndian, Fixed};
 use read_fonts::FontData;
 
-use crate::hb::{buffer::hb_buffer_t, face::Scale, hb_font_t, ot_shape_plan::hb_ot_shape_plan_t};
+use crate::hb::{buffer::Buffer, face::Scale, hb_font_t, ot_shape_plan::hb_ot_shape_plan_t};
 
 pub fn apply(
     _plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
     scale: Scale,
     point_size: Option<f32>,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> Option<()> {
     let trak = face.aat_tables.trak.as_ref()?;
     let mut ptem = point_size.unwrap_or(0.0);

--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -1930,6 +1930,12 @@ impl Buffer {
     }
 
     /// Returns `true` if every allocation made on this buffer has succeeded.
+    ///
+    /// This goes false when filling the buffer runs out of memory, and when
+    /// shaping needs more room, more operations or more nesting than the
+    /// shaper allows. Pathological input can provoke the latter, so it is
+    /// reported here rather than as a [`ShapeError`], and the contents are
+    /// left partly shaped.
     #[inline]
     pub fn allocation_successful(&self) -> bool {
         self.successful
@@ -2237,6 +2243,10 @@ impl From<GlyphBuffer> for Buffer {
 }
 
 /// The reason a call to [`Buffer::shape`] could not produce glyphs.
+///
+/// Each of these is a misuse of the API. Running out of room is not among
+/// them: pathological input can provoke it, so it is reported through
+/// [`Buffer::allocation_successful`] rather than as a failure to shape.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 #[non_exhaustive]
 pub enum ShapeError {
@@ -2275,16 +2285,6 @@ pub enum ShapeError {
         /// The script the buffer carries.
         buffer: Script,
     },
-
-    /// Shaping gave up, having needed more room, more operations or more
-    /// nesting than the shaper allows.
-    ///
-    /// This guards against pathological input rather than reporting a mistake
-    /// by the caller, and it also covers a buffer that failed to allocate while
-    /// being filled. The contents are left partly shaped and should be
-    /// discarded; [`allocation_successful`](Buffer::allocation_successful)
-    /// reports the same condition.
-    LimitsExceeded,
 }
 
 impl core::fmt::Display for ShapeError {
@@ -2301,7 +2301,6 @@ impl core::fmt::Display for ShapeError {
                 fmt,
                 "buffer script does not match plan script: {buffer:?} != {plan:?}"
             ),
-            Self::LimitsExceeded => fmt.write_str("shaping exceeded its limits"),
         }
     }
 }

--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -469,66 +469,84 @@ pub const HB_BUFFER_CLUSTER_LEVEL_CHARACTERS: u32 = 2;
 pub const HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES: u32 = 3;
 pub const HB_BUFFER_CLUSTER_LEVEL_DEFAULT: u32 = HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES;
 
-pub struct hb_buffer_t {
+/// The type of contents currently held by a [`Buffer`].
+///
+/// This matches HarfBuzz's `hb_buffer_content_type_t`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum BufferContentType {
+    /// The buffer holds input characters, ready for shaping.
+    Unicode,
+    /// The buffer holds the glyphs produced by shaping.
+    Glyphs,
+}
+
+/// A buffer of text to be shaped, and of the glyphs that shaping produces.
+///
+/// This is the unified buffer type, matching HarfBuzz's `hb_buffer_t`. It
+/// carries a [`BufferContentType`] describing which of the two states it is
+/// currently in. See [`UnicodeBuffer`] and [`GlyphBuffer`] for the typed
+/// alternative, which encodes that state in the type system instead.
+pub struct Buffer {
     // Information about how the text in the buffer should be treated.
-    pub flags: BufferFlags,
-    pub cluster_level: hb_buffer_cluster_level_t,
-    pub invisible: Option<GlyphId>,
-    pub not_found_variation_selector: Option<u32>,
+    pub(crate) flags: BufferFlags,
+    pub(crate) cluster_level: hb_buffer_cluster_level_t,
+    pub(crate) invisible: Option<GlyphId>,
+    pub(crate) not_found_variation_selector: Option<u32>,
 
     // Buffer contents.
-    pub direction: Direction,
-    pub script: Option<Script>,
-    pub language: Option<Language>,
+    pub(crate) content_type: Option<BufferContentType>,
+    pub(crate) direction: Direction,
+    pub(crate) script: Option<Script>,
+    pub(crate) language: Option<Language>,
 
     /// Allocations successful.
-    pub successful: bool,
+    pub(crate) successful: bool,
     /// Whether we have an output buffer going on.
     pub(crate) have_output: bool,
-    pub have_separate_output: bool,
+    pub(crate) have_separate_output: bool,
     /// Whether we have positions
-    pub have_positions: bool,
+    pub(crate) have_positions: bool,
 
-    pub idx: usize,
-    pub len: usize,
-    pub out_len: usize,
+    pub(crate) idx: usize,
+    pub(crate) len: usize,
+    pub(crate) out_len: usize,
 
-    pub info: Vec<GlyphInfo>,
-    pub pos: Vec<GlyphPosition>,
+    pub(crate) info: Vec<GlyphInfo>,
+    pub(crate) pos: Vec<GlyphPosition>,
 
     // Text before / after the main buffer contents.
     // Always in Unicode, and ordered outward.
     // Index 0 is for "pre-context", 1 for "post-context".
-    pub context: [[Codepoint; CONTEXT_LENGTH]; 2],
-    pub context_len: [usize; 2],
+    pub(crate) context: [[Codepoint; CONTEXT_LENGTH]; 2],
+    pub(crate) context_len: [usize; 2],
 
     pub(crate) digest: hb_set_digest_t,
     pub(crate) glyph_set: U32Set,
 
     // Managed by enter / leave
-    pub allocated_var_bits: u8,
-    pub serial: u8,
-    pub scratch_flags: hb_buffer_scratch_flags_t,
+    pub(crate) allocated_var_bits: u8,
+    pub(crate) serial: u8,
+    pub(crate) scratch_flags: hb_buffer_scratch_flags_t,
     /// Maximum allowed len.
-    pub max_len: usize,
+    pub(crate) max_len: usize,
     /// Maximum allowed operations.
-    pub max_ops: i32,
+    pub(crate) max_ops: i32,
 }
 
-impl hb_buffer_t {
-    pub const MAX_LEN_FACTOR: usize = 256;
-    pub const MAX_LEN_MIN: usize = 65536;
+impl Buffer {
+    pub(crate) const MAX_LEN_FACTOR: usize = 256;
+    pub(crate) const MAX_LEN_MIN: usize = 65536;
     // Shaping more than a billion chars? Let us know!
-    pub const MAX_LEN_DEFAULT: usize = 0x3FFF_FFFF;
+    pub(crate) const MAX_LEN_DEFAULT: usize = 0x3FFF_FFFF;
 
-    pub const MAX_OPS_FACTOR: i32 = 4096;
-    pub const MAX_OPS_MIN: i32 = 65536;
+    pub(crate) const MAX_OPS_FACTOR: i32 = 4096;
+    pub(crate) const MAX_OPS_MIN: i32 = 65536;
     // Shaping more than a billion operations? Let us know!
-    pub const MAX_OPS_DEFAULT: i32 = 0x1FFF_FFFF;
+    pub(crate) const MAX_OPS_DEFAULT: i32 = 0x1FFF_FFFF;
 
     /// Creates a new `Buffer`.
     pub fn new() -> Self {
-        hb_buffer_t {
+        Buffer {
             flags: BufferFlags::empty(),
             cluster_level: HB_BUFFER_CLUSTER_LEVEL_DEFAULT,
             invisible: None,
@@ -536,6 +554,7 @@ impl hb_buffer_t {
             not_found_variation_selector: None,
             max_len: Self::MAX_LEN_DEFAULT,
             max_ops: Self::MAX_OPS_DEFAULT,
+            content_type: None,
             direction: Direction::Invalid,
             script: None,
             language: None,
@@ -558,7 +577,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn allocate_var(&mut self, shape: buffer_var_shape) {
+    pub(crate) fn allocate_var(&mut self, shape: buffer_var_shape) {
         let bits = shape.bits();
         debug_assert_eq!(
             self.allocated_var_bits & bits,
@@ -569,7 +588,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn try_allocate_var(&mut self, shape: buffer_var_shape) -> bool {
+    pub(crate) fn try_allocate_var(&mut self, shape: buffer_var_shape) -> bool {
         let bits = shape.bits();
         if self.allocated_var_bits & bits != 0 {
             return false;
@@ -579,7 +598,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn deallocate_var(&mut self, shape: buffer_var_shape) {
+    pub(crate) fn deallocate_var(&mut self, shape: buffer_var_shape) {
         let bits = shape.bits();
         debug_assert_eq!(
             self.allocated_var_bits & bits,
@@ -590,7 +609,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn assert_var(&self, shape: buffer_var_shape) {
+    pub(crate) fn assert_var(&self, shape: buffer_var_shape) {
         let bits = shape.bits();
         debug_assert_eq!(
             self.allocated_var_bits & bits,
@@ -600,12 +619,12 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn info_slice_mut(&mut self) -> &mut [GlyphInfo] {
+    pub(crate) fn info_slice_mut(&mut self) -> &mut [GlyphInfo] {
         &mut self.info[..self.len]
     }
 
     #[inline]
-    pub fn out_info(&self) -> &[GlyphInfo] {
+    pub(crate) fn out_info(&self) -> &[GlyphInfo] {
         if self.have_separate_output {
             bytemuck::cast_slice(self.pos.as_slice())
         } else {
@@ -614,7 +633,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn out_info_mut(&mut self) -> &mut [GlyphInfo] {
+    pub(crate) fn out_info_mut(&mut self) -> &mut [GlyphInfo] {
         if self.have_separate_output {
             bytemuck::cast_slice_mut(self.pos.as_mut_slice())
         } else {
@@ -692,45 +711,49 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn cur(&self, i: usize) -> &GlyphInfo {
+    pub(crate) fn cur(&self, i: usize) -> &GlyphInfo {
         &self.info[self.idx + i]
     }
 
     #[inline]
-    pub fn cur_mut(&mut self, i: usize) -> &mut GlyphInfo {
+    pub(crate) fn cur_mut(&mut self, i: usize) -> &mut GlyphInfo {
         let idx = self.idx + i;
         &mut self.info[idx]
     }
 
     #[inline]
-    pub fn cur_pos_mut(&mut self) -> &mut GlyphPosition {
+    pub(crate) fn cur_pos_mut(&mut self) -> &mut GlyphPosition {
         let i = self.idx;
         &mut self.pos[i]
     }
 
     #[inline]
-    pub fn prev(&self) -> &GlyphInfo {
+    pub(crate) fn prev(&self) -> &GlyphInfo {
         let idx = self.out_len.saturating_sub(1);
         &self.out_info()[idx]
     }
 
     #[inline]
-    pub fn prev_mut(&mut self) -> &mut GlyphInfo {
+    pub(crate) fn prev_mut(&mut self) -> &mut GlyphInfo {
         let idx = self.out_len.saturating_sub(1);
         &mut self.out_info_mut()[idx]
     }
 
-    pub fn update_digest(&mut self) {
+    pub(crate) fn update_digest(&mut self) {
         self.digest = hb_set_digest_t::new();
         self.digest.add_array(self.info.iter().map(|i| i.glyph_id));
     }
-    pub fn update_glyph_set(&mut self) {
+    pub(crate) fn update_glyph_set(&mut self) {
         self.glyph_set.clear();
         self.glyph_set
             .extend_unsorted(self.info.iter().map(|i| i.glyph_id));
     }
 
-    fn clear(&mut self) {
+    /// Clears the contents of the buffer, retaining its allocation.
+    ///
+    /// This matches HarfBuzz's `hb_buffer_clear_contents`.
+    pub fn clear(&mut self) {
+        self.content_type = None;
         self.direction = Direction::Invalid;
         self.script = None;
         self.language = None;
@@ -756,7 +779,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn backtrack_len(&self) -> usize {
+    pub(crate) fn backtrack_len(&self) -> usize {
         if self.have_output {
             self.out_len
         } else {
@@ -765,7 +788,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn lookahead_len(&self) -> usize {
+    pub(crate) fn lookahead_len(&self) -> usize {
         self.len - self.idx
     }
 
@@ -781,7 +804,11 @@ impl hb_buffer_t {
         self.serial
     }
 
-    fn add(&mut self, codepoint: u32, cluster: u32) {
+    /// Appends a codepoint to the buffer with the given cluster value.
+    ///
+    /// This matches HarfBuzz's `hb_buffer_add`.
+    pub fn push(&mut self, codepoint: u32, cluster: u32) {
+        self.content_type = Some(BufferContentType::Unicode);
         if !self.ensure(self.len + 1) {
             return;
         }
@@ -793,6 +820,7 @@ impl hb_buffer_t {
         self.len += 1;
     }
 
+    /// Reverses the buffer contents.
     #[inline]
     pub fn reverse(&mut self) {
         if self.is_empty() {
@@ -802,6 +830,7 @@ impl hb_buffer_t {
         self.reverse_range(0, self.len);
     }
 
+    /// Reverses the buffer contents between `start` and `end`.
     pub fn reverse_range(&mut self, start: usize, end: usize) {
         if end - start < 2 {
             return;
@@ -813,7 +842,7 @@ impl hb_buffer_t {
         }
     }
 
-    pub fn reverse_groups<F>(&mut self, group: F, merge_clusters: bool)
+    pub(crate) fn reverse_groups<F>(&mut self, group: F, merge_clusters: bool)
     where
         F: Fn(&GlyphInfo, &GlyphInfo) -> bool,
     {
@@ -846,7 +875,7 @@ impl hb_buffer_t {
         self.reverse();
     }
 
-    pub fn group_end<F>(&self, mut start: usize, group: F) -> usize
+    pub(crate) fn group_end<F>(&self, mut start: usize, group: F) -> usize
     where
         F: Fn(&GlyphInfo, &GlyphInfo) -> bool,
     {
@@ -859,13 +888,17 @@ impl hb_buffer_t {
         start
     }
 
+    /// Resets the cluster value of each item to its index.
     #[inline]
-    fn reset_clusters(&mut self) {
+    pub fn reset_clusters(&mut self) {
         for (i, info) in self.info.iter_mut().enumerate() {
             info.cluster = i as u32;
         }
     }
 
+    /// Guesses the direction, script and language of the buffer contents.
+    ///
+    /// Only properties that are still unset are filled in.
     pub fn guess_segment_properties(&mut self) {
         if self.script.is_none() {
             for info in &self.info {
@@ -892,7 +925,7 @@ impl hb_buffer_t {
         // TODO: language must be set
     }
 
-    pub fn sync(&mut self) -> bool {
+    pub(crate) fn sync(&mut self) -> bool {
         debug_assert!(self.have_output);
         debug_assert!(self.idx <= self.len);
 
@@ -922,7 +955,7 @@ impl hb_buffer_t {
         true
     }
 
-    pub fn clear_output(&mut self) {
+    pub(crate) fn clear_output(&mut self) {
         self.have_output = true;
         self.have_positions = false;
 
@@ -931,7 +964,7 @@ impl hb_buffer_t {
         self.have_separate_output = false;
     }
 
-    pub fn clear_positions(&mut self) {
+    pub(crate) fn clear_positions(&mut self) {
         self.have_output = false;
         self.have_positions = true;
 
@@ -943,7 +976,7 @@ impl hb_buffer_t {
         }
     }
 
-    pub fn replace_glyphs(&mut self, num_in: usize, num_out: usize, glyph_data: &[u32]) {
+    pub(crate) fn replace_glyphs(&mut self, num_in: usize, num_out: usize, glyph_data: &[u32]) {
         if !self.make_room_for(num_in, num_out) {
             return;
         }
@@ -964,7 +997,7 @@ impl hb_buffer_t {
         self.out_len += num_out;
     }
 
-    pub fn replace_glyph(&mut self, glyph_index: u32) {
+    pub(crate) fn replace_glyph(&mut self, glyph_index: u32) {
         if self.have_separate_output || self.out_len != self.idx {
             if !self.make_room_for(1, 1) {
                 return;
@@ -980,7 +1013,7 @@ impl hb_buffer_t {
         self.out_len += 1;
     }
 
-    pub fn output_glyph(&mut self, glyph_index: u32) {
+    pub(crate) fn output_glyph(&mut self, glyph_index: u32) {
         if !self.make_room_for(0, 1) {
             return;
         }
@@ -1002,7 +1035,7 @@ impl hb_buffer_t {
         self.out_len += 1;
     }
 
-    pub fn output_info(&mut self, glyph_info: GlyphInfo) {
+    pub(crate) fn output_info(&mut self, glyph_info: GlyphInfo) {
         if !self.make_room_for(0, 1) {
             return;
         }
@@ -1012,7 +1045,7 @@ impl hb_buffer_t {
     }
 
     /// Copies glyph at idx to output but doesn't advance idx.
-    pub fn copy_glyph(&mut self) {
+    pub(crate) fn copy_glyph(&mut self) {
         if !self.make_room_for(0, 1) {
             return;
         }
@@ -1025,7 +1058,7 @@ impl hb_buffer_t {
     ///
     /// If there's no output, just advance idx.
     #[inline(always)]
-    pub fn next_glyph(&mut self) {
+    pub(crate) fn next_glyph(&mut self) {
         if self.have_output {
             if self.have_separate_output || self.out_len != self.idx {
                 if !self.ensure(self.out_len + 1) {
@@ -1045,7 +1078,7 @@ impl hb_buffer_t {
     /// Copies n glyphs at idx to output and advance idx.
     ///
     /// If there's no output, just advance idx.
-    pub fn next_glyphs(&mut self, n: usize) {
+    pub(crate) fn next_glyphs(&mut self, n: usize) {
         if self.have_output {
             if self.have_separate_output || self.out_len != self.idx {
                 if !self.ensure(self.out_len + n) {
@@ -1062,17 +1095,17 @@ impl hb_buffer_t {
     }
 
     /// Advance idx without copying to output.
-    pub fn skip_glyph(&mut self) {
+    pub(crate) fn skip_glyph(&mut self) {
         self.idx += 1;
     }
 
-    pub fn reset_masks(&mut self, mask: hb_mask_t) {
+    pub(crate) fn reset_masks(&mut self, mask: hb_mask_t) {
         for info in &mut self.info[..self.len] {
             info.mask = mask;
         }
     }
 
-    pub fn set_masks(
+    pub(crate) fn set_masks(
         &mut self,
         mut value: hb_mask_t,
         mask: hb_mask_t,
@@ -1107,7 +1140,7 @@ impl hb_buffer_t {
     }
 
     #[inline(always)]
-    pub fn merge_clusters(&mut self, start: usize, end: usize) {
+    pub(crate) fn merge_clusters(&mut self, start: usize, end: usize) {
         if end - start < 2 {
             return;
         }
@@ -1160,7 +1193,7 @@ impl hb_buffer_t {
         }
     }
 
-    pub fn merge_grapheme_clusters(&mut self, start: usize, end: usize) {
+    pub(crate) fn merge_grapheme_clusters(&mut self, start: usize, end: usize) {
         if end - start < 2 {
             return;
         }
@@ -1173,7 +1206,7 @@ impl hb_buffer_t {
         self.merge_clusters_impl(start, end);
     }
 
-    pub fn merge_out_clusters(&mut self, start: usize, end: usize) {
+    pub(crate) fn merge_out_clusters(&mut self, start: usize, end: usize) {
         if end - start < 2 {
             return;
         }
@@ -1185,7 +1218,7 @@ impl hb_buffer_t {
         self.merge_out_clusters_impl(start, end);
     }
 
-    pub fn merge_out_grapheme_clusters(&mut self, start: usize, end: usize) {
+    pub(crate) fn merge_out_grapheme_clusters(&mut self, start: usize, end: usize) {
         if end - start < 2 {
             return;
         }
@@ -1235,7 +1268,7 @@ impl hb_buffer_t {
     }
 
     /// Merge clusters for deleting current glyph, and skip it.
-    pub fn delete_glyph(&mut self) {
+    pub(crate) fn delete_glyph(&mut self) {
         let cluster = self.info[self.idx].cluster;
 
         if (self.idx + 1 < self.len && cluster == self.info[self.idx + 1].cluster)
@@ -1271,7 +1304,7 @@ impl hb_buffer_t {
         self.skip_glyph();
     }
 
-    pub fn delete_glyphs_inplace(&mut self, filter: impl Fn(&GlyphInfo) -> bool) {
+    pub(crate) fn delete_glyphs_inplace(&mut self, filter: impl Fn(&GlyphInfo) -> bool) {
         // Merge clusters and delete filtered glyphs.
         // NOTE! We can't use out-buffer as we have positioning data.
         let mut j = 0;
@@ -1321,7 +1354,7 @@ impl hb_buffer_t {
         self.len = j;
     }
 
-    pub fn unsafe_to_break(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn unsafe_to_break(&mut self, start: Option<usize>, end: Option<usize>) {
         self.set_glyph_flags(
             GlyphFlags::UNSAFE_TO_BREAK | GlyphFlags::UNSAFE_TO_CONCAT,
             start,
@@ -1331,7 +1364,7 @@ impl hb_buffer_t {
         );
     }
 
-    pub fn safe_to_insert_tatweel(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn safe_to_insert_tatweel(&mut self, start: Option<usize>, end: Option<usize>) {
         if !self
             .flags
             .contains(BufferFlags::PRODUCE_SAFE_TO_INSERT_TATWEEL)
@@ -1426,7 +1459,7 @@ impl hb_buffer_t {
         self._set_glyph_flags_impl(flags.0, start, end, interior, from_out_buffer);
     }
 
-    pub fn unsafe_to_concat(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn unsafe_to_concat(&mut self, start: Option<usize>, end: Option<usize>) {
         if !self.flags.contains(BufferFlags::PRODUCE_UNSAFE_TO_CONCAT) {
             return;
         }
@@ -1434,7 +1467,11 @@ impl hb_buffer_t {
         self.set_glyph_flags(GlyphFlags::UNSAFE_TO_CONCAT, start, end, Some(false), None);
     }
 
-    pub fn unsafe_to_break_from_outbuffer(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn unsafe_to_break_from_outbuffer(
+        &mut self,
+        start: Option<usize>,
+        end: Option<usize>,
+    ) {
         self.set_glyph_flags(
             GlyphFlags::UNSAFE_TO_BREAK | GlyphFlags::UNSAFE_TO_CONCAT,
             start,
@@ -1444,7 +1481,11 @@ impl hb_buffer_t {
         );
     }
 
-    pub fn unsafe_to_concat_from_outbuffer(&mut self, start: Option<usize>, end: Option<usize>) {
+    pub(crate) fn unsafe_to_concat_from_outbuffer(
+        &mut self,
+        start: Option<usize>,
+        end: Option<usize>,
+    ) {
         if !self.flags.contains(BufferFlags::PRODUCE_UNSAFE_TO_CONCAT) {
             return;
         }
@@ -1458,7 +1499,7 @@ impl hb_buffer_t {
         );
     }
 
-    pub fn move_to(&mut self, i: usize) -> bool {
+    pub(crate) fn move_to(&mut self, i: usize) -> bool {
         if !self.have_output {
             debug_assert!(i <= self.len);
             self.idx = i;
@@ -1521,7 +1562,7 @@ impl hb_buffer_t {
 
     #[must_use]
     #[inline(always)]
-    pub fn ensure(&mut self, size: usize) -> bool {
+    pub(crate) fn ensure(&mut self, size: usize) -> bool {
         if size <= self.info.len() {
             true
         } else {
@@ -1596,7 +1637,12 @@ impl hb_buffer_t {
         self.context_len[side] = 0;
     }
 
-    pub fn sort(&mut self, start: usize, end: usize, cmp: impl Fn(&GlyphInfo, &GlyphInfo) -> bool) {
+    pub(crate) fn sort(
+        &mut self,
+        start: usize,
+        end: usize,
+        cmp: impl Fn(&GlyphInfo, &GlyphInfo) -> bool,
+    ) {
         debug_assert!(!self.have_positions);
 
         for i in start + 1..end {
@@ -1623,7 +1669,7 @@ impl hb_buffer_t {
         }
     }
 
-    pub fn set_cluster(info: &mut GlyphInfo, cluster: u32, mask: hb_mask_t) {
+    pub(crate) fn set_cluster(info: &mut GlyphInfo, cluster: u32, mask: hb_mask_t) {
         if info.cluster != cluster {
             info.mask = (info.mask & !GlyphFlags::DEFINED_BITS) | (mask & GlyphFlags::DEFINED_BITS);
         }
@@ -1636,21 +1682,21 @@ impl hb_buffer_t {
         self.serial = 0;
         self.scratch_flags = HB_BUFFER_SCRATCH_FLAG_DEFAULT;
 
-        if let Some(len) = self.len.checked_mul(hb_buffer_t::MAX_LEN_FACTOR) {
-            self.max_len = len.max(hb_buffer_t::MAX_LEN_MIN);
+        if let Some(len) = self.len.checked_mul(Buffer::MAX_LEN_FACTOR) {
+            self.max_len = len.max(Buffer::MAX_LEN_MIN);
         }
 
         if let Ok(len) = i32::try_from(self.len) {
-            if let Some(ops) = len.checked_mul(hb_buffer_t::MAX_OPS_FACTOR) {
-                self.max_ops = ops.max(hb_buffer_t::MAX_OPS_MIN);
+            if let Some(ops) = len.checked_mul(Buffer::MAX_OPS_FACTOR) {
+                self.max_ops = ops.max(Buffer::MAX_OPS_MIN);
             }
         }
     }
 
     // Called around shape()
     pub(crate) fn leave(&mut self) {
-        self.max_len = hb_buffer_t::MAX_LEN_DEFAULT;
-        self.max_ops = hb_buffer_t::MAX_OPS_DEFAULT;
+        self.max_len = Buffer::MAX_LEN_DEFAULT;
+        self.max_ops = Buffer::MAX_OPS_DEFAULT;
         self.serial = 0;
     }
 
@@ -1735,14 +1781,19 @@ impl hb_buffer_t {
     }
 
     /// Checks that buffer contains no elements.
+    /// Returns `true` if the buffer contains no items.
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
 
-    fn push_str(&mut self, text: &str) {
+    /// Appends a string to the buffer.
+    ///
+    /// Cluster values are set to the UTF-8 byte offset of each character.
+    pub fn push_str(&mut self, text: &str) {
         if !self.ensure(self.len + text.chars().count()) {
             return;
         }
+        self.content_type = Some(BufferContentType::Unicode);
 
         for (i, c) in text.char_indices() {
             self.info[self.len] = GlyphInfo {
@@ -1754,7 +1805,8 @@ impl hb_buffer_t {
         }
     }
 
-    fn set_pre_context(&mut self, text: &str) {
+    /// Sets the pre-context for this buffer.
+    pub fn set_pre_context(&mut self, text: &str) {
         self.clear_context(0);
         for (i, c) in text.chars().rev().enumerate().take(CONTEXT_LENGTH) {
             self.context[0][i] = c as Codepoint;
@@ -1762,7 +1814,12 @@ impl hb_buffer_t {
         }
     }
 
-    fn set_pre_context_codepoints(&mut self, codepoints: &[u32]) {
+    /// Sets the pre-context for this buffer from codepoints.
+    ///
+    /// The input is expected to be the Unicode codepoints in reverse order.
+    /// This matches HarfBuzz's internal storage of pre-context, and serves
+    /// as a low-overhead method to pass pre-context from HarfBuzz-HarfRust.
+    pub fn set_pre_context_codepoints(&mut self, codepoints: &[u32]) {
         self.clear_context(0);
         for (i, &c) in codepoints.iter().take(CONTEXT_LENGTH).enumerate() {
             self.context[0][i] = c;
@@ -1770,7 +1827,8 @@ impl hb_buffer_t {
         }
     }
 
-    fn set_post_context(&mut self, text: &str) {
+    /// Sets the post-context for this buffer.
+    pub fn set_post_context(&mut self, text: &str) {
         self.clear_context(1);
         for (i, c) in text.chars().enumerate().take(CONTEXT_LENGTH) {
             self.context[1][i] = c as Codepoint;
@@ -1778,7 +1836,8 @@ impl hb_buffer_t {
         }
     }
 
-    fn set_post_context_codepoints(&mut self, codepoints: &[u32]) {
+    /// Sets the post-context for this buffer from codepoints.
+    pub fn set_post_context_codepoints(&mut self, codepoints: &[u32]) {
         self.clear_context(1);
         for (i, &c) in codepoints.iter().take(CONTEXT_LENGTH).enumerate() {
             self.context[1][i] = c;
@@ -1786,7 +1845,7 @@ impl hb_buffer_t {
         }
     }
 
-    pub fn next_syllable(&self, mut start: usize) -> usize {
+    pub(crate) fn next_syllable(&self, mut start: usize) -> usize {
         if start >= self.len {
             return start;
         }
@@ -1802,7 +1861,7 @@ impl hb_buffer_t {
     }
 
     #[inline]
-    pub fn allocate_lig_id(&mut self) -> u8 {
+    pub(crate) fn allocate_lig_id(&mut self) -> u8 {
         let mut lig_id = self.next_serial() & 0x07;
 
         if lig_id == 0 {
@@ -1810,6 +1869,427 @@ impl hb_buffer_t {
         }
 
         lig_id
+    }
+}
+
+/// Public API, mirroring HarfBuzz's `hb-buffer.h`.
+impl Buffer {
+    /// Returns the type of content currently held by the buffer, or `None`
+    /// if the buffer is empty or has been cleared.
+    #[inline]
+    pub fn content_type(&self) -> Option<BufferContentType> {
+        self.content_type
+    }
+
+    /// Sets the type of content held by the buffer.
+    ///
+    /// This only relabels the buffer; it never clears it. Shaping sets this to
+    /// [`BufferContentType::Glyphs`] on its own, so most callers never need it.
+    ///
+    /// Setting it explicitly reinterprets the items already in the buffer, which
+    /// is occasionally what you want: label a buffer of glyph ids as
+    /// [`BufferContentType::Glyphs`] to serialize a run that was shaped
+    /// elsewhere, or label a shaped buffer as [`BufferContentType::Unicode`] to
+    /// force [`shape`](Self::shape) to run over it again.
+    #[inline]
+    pub fn set_content_type(&mut self, content_type: Option<BufferContentType>) {
+        self.content_type = content_type;
+    }
+
+    /// Returns the number of items in the buffer.
+    ///
+    /// Before shaping this is the number of Unicode codepoints; after
+    /// shaping it is the number of glyphs.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Sets the number of items in the buffer.
+    ///
+    /// Growing the buffer fills the new items with zeros. Returns `false` if
+    /// the allocation failed, in which case the buffer is left unchanged.
+    pub fn set_length(&mut self, len: usize) -> bool {
+        if !self.ensure(len) {
+            return false;
+        }
+        if len > self.len {
+            self.info[self.len..len].fill(GlyphInfo::default());
+            if self.have_positions {
+                self.pos[self.len..len].fill(GlyphPosition::default());
+            }
+        }
+        self.len = len;
+        true
+    }
+
+    /// Ensures that the buffer can hold at least `size` items.
+    #[inline]
+    pub fn reserve(&mut self, size: usize) -> bool {
+        self.ensure(size)
+    }
+
+    /// Returns `true` if every allocation made on this buffer has succeeded.
+    #[inline]
+    pub fn allocation_successful(&self) -> bool {
+        self.successful
+    }
+
+    /// Returns the buffer contents.
+    ///
+    /// Before shaping, [`GlyphInfo::glyph_id`] holds the input Unicode
+    /// codepoint rather than a glyph id.
+    #[inline]
+    pub fn glyph_infos(&self) -> &[GlyphInfo] {
+        &self.info[..self.len]
+    }
+
+    /// Returns the buffer contents mutably.
+    #[inline]
+    pub fn glyph_infos_mut(&mut self) -> &mut [GlyphInfo] {
+        let len = self.len;
+        &mut self.info[..len]
+    }
+
+    /// Returns the glyph positions.
+    ///
+    /// Returns an empty slice if the buffer has not been shaped and has no
+    /// positions allocated. Use
+    /// [`glyph_positions_mut`](Self::glyph_positions_mut) to allocate them on
+    /// demand.
+    #[inline]
+    pub fn glyph_positions(&self) -> &[GlyphPosition] {
+        if !self.have_positions {
+            return &[];
+        }
+        &self.pos[..self.len]
+    }
+
+    /// Returns the glyph positions mutably, allocating and zeroing them if
+    /// the buffer does not have positions yet.
+    #[inline]
+    pub fn glyph_positions_mut(&mut self) -> &mut [GlyphPosition] {
+        if !self.have_positions {
+            self.clear_positions();
+        }
+        let len = self.len;
+        &mut self.pos[..len]
+    }
+
+    /// Appends glyph infos to the buffer.
+    pub fn push_glyph_infos(&mut self, infos: &[GlyphInfo]) -> bool {
+        let len = infos.len();
+        if !self.ensure(self.len + len) {
+            return false;
+        }
+        self.info[self.len..self.len + len].copy_from_slice(infos);
+        self.len += len;
+        true
+    }
+
+    /// Appends codepoints to the buffer, using each item's index as its
+    /// cluster value.
+    pub fn push_codepoints(&mut self, codepoints: &[u32]) {
+        if !self.ensure(self.len + codepoints.len()) {
+            return;
+        }
+        self.content_type = Some(BufferContentType::Unicode);
+        for (i, &c) in codepoints.iter().enumerate() {
+            self.info[self.len] = GlyphInfo {
+                glyph_id: c,
+                cluster: i as u32,
+                ..GlyphInfo::default()
+            };
+            self.len += 1;
+        }
+    }
+
+    /// Returns the buffer's text direction.
+    #[inline]
+    pub fn direction(&self) -> Direction {
+        self.direction
+    }
+
+    /// Sets the buffer's text direction.
+    #[inline]
+    pub fn set_direction(&mut self, direction: Direction) {
+        self.direction = direction;
+    }
+
+    /// Returns the buffer's ISO 15924 script.
+    #[inline]
+    pub fn script(&self) -> Script {
+        self.script.unwrap_or(script::UNKNOWN)
+    }
+
+    /// Sets the buffer's script from an ISO 15924 tag.
+    #[inline]
+    pub fn set_script(&mut self, script: Script) {
+        self.script = Some(script);
+    }
+
+    /// Returns the buffer's language.
+    #[inline]
+    pub fn language(&self) -> Option<Language> {
+        self.language.clone()
+    }
+
+    /// Sets the buffer's language.
+    #[inline]
+    pub fn set_language(&mut self, language: Language) {
+        self.language = Some(language);
+    }
+
+    /// Returns the buffer's flags.
+    #[inline]
+    pub fn flags(&self) -> BufferFlags {
+        self.flags
+    }
+
+    /// Sets the buffer's flags.
+    #[inline]
+    pub fn set_flags(&mut self, flags: BufferFlags) {
+        self.flags = flags;
+    }
+
+    /// Returns the buffer's cluster level.
+    #[inline]
+    pub fn cluster_level(&self) -> BufferClusterLevel {
+        BufferClusterLevel::new(self.cluster_level)
+    }
+
+    /// Sets the buffer's cluster level.
+    #[inline]
+    pub fn set_cluster_level(&mut self, cluster_level: BufferClusterLevel) {
+        self.cluster_level = match cluster_level {
+            BufferClusterLevel::MonotoneGraphemes => HB_BUFFER_CLUSTER_LEVEL_MONOTONE_GRAPHEMES,
+            BufferClusterLevel::MonotoneCharacters => HB_BUFFER_CLUSTER_LEVEL_MONOTONE_CHARACTERS,
+            BufferClusterLevel::Characters => HB_BUFFER_CLUSTER_LEVEL_CHARACTERS,
+            BufferClusterLevel::Graphemes => HB_BUFFER_CLUSTER_LEVEL_GRAPHEMES,
+        };
+    }
+
+    /// Returns the glyph used to replace invisible characters, if set.
+    #[inline]
+    pub fn invisible_glyph(&self) -> Option<GlyphId> {
+        self.invisible
+    }
+
+    /// Sets the glyph used to replace invisible characters.
+    #[inline]
+    pub fn set_invisible_glyph(&mut self, glyph: Option<GlyphId>) {
+        self.invisible = glyph;
+    }
+
+    /// Returns the glyph used to replace not-found variation selectors, if set.
+    #[inline]
+    pub fn not_found_variation_selector_glyph(&self) -> Option<u32> {
+        self.not_found_variation_selector
+    }
+
+    /// Sets the glyph used to replace not-found variation-selector characters.
+    #[inline]
+    pub fn set_not_found_variation_selector_glyph(&mut self, glyph: Option<u32>) {
+        self.not_found_variation_selector = glyph;
+    }
+
+    /// Reverses the buffer contents, keeping the items within each cluster in
+    /// their original order.
+    #[inline]
+    pub fn reverse_clusters(&mut self) {
+        self.reverse_groups(|a, b| a.cluster == b.cluster, false);
+    }
+
+    /// Resets the buffer to its default state, clearing its contents along
+    /// with the flags and cluster level.
+    pub fn reset(&mut self) {
+        self.clear();
+        self.flags = BufferFlags::empty();
+        self.cluster_level = HB_BUFFER_CLUSTER_LEVEL_DEFAULT;
+        self.invisible = None;
+        self.not_found_variation_selector = None;
+    }
+    /// Serializes the buffer contents into a string.
+    pub fn serialize(&self, font: &impl SerializerFont, flags: SerializeFlags) -> String {
+        self.serialize_impl(font, flags).unwrap_or_default()
+    }
+
+    pub(crate) fn serialize_impl(
+        &self,
+        font: &impl SerializerFont,
+        flags: SerializeFlags,
+    ) -> Result<String, core::fmt::Error> {
+        use core::fmt::Write;
+
+        let mut s = String::with_capacity(64);
+
+        let info = self.glyph_infos();
+        let pos = self.glyph_positions();
+        let mut x: i32 = 0;
+        let mut y: i32 = 0;
+        let names = font.glyph_names();
+        let glyph_metrics = if flags.contains(SerializeFlags::GLYPH_EXTENTS) {
+            Some(font.glyph_metrics())
+        } else {
+            None
+        };
+        for (info, pos) in info.iter().zip(pos) {
+            s.push(if s.is_empty() { '[' } else { '|' });
+
+            if !flags.contains(SerializeFlags::NO_GLYPH_NAMES) {
+                match names.get(info.as_glyph().to_u32()) {
+                    Some(name) => s.push_str(name),
+                    None => write!(&mut s, "gid{}", info.glyph_id)?,
+                }
+            } else {
+                write!(&mut s, "{}", info.glyph_id)?;
+            }
+
+            if !flags.contains(SerializeFlags::NO_CLUSTERS) {
+                write!(&mut s, "={}", info.cluster)?;
+            }
+
+            if !flags.contains(SerializeFlags::NO_POSITIONS) {
+                let dx = x.saturating_add(pos.x_offset);
+                let dy = y.saturating_add(pos.y_offset);
+                if dx != 0 || dy != 0 {
+                    write!(&mut s, "@{dx},{dy}")?;
+                }
+
+                if !flags.contains(SerializeFlags::NO_ADVANCES) {
+                    write!(&mut s, "+{}", pos.x_advance)?;
+                    if pos.y_advance != 0 {
+                        write!(&mut s, ",{}", pos.y_advance)?;
+                    }
+                }
+            }
+
+            if flags.contains(SerializeFlags::GLYPH_FLAGS) {
+                if info.mask & GlyphFlags::DEFINED_BITS != 0 {
+                    write!(&mut s, "#{:X}", info.mask & GlyphFlags::DEFINED_BITS)?;
+                }
+            }
+
+            if flags.contains(SerializeFlags::GLYPH_EXTENTS) {
+                let extents = glyph_metrics
+                    .as_ref()
+                    .unwrap()
+                    .extents(info.as_glyph(), font.coords())
+                    .unwrap_or_default();
+                write!(
+                    &mut s,
+                    "<{},{},{},{}>",
+                    extents.x_bearing, extents.y_bearing, extents.width, extents.height
+                )?;
+            }
+
+            if flags.contains(SerializeFlags::NO_ADVANCES) {
+                x = x.saturating_add(pos.x_advance);
+                y = y.saturating_add(pos.y_advance);
+            }
+        }
+
+        if !s.is_empty() {
+            s.push(']');
+        }
+
+        Ok(s)
+    }
+}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl core::fmt::Debug for Buffer {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fmt.debug_struct("Buffer")
+            .field("content_type", &self.content_type())
+            .field("direction", &self.direction())
+            .field("language", &self.language())
+            .field("script", &self.script())
+            .field("cluster_level", &self.cluster_level())
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
+impl From<UnicodeBuffer> for Buffer {
+    #[inline]
+    fn from(buffer: UnicodeBuffer) -> Self {
+        let mut buffer = buffer.0;
+        if buffer.len != 0 {
+            buffer.content_type = Some(BufferContentType::Unicode);
+        }
+        buffer
+    }
+}
+
+impl From<GlyphBuffer> for Buffer {
+    #[inline]
+    fn from(buffer: GlyphBuffer) -> Self {
+        let mut buffer = buffer.0;
+        buffer.content_type = Some(BufferContentType::Glyphs);
+        buffer
+    }
+}
+
+/// Error returned when a [`Buffer`] holds the wrong kind of content for the
+/// typed buffer it is being converted into.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct WrongContentType {
+    /// The content type the buffer actually holds.
+    pub found: Option<BufferContentType>,
+    /// The content type that was required.
+    pub expected: BufferContentType,
+}
+
+impl core::fmt::Display for WrongContentType {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            fmt,
+            "buffer holds {:?} content, expected {:?}",
+            self.found, self.expected
+        )
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for WrongContentType {}
+
+impl TryFrom<Buffer> for UnicodeBuffer {
+    type Error = WrongContentType;
+
+    /// Converts into a [`UnicodeBuffer`], which succeeds unless the buffer
+    /// holds the output of shaping.
+    #[inline]
+    fn try_from(buffer: Buffer) -> Result<Self, Self::Error> {
+        if buffer.content_type == Some(BufferContentType::Glyphs) {
+            return Err(WrongContentType {
+                found: buffer.content_type,
+                expected: BufferContentType::Unicode,
+            });
+        }
+        Ok(UnicodeBuffer(buffer))
+    }
+}
+
+impl TryFrom<Buffer> for GlyphBuffer {
+    type Error = WrongContentType;
+
+    /// Converts into a [`GlyphBuffer`], which succeeds only if the buffer
+    /// holds the output of shaping.
+    #[inline]
+    fn try_from(buffer: Buffer) -> Result<Self, Self::Error> {
+        if buffer.content_type != Some(BufferContentType::Glyphs) {
+            return Err(WrongContentType {
+                found: buffer.content_type,
+                expected: BufferContentType::Glyphs,
+            });
+        }
+        Ok(GlyphBuffer(buffer))
     }
 }
 
@@ -1910,13 +2390,13 @@ pub const HB_BUFFER_SCRATCH_FLAG_SHAPER0: u32 = 0x0100_0000;
 // pub const HB_BUFFER_SCRATCH_FLAG_SHAPER3: u32 = 0x08000000;
 
 /// A buffer that contains an input string ready for shaping.
-pub struct UnicodeBuffer(pub(crate) hb_buffer_t);
+pub struct UnicodeBuffer(pub(crate) Buffer);
 
 impl UnicodeBuffer {
     /// Create a new `UnicodeBuffer`.
     #[inline]
     pub fn new() -> UnicodeBuffer {
-        UnicodeBuffer(hb_buffer_t::new())
+        UnicodeBuffer(Buffer::new())
     }
 
     /// Returns the length of the data of the buffer.
@@ -1989,7 +2469,7 @@ impl UnicodeBuffer {
     /// Appends a character to a buffer with the given cluster value.
     #[inline]
     pub fn add(&mut self, codepoint: char, cluster: u32) {
-        self.0.add(codepoint as u32, cluster);
+        self.0.push(codepoint as u32, cluster);
         self.0.context_len[1] = 0;
     }
 
@@ -2107,7 +2587,7 @@ impl Default for UnicodeBuffer {
 }
 
 /// A buffer that contains the results of the shaping process.
-pub struct GlyphBuffer(pub(crate) hb_buffer_t);
+pub struct GlyphBuffer(pub(crate) Buffer);
 
 impl GlyphBuffer {
     /// Returns the length of the data of the buffer.
@@ -2148,89 +2628,7 @@ impl GlyphBuffer {
 
     /// Converts the glyph buffer content into a string.
     pub fn serialize(&self, font: &impl SerializerFont, flags: SerializeFlags) -> String {
-        self.serialize_impl(font, flags).unwrap_or_default()
-    }
-
-    pub(crate) fn serialize_impl(
-        &self,
-        font: &impl SerializerFont,
-        flags: SerializeFlags,
-    ) -> Result<String, core::fmt::Error> {
-        use core::fmt::Write;
-
-        let mut s = String::with_capacity(64);
-
-        let info = self.glyph_infos();
-        let pos = self.glyph_positions();
-        let mut x: i32 = 0;
-        let mut y: i32 = 0;
-        let names = font.glyph_names();
-        let glyph_metrics = if flags.contains(SerializeFlags::GLYPH_EXTENTS) {
-            Some(font.glyph_metrics())
-        } else {
-            None
-        };
-        for (info, pos) in info.iter().zip(pos) {
-            s.push(if s.is_empty() { '[' } else { '|' });
-
-            if !flags.contains(SerializeFlags::NO_GLYPH_NAMES) {
-                match names.get(info.as_glyph().to_u32()) {
-                    Some(name) => s.push_str(name),
-                    None => write!(&mut s, "gid{}", info.glyph_id)?,
-                }
-            } else {
-                write!(&mut s, "{}", info.glyph_id)?;
-            }
-
-            if !flags.contains(SerializeFlags::NO_CLUSTERS) {
-                write!(&mut s, "={}", info.cluster)?;
-            }
-
-            if !flags.contains(SerializeFlags::NO_POSITIONS) {
-                let dx = x.saturating_add(pos.x_offset);
-                let dy = y.saturating_add(pos.y_offset);
-                if dx != 0 || dy != 0 {
-                    write!(&mut s, "@{dx},{dy}")?;
-                }
-
-                if !flags.contains(SerializeFlags::NO_ADVANCES) {
-                    write!(&mut s, "+{}", pos.x_advance)?;
-                    if pos.y_advance != 0 {
-                        write!(&mut s, ",{}", pos.y_advance)?;
-                    }
-                }
-            }
-
-            if flags.contains(SerializeFlags::GLYPH_FLAGS) {
-                if info.mask & GlyphFlags::DEFINED_BITS != 0 {
-                    write!(&mut s, "#{:X}", info.mask & GlyphFlags::DEFINED_BITS)?;
-                }
-            }
-
-            if flags.contains(SerializeFlags::GLYPH_EXTENTS) {
-                let extents = glyph_metrics
-                    .as_ref()
-                    .unwrap()
-                    .extents(info.as_glyph(), font.coords())
-                    .unwrap_or_default();
-                write!(
-                    &mut s,
-                    "<{},{},{},{}>",
-                    extents.x_bearing, extents.y_bearing, extents.width, extents.height
-                )?;
-            }
-
-            if flags.contains(SerializeFlags::NO_ADVANCES) {
-                x = x.saturating_add(pos.x_advance);
-                y = y.saturating_add(pos.y_advance);
-            }
-        }
-
-        if !s.is_empty() {
-            s.push(']');
-        }
-
-        Ok(s)
+        self.0.serialize(font, flags)
     }
 }
 
@@ -2290,7 +2688,7 @@ mod tests {
 
     #[test]
     fn next_syllable_is_bounded() {
-        let mut buffer = hb_buffer_t::new();
+        let mut buffer = Buffer::new();
         buffer
             .info
             .resize(MAX_SYLLABLE_LENGTH + 1, GlyphInfo::default());

--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -2236,6 +2236,79 @@ impl From<GlyphBuffer> for Buffer {
     }
 }
 
+/// The reason a call to [`Buffer::shape`] could not produce glyphs.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[non_exhaustive]
+pub enum ShapeError {
+    /// The buffer already holds the glyphs from an earlier call.
+    ///
+    /// To shape the same contents again, set the content type back to
+    /// [`BufferContentType::Unicode`] with
+    /// [`set_content_type`](Buffer::set_content_type); to shape something else,
+    /// clear the buffer and fill it afresh.
+    AlreadyShaped,
+
+    /// The buffer has no direction, so no plan could be built for it.
+    ///
+    /// Call [`guess_segment_properties`](Buffer::guess_segment_properties) to
+    /// infer one from the contents, or set it with
+    /// [`set_direction`](Buffer::set_direction).
+    DirectionUnset,
+
+    /// The font holds nothing that can be shaped with.
+    ///
+    /// The buffer is left untouched.
+    UnusableFont,
+
+    /// The buffer's direction is not the one the supplied plan was built for.
+    DirectionMismatch {
+        /// The direction the plan was built for.
+        plan: Direction,
+        /// The direction the buffer carries.
+        buffer: Direction,
+    },
+
+    /// The buffer's script is not the one the supplied plan was built for.
+    ScriptMismatch {
+        /// The script the plan was built for.
+        plan: Script,
+        /// The script the buffer carries.
+        buffer: Script,
+    },
+
+    /// Shaping gave up, having needed more room, more operations or more
+    /// nesting than the shaper allows.
+    ///
+    /// This guards against pathological input rather than reporting a mistake
+    /// by the caller, and it also covers a buffer that failed to allocate while
+    /// being filled. The contents are left partly shaped and should be
+    /// discarded; [`allocation_successful`](Buffer::allocation_successful)
+    /// reports the same condition.
+    LimitsExceeded,
+}
+
+impl core::fmt::Display for ShapeError {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::AlreadyShaped => fmt.write_str("buffer already holds shaped glyphs"),
+            Self::DirectionUnset => fmt.write_str("buffer has no direction set"),
+            Self::UnusableFont => fmt.write_str("font has nothing to shape with"),
+            Self::DirectionMismatch { plan, buffer } => write!(
+                fmt,
+                "buffer direction does not match plan direction: {buffer:?} != {plan:?}"
+            ),
+            Self::ScriptMismatch { plan, buffer } => write!(
+                fmt,
+                "buffer script does not match plan script: {buffer:?} != {plan:?}"
+            ),
+            Self::LimitsExceeded => fmt.write_str("shaping exceeded its limits"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ShapeError {}
+
 /// Error returned when a [`Buffer`] holds the wrong kind of content for the
 /// typed buffer it is being converted into.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -20,8 +20,8 @@ use super::ot_shape::OtShapeContext;
 use crate::hb::aat::AatCache;
 use crate::hb::tables::TableRanges;
 use crate::{
-    script, BufferContentType, Feature, GlyphBuffer, NormalizedCoord, ShapePlan, UnicodeBuffer,
-    Variation,
+    script, BufferContentType, Direction, Feature, GlyphBuffer, NormalizedCoord, ShapeError,
+    ShapePlan, UnicodeBuffer, Variation,
 };
 
 pub use super::font_funcs::{
@@ -467,7 +467,10 @@ pub fn shape(
         }
     }
     let mut buffer = buffer.0;
-    hb_font.shape_buffer(&mut buffer, options);
+    // As above, this signature cannot report a failure.
+    if let Err(err) = hb_font.shape_buffer(&mut buffer, options) {
+        assert!(err == ShapeError::LimitsExceeded, "{err}");
+    }
     GlyphBuffer(buffer)
 }
 
@@ -475,23 +478,33 @@ pub fn shape(
 impl Buffer {
     /// Shapes the buffer contents in place with the given font.
     ///
-    /// This matches HarfBuzz's `hb_shape`. On return the buffer holds
-    /// [`BufferContentType::Glyphs`]; shaping a buffer that already holds
-    /// glyphs is a no-op.
+    /// This matches HarfBuzz's `hb_shape`. On success the buffer holds
+    /// [`BufferContentType::Glyphs`].
     ///
-    /// If a plan is provided via [`ShapeOptions::plan`], it is up to the caller
-    /// to ensure that it matches the properties of this buffer, otherwise the
-    /// shaping result will likely be incorrect.
+    /// If a plan is supplied through [`ShapeOptions::plan`] it must have been
+    /// built for this buffer's direction and script, which is checked before
+    /// anything is touched.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic when debugging assertions are enabled if the buffer and plan
-    /// have mismatched properties.
-    pub fn shape(&mut self, font: &crate::font::FontInstance, mut options: ShapeOptions<'_>) {
+    /// [`ShapeError::AlreadyShaped`] if the buffer holds glyphs rather than
+    /// text, [`ShapeError::DirectionUnset`] if it has no direction and no plan
+    /// was supplied to give it one, [`ShapeError::UnusableFont`] if the font
+    /// has nothing to shape with, [`ShapeError::DirectionMismatch`] or
+    /// [`ShapeError::ScriptMismatch`] if the supplied plan was built for other
+    /// properties, and [`ShapeError::LimitsExceeded`] if the shaper ran past
+    /// its budget.
+    ///
+    /// Apart from [`ShapeError::LimitsExceeded`], which leaves the buffer
+    /// partly shaped, a failure leaves it exactly as it arrived.
+    pub fn shape(
+        &mut self,
+        font: &crate::font::FontInstance,
+        mut options: ShapeOptions<'_>,
+    ) -> Result<(), ShapeError> {
         let hb_font = hb_font_t::from_font(font);
         let Some(hb_font) = hb_font.as_ref() else {
-            self.clear();
-            return;
+            return Err(ShapeError::UnusableFont);
         };
         // If the user didn't request an explicit scale but the font instance
         // has a size, set the scale to that size with 16 fractional bits.
@@ -500,7 +513,7 @@ impl Buffer {
                 options = options.scale(Some((ppem * 65536.0) as i32));
             }
         }
-        hb_font.shape_buffer(self, options);
+        hb_font.shape_buffer(self, options)
     }
 }
 
@@ -595,17 +608,31 @@ impl<'a> crate::Shaper<'a> {
     /// properties.    
     pub fn shape(&self, buffer: UnicodeBuffer, options: ShapeOptions<'_>) -> GlyphBuffer {
         let mut buffer = buffer.0;
-        self.shape_buffer(&mut buffer, options);
+        // This signature cannot report a failure. Running out of room still
+        // leaves glyphs worth returning; a plan that does not match the buffer
+        // is a programming error, and panics.
+        if let Err(err) = self.shape_buffer(&mut buffer, options) {
+            assert!(err == ShapeError::LimitsExceeded, "{err}");
+        }
         GlyphBuffer(buffer)
     }
 
-    fn shape_buffer(&self, buffer: &mut Buffer, options: ShapeOptions<'_>) {
+    pub(crate) fn shape_buffer(
+        &self,
+        buffer: &mut Buffer,
+        options: ShapeOptions<'_>,
+    ) -> Result<(), ShapeError> {
         if buffer.content_type == Some(BufferContentType::Glyphs) {
-            return;
+            return Err(ShapeError::AlreadyShaped);
         }
         if let Some(plan) = options.plan {
-            self.shape_with_plan(plan, buffer, options);
+            self.shape_with_plan(plan, buffer, options)
         } else {
+            // Compiling a plan requires a direction, and asserts on its own if
+            // it does not get one.
+            if buffer.direction == Direction::Invalid {
+                return Err(ShapeError::DirectionUnset);
+            }
             let plan = ShapePlan::new(
                 self,
                 buffer.direction,
@@ -613,25 +640,34 @@ impl<'a> crate::Shaper<'a> {
                 buffer.language.as_ref(),
                 options.features,
             );
-            self.shape_with_plan(&plan, buffer, options);
+            self.shape_with_plan(&plan, buffer, options)
         }
     }
 
-    fn shape_with_plan(&self, plan: &ShapePlan, buffer: &mut Buffer, options: ShapeOptions<'_>) {
-        buffer.enter();
+    fn shape_with_plan(
+        &self,
+        plan: &ShapePlan,
+        buffer: &mut Buffer,
+        options: ShapeOptions<'_>,
+    ) -> Result<(), ShapeError> {
+        // Check before `enter`, so a buffer that cannot be shaped is handed
+        // back exactly as it arrived.
+        if buffer.direction != plan.direction {
+            return Err(ShapeError::DirectionMismatch {
+                plan: plan.direction,
+                buffer: buffer.direction,
+            });
+        }
+        let plan_script = plan.script.unwrap_or(script::UNKNOWN);
+        let buffer_script = buffer.script.unwrap_or(script::UNKNOWN);
+        if buffer_script != plan_script {
+            return Err(ShapeError::ScriptMismatch {
+                plan: plan_script,
+                buffer: buffer_script,
+            });
+        }
 
-        assert_eq!(
-            buffer.direction, plan.direction,
-            "Buffer direction does not match plan direction: {:?} != {:?}",
-            buffer.direction, plan.direction
-        );
-        assert_eq!(
-            buffer.script.unwrap_or(script::UNKNOWN),
-            plan.script.unwrap_or(script::UNKNOWN),
-            "Buffer script does not match plan script: {:?} != {:?}",
-            buffer.script.unwrap_or(script::UNKNOWN),
-            plan.script.unwrap_or(script::UNKNOWN)
-        );
+        buffer.enter();
 
         if buffer.len > 0 {
             // Save the original direction, we use it later.
@@ -652,6 +688,13 @@ impl<'a> crate::Shaper<'a> {
 
         buffer.leave();
         buffer.content_type = Some(BufferContentType::Glyphs);
+
+        // Set anywhere the shaper ran past its length, operation or nesting
+        // budget, and also by a buffer that failed to allocate while filling.
+        if !buffer.successful {
+            return Err(ShapeError::LimitsExceeded);
+        }
+        Ok(())
     }
 
     pub(crate) fn glyph_names(&self) -> GlyphNames<'a> {

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -9,7 +9,7 @@ use smallvec::SmallVec;
 use core_maths::CoreFloat as _;
 
 use super::aat::AatTables;
-use super::buffer::hb_buffer_t;
+use super::buffer::Buffer;
 use super::charmap::{cache_t as cmap_cache_t, Charmap};
 use super::font_funcs::FontFuncsDispatch;
 use super::glyph_metrics::GlyphMetrics;
@@ -19,7 +19,10 @@ use super::ot_layout::TableIndex;
 use super::ot_shape::OtShapeContext;
 use crate::hb::aat::AatCache;
 use crate::hb::tables::TableRanges;
-use crate::{script, Feature, GlyphBuffer, NormalizedCoord, ShapePlan, UnicodeBuffer, Variation};
+use crate::{
+    script, BufferContentType, Feature, GlyphBuffer, NormalizedCoord, ShapePlan, UnicodeBuffer,
+    Variation,
+};
 
 pub use super::font_funcs::{
     AdvanceWidthBatch, BuiltinFontFuncs, FontFuncs, NominalGlyphBatch, RawAdvanceWidthBatch,
@@ -468,6 +471,39 @@ pub fn shape(
     GlyphBuffer(buffer)
 }
 
+#[cfg(feature = "experimental_font_api")]
+impl Buffer {
+    /// Shapes the buffer contents in place with the given font.
+    ///
+    /// This matches HarfBuzz's `hb_shape`. On return the buffer holds
+    /// [`BufferContentType::Glyphs`]; shaping a buffer that already holds
+    /// glyphs is a no-op.
+    ///
+    /// If a plan is provided via [`ShapeOptions::plan`], it is up to the caller
+    /// to ensure that it matches the properties of this buffer, otherwise the
+    /// shaping result will likely be incorrect.
+    ///
+    /// # Panics
+    ///
+    /// Will panic when debugging assertions are enabled if the buffer and plan
+    /// have mismatched properties.
+    pub fn shape(&mut self, font: &crate::font::FontInstance, mut options: ShapeOptions<'_>) {
+        let hb_font = hb_font_t::from_font(font);
+        let Some(hb_font) = hb_font.as_ref() else {
+            self.clear();
+            return;
+        };
+        // If the user didn't request an explicit scale but the font instance
+        // has a size, set the scale to that size with 16 fractional bits.
+        if options.scale.is_none() {
+            if let Some(ppem) = font.size() {
+                options = options.scale(Some((ppem * 65536.0) as i32));
+            }
+        }
+        hb_font.shape_buffer(self, options);
+    }
+}
+
 // This will go away completely when we drop the old API.
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
@@ -563,7 +599,10 @@ impl<'a> crate::Shaper<'a> {
         GlyphBuffer(buffer)
     }
 
-    fn shape_buffer(&self, buffer: &mut hb_buffer_t, options: ShapeOptions<'_>) {
+    fn shape_buffer(&self, buffer: &mut Buffer, options: ShapeOptions<'_>) {
+        if buffer.content_type == Some(BufferContentType::Glyphs) {
+            return;
+        }
         if let Some(plan) = options.plan {
             self.shape_with_plan(plan, buffer, options);
         } else {
@@ -578,12 +617,7 @@ impl<'a> crate::Shaper<'a> {
         }
     }
 
-    fn shape_with_plan(
-        &self,
-        plan: &ShapePlan,
-        buffer: &mut hb_buffer_t,
-        options: ShapeOptions<'_>,
-    ) {
+    fn shape_with_plan(&self, plan: &ShapePlan, buffer: &mut Buffer, options: ShapeOptions<'_>) {
         buffer.enter();
 
         assert_eq!(
@@ -617,6 +651,7 @@ impl<'a> crate::Shaper<'a> {
         }
 
         buffer.leave();
+        buffer.content_type = Some(BufferContentType::Glyphs);
     }
 
     pub(crate) fn glyph_names(&self) -> GlyphNames<'a> {

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -469,7 +469,7 @@ pub fn shape(
     let mut buffer = buffer.0;
     // As above, this signature cannot report a failure.
     if let Err(err) = hb_font.shape_buffer(&mut buffer, options) {
-        assert!(err == ShapeError::LimitsExceeded, "{err}");
+        panic!("{err}");
     }
     GlyphBuffer(buffer)
 }
@@ -492,11 +492,12 @@ impl Buffer {
     /// was supplied to give it one, [`ShapeError::UnusableFont`] if the font
     /// has nothing to shape with, [`ShapeError::DirectionMismatch`] or
     /// [`ShapeError::ScriptMismatch`] if the supplied plan was built for other
-    /// properties, and [`ShapeError::LimitsExceeded`] if the shaper ran past
-    /// its budget.
+    /// properties.
     ///
-    /// Apart from [`ShapeError::LimitsExceeded`], which leaves the buffer
-    /// partly shaped, a failure leaves it exactly as it arrived.
+    /// Each of these is a misuse of the API, caught before anything is
+    /// touched, so a failure leaves the buffer exactly as it arrived. Running
+    /// out of room is not among them; check
+    /// [`allocation_successful`](Buffer::allocation_successful) for that.
     pub fn shape(
         &mut self,
         font: &crate::font::FontInstance,
@@ -608,11 +609,10 @@ impl<'a> crate::Shaper<'a> {
     /// properties.    
     pub fn shape(&self, buffer: UnicodeBuffer, options: ShapeOptions<'_>) -> GlyphBuffer {
         let mut buffer = buffer.0;
-        // This signature cannot report a failure. Running out of room still
-        // leaves glyphs worth returning; a plan that does not match the buffer
-        // is a programming error, and panics.
+        // This signature cannot report a failure, and every way shaping can
+        // fail is a programming error, so panic.
         if let Err(err) = self.shape_buffer(&mut buffer, options) {
-            assert!(err == ShapeError::LimitsExceeded, "{err}");
+            panic!("{err}");
         }
         GlyphBuffer(buffer)
     }
@@ -689,11 +689,9 @@ impl<'a> crate::Shaper<'a> {
         buffer.leave();
         buffer.content_type = Some(BufferContentType::Glyphs);
 
-        // Set anywhere the shaper ran past its length, operation or nesting
-        // budget, and also by a buffer that failed to allocate while filling.
-        if !buffer.successful {
-            return Err(ShapeError::LimitsExceeded);
-        }
+        // Running past the length, operation or nesting budget leaves
+        // `successful` false, which the caller reads through
+        // `Buffer::allocation_successful`.
         Ok(())
     }
 

--- a/harfrust/src/hb/font_funcs.rs
+++ b/harfrust/src/hb/font_funcs.rs
@@ -10,7 +10,7 @@ use crate::hb::face::FontKind;
 use crate::hb::face::Scale;
 use crate::hb::glyph_metrics::GlyphMetrics;
 
-use super::buffer::{hb_buffer_t, GlyphInfo, GlyphPosition};
+use super::buffer::{Buffer, GlyphInfo, GlyphPosition};
 use super::face::{hb_font_t, GlyphExtents};
 
 /// Raw C-style view over a batch of glyph ids and advance widths.
@@ -38,7 +38,7 @@ pub struct AdvanceWidthBatch<'a> {
 }
 
 impl<'a> AdvanceWidthBatch<'a> {
-    pub(crate) fn new(buffer: &'a mut hb_buffer_t) -> Self {
+    pub(crate) fn new(buffer: &'a mut Buffer) -> Self {
         let len = buffer.len;
         let infos = &buffer.info[..len];
         let positions = &mut buffer.pos[..len];

--- a/harfrust/src/hb/kerning.rs
+++ b/harfrust/src/hb/kerning.rs
@@ -37,7 +37,7 @@ pub fn hb_ot_layout_kern(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
     scale: Scale,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> Option<()> {
     let mut c = AatApplyContext::new(plan, face, scale, buffer);
 
@@ -129,7 +129,7 @@ pub fn hb_ot_layout_kern(
 fn machine_kern<F>(
     face: &hb_font_t,
     scale: Scale,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     kern_mask: hb_mask_t,
     cross_stream: bool,
     get_kerning: F,

--- a/harfrust/src/hb/ot/gpos/mark.rs
+++ b/harfrust/src/hb/ot/gpos/mark.rs
@@ -1,4 +1,4 @@
-use crate::hb::buffer::{hb_buffer_t, GlyphPosition, HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_ATTACHMENT};
+use crate::hb::buffer::{Buffer, GlyphPosition, HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_ATTACHMENT};
 use crate::hb::ot_layout_common::lookup_flags;
 use crate::hb::ot_layout_gpos_table::attach_type;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
@@ -169,7 +169,7 @@ impl Apply for MarkBasePosFormat1<'_> {
     }
 }
 
-fn accept(buffer: &hb_buffer_t, idx: usize) -> bool {
+fn accept(buffer: &Buffer, idx: usize) -> bool {
     /* We only want to attach to the first of a MultipleSubst sequence.
      * https://github.com/harfbuzz/harfbuzz/issues/740
      * Reject others...
@@ -350,7 +350,7 @@ impl Apply for MarkLigPosFormat1<'_> {
     }
 }
 
-fn accept_mark_ligature(buffer: &hb_buffer_t, idx: usize) -> bool {
+fn accept_mark_ligature(buffer: &Buffer, idx: usize) -> bool {
     // We only want to attach to the first of a MultipleSubst sequence,
     // which might have been ligated into a preceding ligature, and in that
     // case the mark should attach to that ligature.

--- a/harfrust/src/hb/ot_layout.rs
+++ b/harfrust/src/hb/ot_layout.rs
@@ -25,7 +25,7 @@ impl GlyphInfo {
     );
 }
 
-impl hb_buffer_t {
+impl Buffer {
     pub(crate) fn allocate_unicode_vars(&mut self) {
         self.allocate_var(GlyphInfo::UNICODE_PROPS_VAR);
     }
@@ -82,7 +82,7 @@ pub fn hb_ot_layout_has_cross_kerning(face: &hb_font_t) -> bool {
 
 // hb_ot_layout_kern
 
-pub fn _hb_ot_layout_set_glyph_props(face: &hb_font_t, buffer: &mut hb_buffer_t) {
+pub fn _hb_ot_layout_set_glyph_props(face: &hb_font_t, buffer: &mut Buffer) {
     buffer.assert_gsubgpos_vars();
 
     let len = buffer.len;
@@ -138,7 +138,7 @@ pub trait LayoutTable {
 
 /// Called before substitution lookups are performed, to ensure that glyph
 /// class and other properties are set on the glyphs in the buffer.
-pub fn hb_ot_layout_substitute_start(face: &hb_font_t, buffer: &mut hb_buffer_t) {
+pub fn hb_ot_layout_substitute_start(face: &hb_font_t, buffer: &mut Buffer) {
     _hb_ot_layout_set_glyph_props(face, buffer);
 }
 
@@ -147,7 +147,7 @@ pub fn apply_layout_table<T: LayoutTable>(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
     font_funcs: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     table: Option<&T>,
 ) {
     let mut ctx = OT::hb_ot_apply_context_t::new(T::INDEX, face, *font_funcs.scale(), buffer);
@@ -363,7 +363,7 @@ fn apply_backward(ctx: &mut OT::hb_ot_apply_context_t, lookup: &LookupInfo) -> b
 //   HB_MARK_AS_FLAG_T (hb_unicode_props_flags_t);
 
 //   static inline void
-//   _hb_glyph_info_set_unicode_props (hb_glyph_info_t *info, hb_buffer_t *buffer)
+//   _hb_glyph_info_set_unicode_props (hb_glyph_info_t *info, Buffer *buffer)
 //   {
 //     hb_unicode_funcs_t *unicode = buffer->unicode;
 //     unsigned int u = info->codepoint;
@@ -616,7 +616,7 @@ pub(crate) fn _hb_grapheme_group_func(_: &GlyphInfo, b: &GlyphInfo) -> bool {
     b.is_continuation()
 }
 
-pub fn _hb_ot_layout_reverse_graphemes(buffer: &mut hb_buffer_t) {
+pub fn _hb_ot_layout_reverse_graphemes(buffer: &mut Buffer) {
     // MONOTONE_GRAPHEMES was already applied and is taken care of by _hb_grapheme_group_func.
     // So we just check for MONOTONE_CHARACTERS here.
     buffer.reverse_groups(
@@ -897,7 +897,7 @@ impl GlyphInfo {
 pub fn _hb_clear_substitution_flags(
     _: &hb_ot_shape_plan_t,
     _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     let len = buffer.len;
     for info in &mut buffer.info[..len] {

--- a/harfrust/src/hb/ot_layout_gpos_table.rs
+++ b/harfrust/src/hb/ot_layout_gpos_table.rs
@@ -9,7 +9,7 @@ pub fn position(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
     font_funcs: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     apply_layout_table(plan, face, font_funcs, buffer, face.ot_tables.gpos.as_ref());
 }
@@ -100,7 +100,7 @@ fn propagate_attachment_offsets(
 pub mod GPOS {
     use super::*;
 
-    pub fn position_start(_: &hb_font_t, buffer: &mut hb_buffer_t) {
+    pub fn position_start(_: &hb_font_t, buffer: &mut Buffer) {
         let len = buffer.len;
         for pos in &mut buffer.pos[..len] {
             pos.set_attach_chain(0);
@@ -108,11 +108,11 @@ pub mod GPOS {
         }
     }
 
-    pub fn position_finish_advances(_: &hb_font_t, _: &mut hb_buffer_t) {
+    pub fn position_finish_advances(_: &hb_font_t, _: &mut Buffer) {
         //buffer.assert_gsubgpos_vars();
     }
 
-    pub fn position_finish_offsets(_: &hb_font_t, buffer: &mut hb_buffer_t) {
+    pub fn position_finish_offsets(_: &hb_font_t, buffer: &mut Buffer) {
         buffer.assert_gsubgpos_vars();
 
         let len = buffer.len;

--- a/harfrust/src/hb/ot_layout_gsub_table.rs
+++ b/harfrust/src/hb/ot_layout_gsub_table.rs
@@ -1,4 +1,4 @@
-use super::buffer::hb_buffer_t;
+use super::buffer::Buffer;
 use super::font_funcs::FontFuncsDispatch;
 use super::hb_font_t;
 use super::ot_layout::*;
@@ -8,7 +8,7 @@ pub fn substitute(
     plan: &hb_ot_shape_plan_t,
     face: &hb_font_t,
     font_funcs: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     apply_layout_table(plan, face, font_funcs, buffer, face.ot_tables.gsub.as_ref());
 }

--- a/harfrust/src/hb/ot_layout_gsubgpos.rs
+++ b/harfrust/src/hb/ot_layout_gsubgpos.rs
@@ -1,7 +1,7 @@
 //! Matching of glyph patterns.
 
 use super::buffer::GlyphInfo;
-use super::buffer::{hb_buffer_t, GlyphPropsFlags};
+use super::buffer::{Buffer, GlyphPropsFlags};
 use super::cache::hb_cache_t;
 use super::face::Scale;
 use super::hb_font_t;
@@ -316,7 +316,7 @@ impl matcher_t {
 // when needed, and we do not have `init` method that exist in harfbuzz. This has a performance
 // cost, and makes backporting related changes very hard, but it seems unavoidable, unfortunately.
 pub struct skipping_iterator_t<'f, 'c, F> {
-    pub(crate) buffer: &'c mut hb_buffer_t,
+    pub(crate) buffer: &'c mut Buffer,
     face: &'c hb_font_t<'f>,
     matcher: &'c matcher_t,
     match_positions: &'c mut MatchPositions,
@@ -855,7 +855,7 @@ pub mod OT {
         pub table_index: TableIndex,
         pub face: &'a hb_font_t<'a>,
         pub scale: Scale,
-        pub buffer: &'a mut hb_buffer_t,
+        pub buffer: &'a mut Buffer,
         lookup_mask: hb_mask_t,
         pub per_syllable: bool,
         pub lookup_index: u16,
@@ -879,7 +879,7 @@ pub mod OT {
             table_index: TableIndex,
             face: &'a hb_font_t<'a>,
             scale: Scale,
-            buffer: &'a mut hb_buffer_t,
+            buffer: &'a mut Buffer,
         ) -> Self {
             Self {
                 table_index,

--- a/harfrust/src/hb/ot_map.rs
+++ b/harfrust/src/hb/ot_map.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::ops::Range;
 
-use super::buffer::{hb_buffer_t, GlyphFlags};
+use super::buffer::{Buffer, GlyphFlags};
 use super::common::TagExt;
 use super::font_funcs::FontFuncsDispatch;
 use super::ot_layout::TableIndex;
@@ -71,7 +71,7 @@ pub struct StageMap {
 
 // Pause functions return true if new glyph indices might have been added to the buffer.
 // This is used to update buffer digest.
-pub type pause_func_t = fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut hb_buffer_t) -> bool;
+pub type pause_func_t = fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut Buffer) -> bool;
 
 impl hb_ot_map_t {
     pub const MAX_BITS: u32 = 8;

--- a/harfrust/src/hb/ot_shape.rs
+++ b/harfrust/src/hb/ot_shape.rs
@@ -301,7 +301,7 @@ impl<'a> hb_ot_shape_planner_t<'a> {
 pub(crate) struct OtShapeContext<'a, 'u> {
     pub plan: &'a hb_ot_shape_plan_t,
     pub face: &'a hb_font_t<'a>,
-    pub buffer: &'a mut hb_buffer_t,
+    pub buffer: &'a mut Buffer,
     pub features: &'a [Feature],
     // Transient stuff
     pub target_direction: Direction,
@@ -786,7 +786,7 @@ impl OtShapeContext<'_, '_> {
     }
 }
 
-fn form_clusters(buffer: &mut hb_buffer_t) {
+fn form_clusters(buffer: &mut Buffer) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_CONTINUATIONS != 0 {
         foreach_grapheme!(buffer, start, end, {
             buffer.merge_grapheme_clusters(start, end);
@@ -794,7 +794,7 @@ fn form_clusters(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn ensure_native_direction(buffer: &mut hb_buffer_t) {
+fn ensure_native_direction(buffer: &mut Buffer) {
     let dir = buffer.direction;
     let mut hor = buffer
         .script
@@ -850,7 +850,7 @@ fn ensure_native_direction(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn map_glyphs_fast(buffer: &mut hb_buffer_t) {
+fn map_glyphs_fast(buffer: &mut Buffer) {
     // Normalization process sets up normalizer_glyph_index(), we just copy it.
     let len = buffer.len;
     for info in &mut buffer.info[..len] {
@@ -862,7 +862,7 @@ fn map_glyphs_fast(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn hb_synthesize_glyph_classes(buffer: &mut hb_buffer_t) {
+fn hb_synthesize_glyph_classes(buffer: &mut Buffer) {
     let len = buffer.len;
     for info in &mut buffer.info[..len] {
         // Never mark default-ignorables as marks.
@@ -885,7 +885,7 @@ fn hb_synthesize_glyph_classes(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn zero_width_default_ignorables(buffer: &mut hb_buffer_t) {
+fn zero_width_default_ignorables(buffer: &mut Buffer) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_DEFAULT_IGNORABLES != 0
         && !buffer
             .flags
@@ -909,7 +909,7 @@ fn zero_width_default_ignorables(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn deal_with_variation_selectors(buffer: &mut hb_buffer_t) {
+fn deal_with_variation_selectors(buffer: &mut Buffer) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_VARIATION_SELECTOR_FALLBACK == 0 {
         return;
     }
@@ -936,7 +936,7 @@ fn deal_with_variation_selectors(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn zero_mark_widths_by_gdef(buffer: &mut hb_buffer_t, adjust_offsets: bool) {
+fn zero_mark_widths_by_gdef(buffer: &mut Buffer, adjust_offsets: bool) {
     let len = buffer.len;
     for (info, pos) in buffer.info[..len].iter().zip(&mut buffer.pos[..len]) {
         if info.is_mark() {
@@ -951,7 +951,7 @@ fn zero_mark_widths_by_gdef(buffer: &mut hb_buffer_t, adjust_offsets: bool) {
     }
 }
 
-fn hide_default_ignorables(buffer: &mut hb_buffer_t, font_funcs: &mut FontFuncsDispatch<'_, '_>) {
+fn hide_default_ignorables(buffer: &mut Buffer, font_funcs: &mut FontFuncsDispatch<'_, '_>) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_HAS_DEFAULT_IGNORABLES != 0
         && !buffer
             .flags
@@ -979,7 +979,7 @@ fn hide_default_ignorables(buffer: &mut hb_buffer_t, font_funcs: &mut FontFuncsD
     }
 }
 
-fn propagate_flags(buffer: &mut hb_buffer_t) {
+fn propagate_flags(buffer: &mut Buffer) {
     // Propagate cluster-level glyph flags to be the same on all cluster glyphs.
     // Simplifies using them.
 

--- a/harfrust/src/hb/ot_shape_fallback.rs
+++ b/harfrust/src/hb/ot_shape_fallback.rs
@@ -1,6 +1,6 @@
 use read_fonts::types::GlyphId;
 
-use super::buffer::{hb_buffer_t, GlyphPosition};
+use super::buffer::{Buffer, GlyphPosition};
 use super::face::GlyphExtents;
 use super::font_funcs::FontFuncsDispatch;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
@@ -10,7 +10,7 @@ use crate::unicode::*;
 struct FallbackShapeContext<'a, 'x, 'u> {
     plan: &'a hb_ot_shape_plan_t,
     face: &'a hb_font_t<'a>,
-    buffer: &'x mut hb_buffer_t,
+    buffer: &'x mut Buffer,
     adjust_offsets_when_zeroing: bool,
     font_funcs: &'x mut FontFuncsDispatch<'a, 'u>,
 }
@@ -98,7 +98,7 @@ fn recategorize_combining_class(u: u32, mut class: u8) -> u8 {
 pub fn _hb_ot_shape_fallback_mark_position_recategorize_marks(
     _: &hb_ot_shape_plan_t,
     _: &hb_font_t,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     let len = buffer.len;
     for info in &mut buffer.info[..len] {
@@ -111,7 +111,7 @@ pub fn _hb_ot_shape_fallback_mark_position_recategorize_marks(
 }
 
 fn zero_mark_advances(
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     start: usize,
     end: usize,
     adjust_offsets_when_zeroing: bool,
@@ -421,7 +421,7 @@ fn position_cluster(ctx: &mut FallbackShapeContext, start: usize, end: usize) {
 pub fn position_marks<'a, 'x>(
     plan: &'a hb_ot_shape_plan_t,
     face: &'a hb_font_t<'a>,
-    buffer: &'x mut hb_buffer_t,
+    buffer: &'x mut Buffer,
     adjust_offsets_when_zeroing: bool,
     font_funcs: &'x mut FontFuncsDispatch<'a, '_>,
 ) {
@@ -450,14 +450,14 @@ pub fn position_marks<'a, 'x>(
     position_cluster(&mut ctx, start, len);
 }
 
-pub fn _hb_ot_shape_fallback_kern(_: &hb_ot_shape_plan_t, _: &hb_font_t, _: &mut hb_buffer_t) {
+pub fn _hb_ot_shape_fallback_kern(_: &hb_ot_shape_plan_t, _: &hb_font_t, _: &mut Buffer) {
     // STUB: this is deprecated in HarfBuzz
 }
 
 pub fn _hb_ot_shape_fallback_spaces<'a, 'x>(
     plan: &'a hb_ot_shape_plan_t,
     face: &'a hb_font_t<'a>,
-    buffer: &'x mut hb_buffer_t,
+    buffer: &'x mut Buffer,
     font_funcs: &'x mut FontFuncsDispatch<'a, '_>,
 ) {
     use crate::unicode::hb_unicode_funcs_t as t;

--- a/harfrust/src/hb/ot_shape_normalize.rs
+++ b/harfrust/src/hb/ot_shape_normalize.rs
@@ -19,7 +19,7 @@ impl GlyphInfo {
 
 pub struct hb_ot_shape_normalize_context_t<'a, 'x, 'u> {
     pub plan: &'a hb_ot_shape_plan_t,
-    pub buffer: &'x mut hb_buffer_t,
+    pub buffer: &'x mut Buffer,
     pub font_funcs: &'x mut FontFuncsDispatch<'a, 'u>,
     pub decompose: DecomposeFn,
     pub compose: ComposeFn,
@@ -105,7 +105,7 @@ fn compose_unicode(
     crate::unicode::compose(a, b)
 }
 
-fn output_char(buffer: &mut hb_buffer_t, unichar: u32, glyph: u32) {
+fn output_char(buffer: &mut Buffer, unichar: u32, glyph: u32) {
     // This is very confusing indeed.
     buffer.cur_mut(0).set_normalizer_glyph_index(glyph);
     buffer.output_glyph(unichar);
@@ -115,12 +115,12 @@ fn output_char(buffer: &mut hb_buffer_t, unichar: u32, glyph: u32) {
     buffer.scratch_flags = flags;
 }
 
-fn next_char(buffer: &mut hb_buffer_t, glyph: u32) {
+fn next_char(buffer: &mut Buffer, glyph: u32) {
     buffer.cur_mut(0).set_normalizer_glyph_index(glyph);
     buffer.next_glyph();
 }
 
-fn skip_char(buffer: &mut hb_buffer_t) {
+fn skip_char(buffer: &mut Buffer) {
     buffer.skip_glyph();
 }
 
@@ -300,7 +300,7 @@ fn compare_combining_class(pa: &GlyphInfo, pb: &GlyphInfo) -> bool {
 
 pub fn _hb_ot_shape_normalize<'a, 'x>(
     plan: &'a hb_ot_shape_plan_t,
-    buffer: &'x mut hb_buffer_t,
+    buffer: &'x mut Buffer,
     _face: &'a hb_font_t<'a>,
     font_funcs: &'x mut FontFuncsDispatch<'a, '_>,
 ) {

--- a/harfrust/src/hb/ot_shaper.rs
+++ b/harfrust/src/hb/ot_shaper.rs
@@ -72,12 +72,11 @@ pub struct hb_ot_shaper_t {
 
     /// Called during `shape()`.
     /// Shapers can use to modify text before shaping starts.
-    pub preprocess_text: Option<fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut hb_buffer_t)>,
+    pub preprocess_text: Option<fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut Buffer)>,
 
     /// Called during `shape()`.
     /// Shapers can use to modify text before shaping starts.
-    pub postprocess_glyphs:
-        Option<fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut hb_buffer_t)>,
+    pub postprocess_glyphs: Option<fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut Buffer)>,
 
     /// How to normalize.
     pub normalization_preference: hb_ot_shape_normalization_mode_t,
@@ -91,7 +90,7 @@ pub struct hb_ot_shaper_t {
     /// Called during `shape()`.
     /// Shapers should use map to get feature masks and set on buffer.
     /// Shapers may NOT modify characters.
-    pub setup_masks: Option<fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut hb_buffer_t)>,
+    pub setup_masks: Option<fn(&hb_ot_shape_plan_t, &mut FontFuncsDispatch, &mut Buffer)>,
 
     /// If not `None`, then must match found GPOS script tag for
     /// GPOS to be applied.  Otherwise, fallback positioning will be used.
@@ -99,7 +98,7 @@ pub struct hb_ot_shaper_t {
 
     /// Called during `shape()`.
     /// Shapers can use to modify ordering of combining marks.
-    pub reorder_marks: Option<fn(&hb_ot_shape_plan_t, &mut hb_buffer_t, usize, usize)>,
+    pub reorder_marks: Option<fn(&hb_ot_shape_plan_t, &mut Buffer, usize, usize)>,
 
     /// If and when to zero-width marks.
     pub zero_width_marks: hb_ot_shape_zero_width_marks_type_t,

--- a/harfrust/src/hb/ot_shaper_arabic.rs
+++ b/harfrust/src/hb/ot_shaper_arabic.rs
@@ -181,7 +181,7 @@ impl GlyphInfo {
 fn deallocate_buffer_var(
     _: &hb_ot_shape_plan_t,
     _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     buffer.deallocate_var(GlyphInfo::ARABIC_SHAPING_ACTION_VAR);
 
@@ -308,7 +308,7 @@ pub fn data_create_arabic(plan: &hb_ot_shape_plan_t) -> arabic_shape_plan_t {
     }
 }
 
-fn arabic_joining(buffer: &mut hb_buffer_t) {
+fn arabic_joining(buffer: &mut Buffer) {
     let mut prev: Option<usize> = None;
     let mut state = 0;
 
@@ -385,7 +385,7 @@ fn arabic_joining(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn mongolian_variation_selectors(buffer: &mut hb_buffer_t) {
+fn mongolian_variation_selectors(buffer: &mut Buffer) {
     // Copy arabic_shaping_action() from base to Mongolian variation selectors.
     let len = buffer.len;
     let info = &mut buffer.info;
@@ -400,7 +400,7 @@ fn mongolian_variation_selectors(buffer: &mut hb_buffer_t) {
 fn setup_masks_arabic_plan(
     plan: &hb_ot_shape_plan_t,
     _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     buffer.allocate_var(GlyphInfo::ARABIC_SHAPING_ACTION_VAR);
 
@@ -411,7 +411,7 @@ fn setup_masks_arabic_plan(
 pub fn setup_masks_inner(
     arabic_plan: &arabic_shape_plan_t,
     script: Option<Script>,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     arabic_joining(buffer);
     if script == Some(script::MONGOLIAN) {
@@ -426,7 +426,7 @@ pub fn setup_masks_inner(
 fn arabic_fallback_shape(
     plan: &hb_ot_shape_plan_t,
     font_funcs: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     let arabic_plan = plan.data::<arabic_shape_plan_t>();
     if !arabic_plan.do_fallback {
@@ -449,11 +449,7 @@ fn arabic_fallback_shape(
 // https://docs.microsoft.com/en-us/typography/script-development/syriac
 // We implement this in a generic way, such that the Arabic subtending
 // marks can use it as well.
-fn record_stch(
-    plan: &hb_ot_shape_plan_t,
-    _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
-) -> bool {
+fn record_stch(plan: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) -> bool {
     let arabic_plan = plan.data::<arabic_shape_plan_t>();
     if !arabic_plan.has_stch {
         return false;
@@ -487,7 +483,7 @@ fn record_stch(
     false
 }
 
-fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
+fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     if buffer.scratch_flags & HB_BUFFER_SCRATCH_FLAG_ARABIC_HAS_STCH == 0 {
         return;
     }
@@ -644,7 +640,7 @@ fn apply_stch(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
 fn postprocess_glyphs_arabic(
     _: &hb_ot_shape_plan_t,
     face: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     apply_stch(face, buffer);
 }
@@ -667,12 +663,7 @@ static MODIFIER_COMBINING_MARKS: &[u32] = &[
     0x08F3, // ARABIC SMALL HIGH WAW
 ];
 
-fn reorder_marks_arabic(
-    _: &hb_ot_shape_plan_t,
-    buffer: &mut hb_buffer_t,
-    mut start: usize,
-    end: usize,
-) {
+fn reorder_marks_arabic(_: &hb_ot_shape_plan_t, buffer: &mut Buffer, mut start: usize, end: usize) {
     let mut i = start;
     for cc in [220u8, 230] {
         while i < end && buffer.info[i].modified_combining_class() < cc {

--- a/harfrust/src/hb/ot_shaper_arabic_fallback.rs
+++ b/harfrust/src/hb/ot_shaper_arabic_fallback.rs
@@ -1,5 +1,5 @@
 use super::{
-    buffer::hb_buffer_t,
+    buffer::Buffer,
     font_funcs::FontFuncsDispatch,
     hb_mask_t, hb_tag_t,
     ot::lookup::LookupInfo,
@@ -217,7 +217,7 @@ impl FallbackPlan {
         (!lookups.is_empty()).then_some(Self { lookups })
     }
 
-    pub(crate) fn apply(&self, font_funcs: &FontFuncsDispatch, buffer: &mut hb_buffer_t) {
+    pub(crate) fn apply(&self, font_funcs: &FontFuncsDispatch, buffer: &mut Buffer) {
         let mut ctx = hb_ot_apply_context_t::new(
             TableIndex::GSUB,
             font_funcs.font(),

--- a/harfrust/src/hb/ot_shaper_hangul.rs
+++ b/harfrust/src/hb/ot_shaper_hangul.rs
@@ -124,7 +124,7 @@ fn is_zero_width_char(face: &mut FontFuncsDispatch, c: Codepoint) -> bool {
 fn preprocess_text_hangul(
     _: &hb_ot_shape_plan_t,
     face: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     buffer.allocate_var(GlyphInfo::HANGUL_SHAPING_FEATURE_VAR);
 
@@ -369,11 +369,7 @@ fn preprocess_text_hangul(
     buffer.sync();
 }
 
-fn setup_masks_hangul(
-    plan: &hb_ot_shape_plan_t,
-    _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
-) {
+fn setup_masks_hangul(plan: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     let hangul_plan = plan.data::<hangul_shape_plan_t>();
     for info in buffer.info_slice_mut() {
         info.mask |= hangul_plan.mask_array[info.hangul_shaping_feature() as usize];

--- a/harfrust/src/hb/ot_shaper_hebrew.rs
+++ b/harfrust/src/hb/ot_shaper_hebrew.rs
@@ -1,7 +1,7 @@
 use super::hb_tag_t;
 use super::ot_shape_normalize::*;
 use super::ot_shaper::*;
-use crate::hb::buffer::hb_buffer_t;
+use crate::hb::buffer::Buffer;
 use crate::hb::ot_shape_plan::hb_ot_shape_plan_t;
 use crate::unicode::{self, combining_class, modified_combining_class, Codepoint};
 
@@ -21,12 +21,7 @@ pub const HEBREW_SHAPER: hb_ot_shaper_t = hb_ot_shaper_t {
     fallback_position: true,
 };
 
-fn reorder_marks_hebrew(
-    _: &hb_ot_shape_plan_t,
-    buffer: &mut hb_buffer_t,
-    start: usize,
-    end: usize,
-) {
+fn reorder_marks_hebrew(_: &hb_ot_shape_plan_t, buffer: &mut Buffer, start: usize, end: usize) {
     for i in start + 2..end {
         let c0 = buffer.info[i - 2];
         let c1 = buffer.info[i - 1];

--- a/harfrust/src/hb/ot_shaper_indic.rs
+++ b/harfrust/src/hb/ot_shaper_indic.rs
@@ -576,7 +576,7 @@ fn override_features(planner: &mut hb_ot_shape_planner_t) {
     planner.ot_map.add_gsub_pause(Some(syllabic_clear_var)); // Don't need syllables anymore.
 }
 
-fn preprocess_text(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
+fn preprocess_text(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     super::ot_shaper_vowel_constraints::preprocess_text_vowel_constraints(buffer);
 }
 
@@ -608,7 +608,7 @@ fn compose(_: &hb_ot_shape_normalize_context_t, a: Codepoint, b: Codepoint) -> O
     crate::unicode::compose(a, b)
 }
 
-fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
+fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     buffer.allocate_var(GlyphInfo::INDIC_CATEGORY_VAR);
     buffer.allocate_var(GlyphInfo::INDIC_POSITION_VAR);
 
@@ -619,11 +619,7 @@ fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut h
     }
 }
 
-fn setup_syllables(
-    _: &hb_ot_shape_plan_t,
-    _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
-) -> bool {
+fn setup_syllables(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_indic_machine::find_syllables_indic(buffer);
@@ -642,7 +638,7 @@ fn setup_syllables(
 fn initial_reordering(
     plan: &hb_ot_shape_plan_t,
     font_funcs: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     use super::ot_shaper_indic_machine::SyllableType;
 
@@ -677,7 +673,7 @@ fn update_consonant_positions(
     plan: &hb_ot_shape_plan_t,
     indic_plan: &IndicShapePlan,
     font_funcs: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     let mut virama_glyph = None;
     if indic_plan.config.virama != 0 {
@@ -763,7 +759,7 @@ fn initial_reordering_syllable(
     font_funcs: &mut FontFuncsDispatch,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     use super::ot_shaper_indic_machine::SyllableType;
 
@@ -798,7 +794,7 @@ fn initial_reordering_consonant_syllable(
     font_funcs: &mut FontFuncsDispatch,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     let face = font_funcs.font();
     // https://github.com/harfbuzz/harfbuzz/issues/435#issuecomment-335560167
@@ -1322,7 +1318,7 @@ fn initial_reordering_standalone_cluster(
     face: &mut FontFuncsDispatch,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     // We treat placeholder/dotted-circle as if they are consonants, so we
     // should just chain.  Only if not in compatibility mode that is...
@@ -1332,7 +1328,7 @@ fn initial_reordering_standalone_cluster(
 fn final_reordering(
     plan: &hb_ot_shape_plan_t,
     face: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     if buffer.is_empty() {
         return false;
@@ -1353,7 +1349,7 @@ fn final_reordering_impl(
     face: &mut FontFuncsDispatch,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     let indic_plan = plan.data::<IndicShapePlan>();
 

--- a/harfrust/src/hb/ot_shaper_indic_machine.rs
+++ b/harfrust/src/hb/ot_shaper_indic_machine.rs
@@ -12,7 +12,7 @@
     clippy::never_loop
 )]
 
-use super::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
+use super::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
 
 static _indic_syllable_machine_trans_keys: [u8; 278] = [
     7, 19, 3, 19, 4, 19, 4, 19, 12, 12, 3, 19, 3, 19, 3, 19, 7, 19, 4, 19, 4, 19, 12, 12, 3, 19, 3,
@@ -201,7 +201,7 @@ pub enum SyllableType {
     NonIndicCluster,
 }
 
-pub fn find_syllables_indic(buffer: &mut hb_buffer_t) {
+pub fn find_syllables_indic(buffer: &mut Buffer) {
     let mut cs = 0;
     let mut ts = 0;
     let mut te = 0;
@@ -489,7 +489,7 @@ fn found_syllable(
     end: usize,
     syllable_serial: &mut u8,
     kind: SyllableType,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     for i in start..end {
         buffer.info[i].set_syllable((*syllable_serial << 4) | kind as u8);

--- a/harfrust/src/hb/ot_shaper_khmer.rs
+++ b/harfrust/src/hb/ot_shaper_khmer.rs
@@ -124,11 +124,7 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 }
 
-fn setup_syllables(
-    _: &hb_ot_shape_plan_t,
-    _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
-) -> bool {
+fn setup_syllables(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_khmer_machine::find_syllables_khmer(buffer);
@@ -147,7 +143,7 @@ fn setup_syllables(
 fn reorder_khmer(
     plan: &hb_ot_shape_plan_t,
     face: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     use super::ot_shaper_khmer_machine::SyllableType;
 
@@ -183,7 +179,7 @@ fn reorder_syllable_khmer(
     khmer_plan: &KhmerShapePlan,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     use super::ot_shaper_khmer_machine::SyllableType;
 
@@ -208,7 +204,7 @@ fn reorder_consonant_syllable(
     plan: &KhmerShapePlan,
     start: usize,
     end: usize,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     // Setup masks.
     {
@@ -307,7 +303,7 @@ fn compose(_: &hb_ot_shape_normalize_context_t, a: Codepoint, b: Codepoint) -> O
     crate::unicode::compose(a, b)
 }
 
-fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
+fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     buffer.allocate_var(GlyphInfo::KHMER_CATEGORY_VAR);
 
     // We cannot setup masks here.  We save information about characters

--- a/harfrust/src/hb/ot_shaper_khmer_machine.rs
+++ b/harfrust/src/hb/ot_shaper_khmer_machine.rs
@@ -13,7 +13,7 @@
     clippy::never_loop
 )]
 
-use super::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
+use super::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
 
 static _khmer_syllable_machine_actions: [i8; 29] = [
     0, 1, 0, 1, 1, 1, 2, 1, 5, 1, 6, 1, 7, 1, 8, 1, 9, 1, 10, 1, 11, 2, 2, 3, 2, 2, 4, 0, 0,
@@ -97,7 +97,7 @@ pub enum SyllableType {
     NonKhmerCluster,
 }
 
-pub fn find_syllables_khmer(buffer: &mut hb_buffer_t) {
+pub fn find_syllables_khmer(buffer: &mut Buffer) {
     let mut cs = 0;
     let mut ts = 0;
     let mut te = 0;
@@ -348,7 +348,7 @@ fn found_syllable(
     end: usize,
     syllable_serial: &mut u8,
     kind: SyllableType,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     for i in start..end {
         buffer.info[i].set_syllable((*syllable_serial << 4) | kind as u8);

--- a/harfrust/src/hb/ot_shaper_myanmar.rs
+++ b/harfrust/src/hb/ot_shaper_myanmar.rs
@@ -116,11 +116,7 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
     }
 }
 
-fn setup_syllables(
-    _: &hb_ot_shape_plan_t,
-    _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
-) -> bool {
+fn setup_syllables(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
     super::ot_shaper_myanmar_machine::find_syllables_myanmar(buffer);
@@ -139,7 +135,7 @@ fn setup_syllables(
 fn reorder_myanmar(
     _: &hb_ot_shape_plan_t,
     face: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     use super::ot_shaper_myanmar_machine::SyllableType;
 
@@ -170,7 +166,7 @@ fn reorder_myanmar(
     ret
 }
 
-fn reorder_syllable_myanmar(start: usize, end: usize, buffer: &mut hb_buffer_t) {
+fn reorder_syllable_myanmar(start: usize, end: usize, buffer: &mut Buffer) {
     use super::ot_shaper_myanmar_machine::SyllableType;
 
     let syllable_type = match buffer.info[start].syllable() & 0x0F {
@@ -192,7 +188,7 @@ fn reorder_syllable_myanmar(start: usize, end: usize, buffer: &mut hb_buffer_t) 
 
 // Rules from:
 // https://docs.microsoft.com/en-us/typography/script-development/myanmar
-fn initial_reordering_consonant_syllable(start: usize, end: usize, buffer: &mut hb_buffer_t) {
+fn initial_reordering_consonant_syllable(start: usize, end: usize, buffer: &mut Buffer) {
     let mut base = end;
     let mut has_reph = false;
 
@@ -330,7 +326,7 @@ fn initial_reordering_consonant_syllable(start: usize, end: usize, buffer: &mut 
     }
 }
 
-fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
+fn setup_masks(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     buffer.allocate_var(GlyphInfo::MYANMAR_CATEGORY_VAR);
     buffer.allocate_var(GlyphInfo::MYANMAR_POSITION_VAR);
 

--- a/harfrust/src/hb/ot_shaper_myanmar_machine.rs
+++ b/harfrust/src/hb/ot_shaper_myanmar_machine.rs
@@ -13,7 +13,7 @@
     clippy::never_loop
 )]
 
-use super::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
+use super::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
 
 static _myanmar_syllable_machine_trans_keys: [u8; 108] = [
     0, 22, 1, 22, 3, 22, 3, 22, 1, 22, 3, 22, 1, 22, 1, 22, 1, 22, 1, 22, 1, 22, 3, 22, 0, 8, 1,
@@ -118,7 +118,7 @@ pub enum SyllableType {
     NonMyanmarCluster,
 }
 
-pub fn find_syllables_myanmar(buffer: &mut hb_buffer_t) {
+pub fn find_syllables_myanmar(buffer: &mut Buffer) {
     let mut cs = 0;
     let mut ts = 0;
     let mut te;
@@ -339,7 +339,7 @@ fn found_syllable(
     end: usize,
     syllable_serial: &mut u8,
     kind: SyllableType,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) {
     for i in start..end {
         buffer.info[i].set_syllable((*syllable_serial << 4) | kind as u8);

--- a/harfrust/src/hb/ot_shaper_syllabic.rs
+++ b/harfrust/src/hb/ot_shaper_syllabic.rs
@@ -6,7 +6,7 @@ use crate::BufferFlags;
 
 pub fn insert_dotted_circles(
     font_funcs: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
     broken_syllable_type: u8,
     dottedcircle_category: u8,
     repha_category: Option<u8>,
@@ -76,7 +76,7 @@ pub fn insert_dotted_circles(
 pub(crate) fn syllabic_clear_var(
     _: &hb_ot_shape_plan_t,
     _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     for info in &mut buffer.info {
         info.set_syllable(0);

--- a/harfrust/src/hb/ot_shaper_thai.rs
+++ b/harfrust/src/hb/ot_shaper_thai.rs
@@ -271,7 +271,7 @@ static BELOW_STATE_MACHINE: &[[BSME; 3]] = &[
     ],
 ];
 
-fn do_pua_shaping(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
+fn do_pua_shaping(face: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     let mut above_state = ABOVE_START_STATE[Consonant::NotConsonant as usize];
     let mut below_state = BELOW_START_STATE[Consonant::NotConsonant as usize];
     let mut base = 0;
@@ -309,11 +309,7 @@ fn do_pua_shaping(face: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
 }
 
 // TODO: more tests
-fn preprocess_text(
-    plan: &hb_ot_shape_plan_t,
-    face: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
-) {
+fn preprocess_text(plan: &hb_ot_shape_plan_t, face: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     // This function implements the shaping logic documented here:
     //
     //   https://linux.thai.net/~thep/th-otf/shaping.html

--- a/harfrust/src/hb/ot_shaper_use.rs
+++ b/harfrust/src/hb/ot_shaper_use.rs
@@ -238,7 +238,7 @@ fn collect_features(planner: &mut hb_ot_shape_planner_t) {
 fn setup_syllables(
     plan: &hb_ot_shape_plan_t,
     _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
+    buffer: &mut Buffer,
 ) -> bool {
     buffer.allocate_var(GlyphInfo::SYLLABLE_VAR);
 
@@ -254,7 +254,7 @@ fn setup_syllables(
     false
 }
 
-fn setup_rphf_mask(plan: &hb_ot_shape_plan_t, buffer: &mut hb_buffer_t) -> bool {
+fn setup_rphf_mask(plan: &hb_ot_shape_plan_t, buffer: &mut Buffer) -> bool {
     let universal_plan = plan.data::<UniversalShapePlan>();
 
     let mask = universal_plan.rphf_mask;
@@ -282,7 +282,7 @@ fn setup_rphf_mask(plan: &hb_ot_shape_plan_t, buffer: &mut hb_buffer_t) -> bool 
     false
 }
 
-fn setup_topographical_masks(plan: &hb_ot_shape_plan_t, buffer: &mut hb_buffer_t) {
+fn setup_topographical_masks(plan: &hb_ot_shape_plan_t, buffer: &mut Buffer) {
     use super::ot_shaper_use_machine::SyllableType;
 
     if plan.data::<UniversalShapePlan>().arabic_plan.is_some() {
@@ -352,11 +352,7 @@ fn setup_topographical_masks(plan: &hb_ot_shape_plan_t, buffer: &mut hb_buffer_t
     }
 }
 
-fn record_rphf(
-    plan: &hb_ot_shape_plan_t,
-    _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
-) -> bool {
+fn record_rphf(plan: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) -> bool {
     let universal_plan = plan.data::<UniversalShapePlan>();
 
     let mask = universal_plan.rphf_mask;
@@ -386,11 +382,7 @@ fn record_rphf(
     false
 }
 
-fn reorder_use(
-    _: &hb_ot_shape_plan_t,
-    font: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
-) -> bool {
+fn reorder_use(_: &hb_ot_shape_plan_t, font: &mut FontFuncsDispatch, buffer: &mut Buffer) -> bool {
     use super::ot_shaper_use_machine::SyllableType;
 
     let mut ret = false;
@@ -446,7 +438,7 @@ const POST_BASE_FLAGS: u64 = category_flag64(category::FAbv)
     | category_flag64(category::VMPst)
     | category_flag64(category::VMPre);
 
-fn reorder_syllable_use(start: usize, end: usize, buffer: &mut hb_buffer_t) {
+fn reorder_syllable_use(start: usize, end: usize, buffer: &mut Buffer) {
     use super::ot_shaper_use_machine::SyllableType;
 
     let syllable_type = (buffer.info[start].syllable() & 0x0F) as u32;
@@ -514,11 +506,7 @@ fn reorder_syllable_use(start: usize, end: usize, buffer: &mut hb_buffer_t) {
     }
 }
 
-fn record_pref(
-    _: &hb_ot_shape_plan_t,
-    _: &mut FontFuncsDispatch,
-    buffer: &mut hb_buffer_t,
-) -> bool {
+fn record_pref(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) -> bool {
     let mut start = 0;
     let mut end = buffer.next_syllable(0);
     while start < buffer.len {
@@ -557,7 +545,7 @@ fn has_arabic_joining(script: Script) -> bool {
     )
 }
 
-fn preprocess_text(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
+fn preprocess_text(_: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     super::ot_shaper_vowel_constraints::preprocess_text_vowel_constraints(buffer);
 }
 
@@ -570,7 +558,7 @@ fn compose(_: &hb_ot_shape_normalize_context_t, a: Codepoint, b: Codepoint) -> O
     crate::unicode::compose(a, b)
 }
 
-fn setup_masks(plan: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut hb_buffer_t) {
+fn setup_masks(plan: &hb_ot_shape_plan_t, _: &mut FontFuncsDispatch, buffer: &mut Buffer) {
     let universal_plan = plan.data::<UniversalShapePlan>();
 
     // Do this before allocating use_category().

--- a/harfrust/src/hb/ot_shaper_use_machine.rs
+++ b/harfrust/src/hb/ot_shaper_use_machine.rs
@@ -15,7 +15,7 @@
 
 use core::cell::Cell;
 
-use super::buffer::{hb_buffer_t, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
+use super::buffer::{Buffer, HB_BUFFER_SCRATCH_FLAG_HAS_BROKEN_SYLLABLE};
 use super::machine_cursor::MachineCursor;
 use super::ot_shaper_use::category;
 use super::GlyphInfo;
@@ -265,7 +265,7 @@ pub enum SyllableType {
     NonCluster,
 }
 
-pub fn find_syllables(buffer: &mut hb_buffer_t) {
+pub fn find_syllables(buffer: &mut Buffer) {
     let mut cs = 0;
     let infos = Cell::as_slice_of_cells(Cell::from_mut(&mut buffer.info));
     let p0 = MachineCursor::new(infos, included);

--- a/harfrust/src/hb/ot_shaper_vowel_constraints.rs
+++ b/harfrust/src/hb/ot_shaper_vowel_constraints.rs
@@ -3,11 +3,11 @@
 
 #![allow(clippy::single_match)]
 
-use super::buffer::hb_buffer_t;
+use super::buffer::Buffer;
 use super::script;
 use crate::BufferFlags;
 
-fn output_dotted_circle(buffer: &mut hb_buffer_t) {
+fn output_dotted_circle(buffer: &mut Buffer) {
     buffer.output_glyph(0x25CC);
     {
         let out_idx = buffer.out_len - 1;
@@ -15,12 +15,12 @@ fn output_dotted_circle(buffer: &mut hb_buffer_t) {
     }
 }
 
-fn output_with_dotted_circle(buffer: &mut hb_buffer_t) {
+fn output_with_dotted_circle(buffer: &mut Buffer) {
     output_dotted_circle(buffer);
     buffer.next_glyph();
 }
 
-pub fn preprocess_text_vowel_constraints(buffer: &mut hb_buffer_t) {
+pub fn preprocess_text_vowel_constraints(buffer: &mut Buffer) {
     if buffer
         .flags
         .contains(BufferFlags::DO_NOT_INSERT_DOTTED_CIRCLE)

--- a/harfrust/src/lib.rs
+++ b/harfrust/src/lib.rs
@@ -45,7 +45,10 @@ pub mod font {
     pub(crate) use read_fonts::model::*;
 }
 
-pub use hb::buffer::{GlyphBuffer, GlyphFlags, GlyphInfo, GlyphPosition, UnicodeBuffer};
+pub use hb::buffer::{
+    Buffer, BufferContentType, GlyphBuffer, GlyphFlags, GlyphInfo, GlyphPosition, UnicodeBuffer,
+    WrongContentType,
+};
 pub use hb::common::{script, Direction, Feature, Language, Script, Variation};
 pub use hb::face::{
     hb_font_t as Shaper, GlyphExtents, ShapeOptions, ShaperBuilder, ShaperData, ShaperInstance,

--- a/harfrust/src/lib.rs
+++ b/harfrust/src/lib.rs
@@ -46,8 +46,8 @@ pub mod font {
 }
 
 pub use hb::buffer::{
-    Buffer, BufferContentType, GlyphBuffer, GlyphFlags, GlyphInfo, GlyphPosition, UnicodeBuffer,
-    WrongContentType,
+    Buffer, BufferContentType, GlyphBuffer, GlyphFlags, GlyphInfo, GlyphPosition, ShapeError,
+    UnicodeBuffer, WrongContentType,
 };
 pub use hb::common::{script, Direction, Feature, Language, Script, Variation};
 pub use hb::face::{

--- a/harfrust/tests/buffer.rs
+++ b/harfrust/tests/buffer.rs
@@ -6,7 +6,8 @@ use std::path::PathBuf;
 
 use harfrust::{
     font::{Font, FontInstance},
-    shape, Buffer, BufferContentType, Direction, GlyphBuffer, ShapeOptions, UnicodeBuffer,
+    shape, Buffer, BufferContentType, Direction, GlyphBuffer, ShapeError, ShapeOptions,
+    UnicodeBuffer,
 };
 
 fn test_instance() -> FontInstance {
@@ -95,21 +96,151 @@ fn glyph_positions_mut_allocates_on_demand() {
 fn shaping_sets_glyphs_content_type() {
     let instance = test_instance();
     let mut buffer = unicode_buffer(TEXT);
-    buffer.shape(&instance, ShapeOptions::new());
+    buffer.shape(&instance, ShapeOptions::new()).unwrap();
     assert_eq!(buffer.content_type(), Some(BufferContentType::Glyphs));
     assert!(!buffer.is_empty());
     assert_eq!(buffer.glyph_positions().len(), buffer.len());
 }
 
 #[test]
-fn shaping_a_shaped_buffer_is_a_noop() {
+fn shaping_a_shaped_buffer_is_refused() {
     let instance = test_instance();
     let mut buffer = unicode_buffer(TEXT);
-    buffer.shape(&instance, ShapeOptions::new());
+    buffer.shape(&instance, ShapeOptions::new()).unwrap();
     let once = ids_and_clusters(buffer.glyph_infos());
 
-    buffer.shape(&instance, ShapeOptions::new());
-    assert_eq!(ids_and_clusters(buffer.glyph_infos()), once);
+    // Shaping glyphs as though they were text would be nonsense, so it is
+    // reported rather than quietly ignored.
+    assert_eq!(
+        buffer.shape(&instance, ShapeOptions::new()),
+        Err(ShapeError::AlreadyShaped)
+    );
+    assert_eq!(
+        ids_and_clusters(buffer.glyph_infos()),
+        once,
+        "a refused call must leave the buffer alone"
+    );
+
+    // Relabelling the contents is how you ask for them to be shaped again.
+    buffer.set_content_type(Some(BufferContentType::Unicode));
+    assert!(buffer.shape(&instance, ShapeOptions::new()).is_ok());
+}
+
+#[test]
+fn shaping_without_a_direction_is_refused() {
+    let instance = test_instance();
+    let mut buffer = Buffer::new();
+    buffer.push_str(TEXT);
+    // No direction, and none guessed.
+    assert_eq!(buffer.direction(), Direction::Invalid);
+    assert_eq!(
+        buffer.shape(&instance, ShapeOptions::new()),
+        Err(ShapeError::DirectionUnset)
+    );
+    assert_eq!(
+        buffer.content_type(),
+        Some(BufferContentType::Unicode),
+        "a refused call must leave the buffer alone"
+    );
+
+    buffer.guess_segment_properties();
+    assert!(buffer.shape(&instance, ShapeOptions::new()).is_ok());
+}
+
+#[test]
+fn shaping_with_a_mismatched_plan_is_refused() {
+    use harfrust::{script, ShapePlan};
+
+    let instance = test_instance();
+    let plan = ShapePlan::new(
+        &instance,
+        Direction::RightToLeft,
+        Some(script::ARABIC),
+        None,
+        &[],
+    );
+
+    let mut buffer = unicode_buffer(TEXT);
+    let before = ids_and_clusters(buffer.glyph_infos());
+    let err = buffer
+        .shape(&instance, ShapeOptions::new().plan(Some(&plan)))
+        .unwrap_err();
+    // The direction is checked first.
+    assert_eq!(
+        err,
+        ShapeError::DirectionMismatch {
+            plan: Direction::RightToLeft,
+            buffer: Direction::LeftToRight,
+        }
+    );
+    assert_eq!(
+        ids_and_clusters(buffer.glyph_infos()),
+        before,
+        "a refused call must leave the buffer alone"
+    );
+    assert_eq!(buffer.content_type(), Some(BufferContentType::Unicode));
+
+    // With the direction agreed, the script is checked next.
+    let plan = ShapePlan::new(
+        &instance,
+        Direction::LeftToRight,
+        Some(script::ARABIC),
+        None,
+        &[],
+    );
+    let err = buffer
+        .shape(&instance, ShapeOptions::new().plan(Some(&plan)))
+        .unwrap_err();
+    assert_eq!(
+        err,
+        ShapeError::ScriptMismatch {
+            plan: script::ARABIC,
+            buffer: script::LATIN,
+        }
+    );
+}
+
+#[test]
+fn a_matching_plan_shapes() {
+    use harfrust::{script, ShapePlan};
+
+    let instance = test_instance();
+    let plan = ShapePlan::new(
+        &instance,
+        Direction::LeftToRight,
+        Some(script::LATIN),
+        None,
+        &[],
+    );
+
+    let mut planned = unicode_buffer(TEXT);
+    planned
+        .shape(&instance, ShapeOptions::new().plan(Some(&plan)))
+        .unwrap();
+
+    let mut direct = unicode_buffer(TEXT);
+    direct.shape(&instance, ShapeOptions::new()).unwrap();
+
+    assert_eq!(
+        ids_and_clusters(planned.glyph_infos()),
+        ids_and_clusters(direct.glyph_infos())
+    );
+}
+
+#[test]
+fn shape_errors_describe_themselves() {
+    assert_eq!(
+        ShapeError::AlreadyShaped.to_string(),
+        "buffer already holds shaped glyphs"
+    );
+    assert_eq!(
+        ShapeError::DirectionMismatch {
+            plan: Direction::RightToLeft,
+            buffer: Direction::LeftToRight,
+        }
+        .to_string(),
+        "buffer direction does not match plan direction: LeftToRight != RightToLeft"
+    );
 }
 
 #[test]
@@ -122,7 +253,7 @@ fn buffer_matches_typed_buffer_shaping() {
     let typed = shape(&instance, typed, ShapeOptions::new());
 
     let mut unified = unicode_buffer(TEXT);
-    unified.shape(&instance, ShapeOptions::new());
+    unified.shape(&instance, ShapeOptions::new()).unwrap();
 
     assert_eq!(
         ids_and_clusters(typed.glyph_infos()),
@@ -173,7 +304,7 @@ fn conversions_reject_mismatched_content() {
 
     // A shaped buffer is not a UnicodeBuffer.
     let mut buffer = unicode_buffer(TEXT);
-    buffer.shape(&instance, ShapeOptions::new());
+    buffer.shape(&instance, ShapeOptions::new()).unwrap();
     let err = UnicodeBuffer::try_from(buffer).unwrap_err();
     assert_eq!(err.found, Some(BufferContentType::Glyphs));
     assert_eq!(err.expected, BufferContentType::Unicode);

--- a/harfrust/tests/buffer.rs
+++ b/harfrust/tests/buffer.rs
@@ -100,6 +100,8 @@ fn shaping_sets_glyphs_content_type() {
     assert_eq!(buffer.content_type(), Some(BufferContentType::Glyphs));
     assert!(!buffer.is_empty());
     assert_eq!(buffer.glyph_positions().len(), buffer.len());
+    // Running out of room is reported here rather than as a `ShapeError`.
+    assert!(buffer.allocation_successful());
 }
 
 #[test]

--- a/harfrust/tests/buffer.rs
+++ b/harfrust/tests/buffer.rs
@@ -1,0 +1,281 @@
+//! Tests for the unified [`Buffer`] type and its conversions to and from the
+//! typed [`UnicodeBuffer`] / [`GlyphBuffer`] pair.
+
+use std::fs;
+use std::path::PathBuf;
+
+use harfrust::{
+    font::{Font, FontInstance},
+    shape, Buffer, BufferContentType, Direction, GlyphBuffer, ShapeOptions, UnicodeBuffer,
+};
+
+fn test_instance() -> FontInstance {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fonts")
+        .join("rb_custom")
+        .join("OpenSans.subset1.ttf");
+    let data = fs::read(path).expect("failed to read test font");
+    let font = Font::new(data, 0).expect("failed to parse test font");
+    FontInstance::builder(&font).build()
+}
+
+fn ids_and_clusters(infos: &[harfrust::GlyphInfo]) -> Vec<(u32, u32)> {
+    infos.iter().map(|i| (i.glyph_id, i.cluster)).collect()
+}
+
+fn advances(positions: &[harfrust::GlyphPosition]) -> Vec<(i32, i32, i32, i32)> {
+    positions
+        .iter()
+        .map(|p| (p.x_advance, p.y_advance, p.x_offset, p.y_offset))
+        .collect()
+}
+
+const TEXT: &str = "Hello, world!";
+
+fn unicode_buffer(text: &str) -> Buffer {
+    let mut buffer = Buffer::new();
+    buffer.push_str(text);
+    buffer.guess_segment_properties();
+    buffer
+}
+
+#[test]
+fn new_buffer_has_no_content_type() {
+    let buffer = Buffer::new();
+    assert_eq!(buffer.content_type(), None);
+    assert!(buffer.is_empty());
+    assert_eq!(buffer.len(), 0);
+}
+
+#[test]
+fn adding_text_sets_unicode_content_type() {
+    let mut buffer = Buffer::new();
+    buffer.push_str(TEXT);
+    assert_eq!(buffer.content_type(), Some(BufferContentType::Unicode));
+    assert_eq!(buffer.len(), TEXT.chars().count());
+
+    let mut buffer = Buffer::new();
+    buffer.push('x' as u32, 0);
+    assert_eq!(buffer.content_type(), Some(BufferContentType::Unicode));
+
+    let mut buffer = Buffer::new();
+    buffer.push_codepoints(&['a' as u32, 'b' as u32]);
+    assert_eq!(buffer.content_type(), Some(BufferContentType::Unicode));
+    assert_eq!(buffer.len(), 2);
+}
+
+#[test]
+fn glyph_infos_readable_before_shaping() {
+    let mut buffer = Buffer::new();
+    buffer.push_str(TEXT);
+    // Before shaping, `glyph_id` holds the input codepoint.
+    let codepoints: Vec<u32> = buffer.glyph_infos().iter().map(|i| i.glyph_id).collect();
+    assert_eq!(
+        codepoints,
+        TEXT.chars().map(|c| c as u32).collect::<Vec<_>>()
+    );
+    // ... and no positions have been allocated yet.
+    assert!(buffer.glyph_positions().is_empty());
+}
+
+#[test]
+fn glyph_positions_mut_allocates_on_demand() {
+    let mut buffer = Buffer::new();
+    buffer.push_str(TEXT);
+    assert!(buffer.glyph_positions().is_empty());
+    let positions = buffer.glyph_positions_mut();
+    assert_eq!(positions.len(), TEXT.chars().count());
+    assert!(positions
+        .iter()
+        .all(|p| p.x_advance == 0 && p.y_advance == 0));
+}
+
+#[test]
+fn shaping_sets_glyphs_content_type() {
+    let instance = test_instance();
+    let mut buffer = unicode_buffer(TEXT);
+    buffer.shape(&instance, ShapeOptions::new());
+    assert_eq!(buffer.content_type(), Some(BufferContentType::Glyphs));
+    assert!(!buffer.is_empty());
+    assert_eq!(buffer.glyph_positions().len(), buffer.len());
+}
+
+#[test]
+fn shaping_a_shaped_buffer_is_a_noop() {
+    let instance = test_instance();
+    let mut buffer = unicode_buffer(TEXT);
+    buffer.shape(&instance, ShapeOptions::new());
+    let once = ids_and_clusters(buffer.glyph_infos());
+
+    buffer.shape(&instance, ShapeOptions::new());
+    assert_eq!(ids_and_clusters(buffer.glyph_infos()), once);
+}
+
+#[test]
+fn buffer_matches_typed_buffer_shaping() {
+    let instance = test_instance();
+
+    let mut typed = UnicodeBuffer::new();
+    typed.push_str(TEXT);
+    typed.guess_segment_properties();
+    let typed = shape(&instance, typed, ShapeOptions::new());
+
+    let mut unified = unicode_buffer(TEXT);
+    unified.shape(&instance, ShapeOptions::new());
+
+    assert_eq!(
+        ids_and_clusters(typed.glyph_infos()),
+        ids_and_clusters(unified.glyph_infos())
+    );
+    assert_eq!(
+        advances(typed.glyph_positions()),
+        advances(unified.glyph_positions())
+    );
+}
+
+#[test]
+fn round_trip_through_unicode_buffer() {
+    let mut typed = UnicodeBuffer::new();
+    typed.push_str(TEXT);
+    typed.set_direction(Direction::LeftToRight);
+
+    let unified = Buffer::from(typed);
+    assert_eq!(unified.content_type(), Some(BufferContentType::Unicode));
+    assert_eq!(unified.direction(), Direction::LeftToRight);
+    assert_eq!(unified.len(), TEXT.chars().count());
+
+    let back = UnicodeBuffer::try_from(unified).expect("unicode content should convert back");
+    assert_eq!(back.len(), TEXT.chars().count());
+    assert_eq!(back.direction(), Direction::LeftToRight);
+}
+
+#[test]
+fn round_trip_through_glyph_buffer() {
+    let instance = test_instance();
+    let mut typed = UnicodeBuffer::new();
+    typed.push_str(TEXT);
+    typed.guess_segment_properties();
+    let shaped = shape(&instance, typed, ShapeOptions::new());
+    let expected = ids_and_clusters(shaped.glyph_infos());
+
+    let unified = Buffer::from(shaped);
+    assert_eq!(unified.content_type(), Some(BufferContentType::Glyphs));
+    assert_eq!(ids_and_clusters(unified.glyph_infos()), expected);
+
+    let back = GlyphBuffer::try_from(unified).expect("glyph content should convert back");
+    assert_eq!(ids_and_clusters(back.glyph_infos()), expected);
+}
+
+#[test]
+fn conversions_reject_mismatched_content() {
+    let instance = test_instance();
+
+    // A shaped buffer is not a UnicodeBuffer.
+    let mut buffer = unicode_buffer(TEXT);
+    buffer.shape(&instance, ShapeOptions::new());
+    let err = UnicodeBuffer::try_from(buffer).unwrap_err();
+    assert_eq!(err.found, Some(BufferContentType::Glyphs));
+    assert_eq!(err.expected, BufferContentType::Unicode);
+
+    // ... and an unshaped one is not a GlyphBuffer.
+    let mut buffer = Buffer::new();
+    buffer.push_str(TEXT);
+    let err = GlyphBuffer::try_from(buffer).unwrap_err();
+    assert_eq!(err.found, Some(BufferContentType::Unicode));
+    assert_eq!(err.expected, BufferContentType::Glyphs);
+}
+
+#[test]
+fn empty_buffer_converts_either_way() {
+    // With no content type set, an empty buffer is still valid input.
+    assert!(UnicodeBuffer::try_from(Buffer::new()).is_ok());
+    assert!(GlyphBuffer::try_from(Buffer::new()).is_err());
+}
+
+#[test]
+fn clear_resets_content_type() {
+    let mut buffer = Buffer::new();
+    buffer.push_str(TEXT);
+    assert_eq!(buffer.content_type(), Some(BufferContentType::Unicode));
+    buffer.clear();
+    assert_eq!(buffer.content_type(), None);
+    assert!(buffer.is_empty());
+}
+
+#[test]
+fn reset_restores_defaults() {
+    let mut buffer = Buffer::new();
+    buffer.push_str(TEXT);
+    buffer.set_direction(Direction::RightToLeft);
+    buffer.set_cluster_level(harfrust::BufferClusterLevel::Characters);
+    buffer.set_flags(harfrust::BufferFlags::BEGINNING_OF_TEXT);
+
+    buffer.reset();
+    assert_eq!(buffer.content_type(), None);
+    assert_eq!(buffer.direction(), Direction::Invalid);
+    assert_eq!(
+        buffer.cluster_level(),
+        harfrust::BufferClusterLevel::MonotoneGraphemes
+    );
+    assert_eq!(buffer.flags().bits(), harfrust::BufferFlags::empty().bits());
+}
+
+#[test]
+fn set_length_grows_and_truncates() {
+    let mut buffer = Buffer::new();
+    buffer.push_str(TEXT);
+    let original = buffer.len();
+
+    assert!(buffer.set_length(original + 3));
+    assert_eq!(buffer.len(), original + 3);
+    assert!(buffer.glyph_infos()[original..]
+        .iter()
+        .all(|i| i.glyph_id == 0));
+
+    assert!(buffer.set_length(2));
+    assert_eq!(buffer.len(), 2);
+}
+
+#[test]
+fn reverse_and_reverse_clusters() {
+    let mut buffer = Buffer::new();
+    // Two clusters of two items each.
+    buffer.push('a' as u32, 0);
+    buffer.push('b' as u32, 0);
+    buffer.push('c' as u32, 1);
+    buffer.push('d' as u32, 1);
+
+    let mut reversed = Buffer::new();
+    reversed.push_glyph_infos(buffer.glyph_infos());
+    reversed.reverse();
+    let codepoints: Vec<u32> = reversed.glyph_infos().iter().map(|i| i.glyph_id).collect();
+    assert_eq!(
+        codepoints,
+        vec!['d' as u32, 'c' as u32, 'b' as u32, 'a' as u32]
+    );
+
+    // Reversing by cluster keeps each cluster's items in their original order.
+    buffer.reverse_clusters();
+    let codepoints: Vec<u32> = buffer.glyph_infos().iter().map(|i| i.glyph_id).collect();
+    assert_eq!(
+        codepoints,
+        vec!['c' as u32, 'd' as u32, 'a' as u32, 'b' as u32]
+    );
+}
+
+#[test]
+fn properties_round_trip() {
+    let mut buffer = Buffer::new();
+    buffer.set_direction(Direction::RightToLeft);
+    buffer.set_script(harfrust::script::ARABIC);
+    buffer.set_language(harfrust::Language::new("ar").unwrap());
+    buffer.set_invisible_glyph(Some(harfrust::GlyphId::new(3)));
+    buffer.set_not_found_variation_selector_glyph(Some(7));
+
+    assert_eq!(buffer.direction(), Direction::RightToLeft);
+    assert_eq!(buffer.script(), harfrust::script::ARABIC);
+    assert_eq!(buffer.language().unwrap().as_str(), "ar");
+    assert_eq!(buffer.invisible_glyph(), Some(harfrust::GlyphId::new(3)));
+    assert_eq!(buffer.not_found_variation_selector_glyph(), Some(7));
+}


### PR DESCRIPTION
Apologies for the churn. The only files actually modified are buffer.rs, face.rs and the new buffer tests. The remainder are just fallout from renaming the buffer type for public exposure.

Renames the internal `hb_buffer_t` to `Buffer` and exposes it, matching HarfBuzz's `hb_buffer_t`. Every internal method and field drops to `pub(crate)`, and the public surface is the set of operations HarfBuzz's hb-buffer.h offers.

`Buffer` carries a `BufferContentType` recording whether it holds input characters or the glyphs produced by shaping. Shaping sets it to `Glyphs`, and shaping a buffer that already holds glyphs is a no-op. This makes the buffer usable across the whole shaping cycle from a single type, which the typed pair cannot express: notably, glyph infos are now readable before shaping, and the segment properties remain readable after it.

`UnicodeBuffer` and `GlyphBuffer` are unchanged. They convert into `Buffer` infallibly, and back out through `TryFrom`, which fails with `WrongContentType` when the buffer holds the other kind of content.