### PR TITLE
Add hegel property tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /Cargo.lock
 benches/Cargo.lock
 /.cargo
+# hegeltest's saved failing inputs
 .hegel/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /Cargo.lock
 benches/Cargo.lock
 /.cargo
+.hegel/

--- a/harfrust/Cargo.toml
+++ b/harfrust/Cargo.toml
@@ -33,6 +33,7 @@ harfrust = { path = "../harfrust", features = ["experimental_font_api"] }
 criterion = "0.8.0"
 harfbuzz_rs = { git = "https://github.com/harfbuzz/harfbuzz_rs/", rev = "66dae27" }
 hr-shape = { path = "../hr-shape" }
+hegeltest = "0.35.0"
 
 [target.'cfg(target_vendor = "apple")'.dev-dependencies]
 objc2-core-text = { version = "0.3.1", default-features = false, features = [

--- a/harfrust/Cargo.toml
+++ b/harfrust/Cargo.toml
@@ -33,7 +33,9 @@ harfrust = { path = "../harfrust", features = ["experimental_font_api"] }
 criterion = "0.8.0"
 harfbuzz_rs = { git = "https://github.com/harfbuzz/harfbuzz_rs/", rev = "66dae27" }
 hr-shape = { path = "../hr-shape" }
-hegeltest = "0.35.0"
+# Property-based testing library. A `#[hegel::test]` function runs many times
+# over inputs drawn inside its body and reports a shrunk failing input.
+hegel = { package = "hegeltest", version = "0.35.0" }
 
 [target.'cfg(target_vendor = "apple")'.dev-dependencies]
 objc2-core-text = { version = "0.3.1", default-features = false, features = [

--- a/harfrust/src/hb/cache.rs
+++ b/harfrust/src/hb/cache.rs
@@ -144,3 +144,126 @@ impl<const KEY_BITS: usize, const VALUE_BITS: usize, const CACHE_SIZE: usize, T:
         self.values[index].set(packed);
     }
 }
+
+/// Gated on `std` because `#[hegel::test]`'s generated code uses the std
+/// prelude.
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use hegel::generators;
+    use hegel::TestCase;
+    use std::collections::HashMap;
+
+    /// The instantiation `Charmap` uses: 21-bit keys (a Unicode scalar value),
+    /// 19-bit values (a glyph id), 256 slots of `u32`.
+    type Cache = hb_cache_t<21, 19, 256, 32>;
+
+    const KEY_BITS: u32 = 21;
+    const VALUE_BITS: u32 = 19;
+
+    /// Keys are drawn from a narrow band as well as the whole 21-bit space so
+    /// that slot collisions and repeats actually happen: the slot is the key's
+    /// low 8 bits, so keys 256 apart share one.
+    fn draw_key(tc: &TestCase) -> u32 {
+        tc.draw(hegel::one_of!(
+            generators::integers::<u32>().max_value(600),
+            generators::integers::<u32>().max_value((1 << KEY_BITS) - 1),
+            generators::sampled_from(vec![0, 255, 256, 511, (1 << KEY_BITS) - 1]),
+        ))
+    }
+
+    fn draw_value(tc: &TestCase) -> u32 {
+        tc.draw(hegel::one_of!(
+            generators::integers::<u32>().max_value(600),
+            generators::integers::<u32>().max_value((1 << VALUE_BITS) - 1),
+        ))
+    }
+
+    struct CacheModel {
+        cache: Cache,
+        /// The last value successfully written for each key.
+        written: HashMap<u32, u32>,
+    }
+
+    impl CacheModel {
+        /// A hit has to carry the last value written for that key; a miss is
+        /// always allowed, since a later key sharing the slot evicts an
+        /// earlier one.
+        fn check(&self, key: u32) {
+            let cached = self.cache.get(key);
+            match (cached, self.written.get(&key)) {
+                (None, _) => {}
+                (Some(cached), Some(written)) => assert_eq!(
+                    cached, *written,
+                    "{key} was last written as {written}, read back as {cached}"
+                ),
+                (Some(cached), None) => {
+                    panic!("{key} was never written, read back as {cached}")
+                }
+            }
+        }
+    }
+
+    #[hegel::state_machine]
+    impl CacheModel {
+        #[rule]
+        fn set(&mut self, tc: TestCase) {
+            let key = draw_key(&tc);
+            let value = draw_value(&tc);
+            self.cache.set(key, value);
+            self.written.insert(key, value);
+            self.check(key);
+        }
+
+        /// `set` drops keys and values that do not fit their bit widths.
+        #[rule]
+        fn set_out_of_range(&mut self, tc: TestCase) {
+            let key = draw_key(&tc);
+            let (key, value) = if tc.draw(generators::booleans()) {
+                (
+                    key | (1 << KEY_BITS),
+                    tc.draw(generators::integers::<u32>().max_value((1 << VALUE_BITS) - 1)),
+                )
+            } else {
+                (key, draw_value(&tc) | (1 << VALUE_BITS))
+            };
+
+            let before = self.cache.get(key);
+            self.cache.set(key, value);
+            assert_eq!(self.cache.get(key), before, "{key} => {value} was refused");
+        }
+
+        #[rule]
+        fn get(&mut self, tc: TestCase) {
+            let key = draw_key(&tc);
+            self.check(key);
+        }
+
+        #[invariant]
+        fn every_hit_is_the_last_value_written(&self, _: TestCase) {
+            for key in self.written.keys() {
+                self.check(*key);
+            }
+        }
+    }
+
+    /// Property: reading the cache never produces a value other than the last
+    /// one written for that key.
+    ///
+    /// The slot is the key's low `log2(CACHE_SIZE)` bits and the rest of the
+    /// key is stored as a tag beside the value, so a key that shares a slot
+    /// with another has to miss rather than return the other's value. The one
+    /// hit the implementation gives up is the largest key with the largest
+    /// value, whose packed form equals the empty-slot sentinel; a miss is
+    /// always allowed, so the property covers that too.
+    #[hegel::test]
+    fn a_cache_hit_carries_the_last_value_written(tc: TestCase) {
+        hegel::stateful::run(
+            CacheModel {
+                cache: Cache::new(),
+                written: HashMap::new(),
+            },
+            tc,
+        );
+    }
+}

--- a/harfrust/src/hb/charmap.rs
+++ b/harfrust/src/hb/charmap.rs
@@ -173,4 +173,60 @@ mod tests {
             Some(GlyphId::new(65))
         );
     }
+
+    /// KNOWN FAILURE: a cmap entry that resolves to glyph 0 is reported as a
+    /// hit rather than a miss.
+    ///
+    /// Every one of HarfBuzz's `CmapSubtable*::get_glyph` implementations ends
+    /// with `if (unlikely (!gid)) return false`, so "the cmap maps this
+    /// codepoint to .notdef" and "the cmap does not map this codepoint" are
+    /// the same answer there. HarfRust takes whatever `read-fonts` returns,
+    /// and `Cmap0::map_codepoint` hands back `Some(GlyphId::new(0))` for an
+    /// entry of 0. Callers that ask "does the font have this glyph" then get
+    /// the wrong answer: normalisation composes sequences the font cannot
+    /// draw, `hide_default_ignorables` keeps glyphs HarfBuzz drops, and the
+    /// Arabic fallback synthesises lookups over glyph 0.
+    ///
+    /// `unicode_to_macroman` above reaches the same place a second way: it
+    /// returns 0 for a codepoint outside Mac Roman, and that 0 is then looked
+    /// up as a codepoint.
+    ///
+    /// `TestCMAPMacTurkish.ttf` shows it through the public API. It carries
+    /// only a Mac Roman cmap, so shaping five Arabic letters gives one glyph
+    /// in HarfRust and five in HarfBuzz: every letter maps to glyph 0, and the
+    /// Arabic fallback ligates the run.
+    #[test]
+    #[ignore = "cmap hits on glyph 0 are not treated as misses"]
+    fn a_cmap_entry_of_glyph_zero_is_a_miss() {
+        let fonts: [(&str, &[u8]); 2] = [
+            (
+                "TestCMAPMacTurkish.ttf",
+                include_bytes!("../../tests/fonts/text-rendering-tests/TestCMAPMacTurkish.ttf"),
+            ),
+            (
+                "cmap0_font1.otf",
+                include_bytes!("../../tests/fonts/aots/cmap0_font1.otf"),
+            ),
+        ];
+        let charmaps: Vec<(&str, Charmap)> = fonts
+            .iter()
+            .map(|(name, bytes)| {
+                let font = FontRef::new(bytes).unwrap();
+                let ranges = TableRanges::new(&font);
+                (*name, Charmap::new(&font, &ranges))
+            })
+            .collect();
+
+        hegel::Hegel::new(|tc| {
+            let index = tc.draw(hegel::generators::integers::<usize>().max_value(1));
+            let codepoint = tc.draw(hegel::generators::integers::<u32>().max_value(0x10_FFFF));
+            let (name, charmap) = &charmaps[index];
+            assert_ne!(
+                charmap.map(codepoint),
+                Some(GlyphId::new(0)),
+                "{name} maps U+{codepoint:04X} to .notdef"
+            );
+        })
+        .run();
+    }
 }

--- a/harfrust/src/hb/common.rs
+++ b/harfrust/src/hb/common.rs
@@ -931,3 +931,304 @@ impl TagExt for Tag {
         ])
     }
 }
+
+/// Gated on `std` because `#[hegel::test]`'s generated code uses the std
+/// prelude.
+#[cfg(all(test, feature = "std"))]
+mod properties {
+    use super::*;
+    use hegel::generators::{self, Generator};
+
+    /// The four shapes the `[..]` part of a feature spec can take, plus its
+    /// absence.
+    #[derive(Debug, Clone, Copy)]
+    enum Range {
+        None,
+        Empty,
+        Colon,
+        Start(i32),
+        StartEnd(i32, i32),
+        StartOpen(i32),
+        OpenEnd(i32),
+    }
+
+    /// The three shapes the `=..` part of a feature spec can take, plus its
+    /// absence.
+    #[derive(Debug, Clone, Copy)]
+    enum Value {
+        None,
+        Int(i32),
+        Bool(bool),
+    }
+
+    fn draw_tag_text(tc: &hegel::TestCase) -> String {
+        tc.draw(generators::from_regex(r"[A-Za-z0-9_]{4}"))
+    }
+
+    fn draw_index(tc: &hegel::TestCase) -> i32 {
+        tc.draw(hegel::one_of!(
+            generators::integers::<i32>().min_value(0).max_value(16),
+            generators::integers::<i32>(),
+        ))
+    }
+
+    /// Property: `Feature::from_str` reads back every field of a spec string
+    /// built from the documented grammar.
+    ///
+    /// The expected tag, value and range come from the table in
+    /// `Feature::from_str`'s own documentation; `tests_features` pins one
+    /// example of each row.
+    #[hegel::test]
+    fn feature_from_str_reads_back_a_constructed_spec(tc: hegel::TestCase) {
+        let tag = draw_tag_text(&tc);
+        let sign = tc.draw(generators::sampled_from(vec!["", "+", "-"]));
+        let range = tc.draw(
+            hegel::one_of!(
+                generators::just(Range::None),
+                generators::just(Range::Empty),
+                generators::just(Range::Colon),
+                hegel::compose!(|tc| { Range::Start(draw_index(tc)) }),
+                hegel::compose!(|tc| { Range::StartEnd(draw_index(tc), draw_index(tc)) }),
+                hegel::compose!(|tc| { Range::StartOpen(draw_index(tc)) }),
+                hegel::compose!(|tc| { Range::OpenEnd(draw_index(tc)) }),
+            )
+            .print_as_debug(),
+        );
+        let value = tc.draw(
+            hegel::one_of!(
+                generators::just(Value::None),
+                hegel::compose!(|tc| { Value::Int(draw_index(tc)) }),
+                hegel::compose!(|tc| { Value::Bool(tc.draw(generators::booleans())) }),
+            )
+            .print_as_debug(),
+        );
+
+        let range_text = match range {
+            Range::None => String::new(),
+            Range::Empty => "[]".into(),
+            Range::Colon => "[:]".into(),
+            Range::Start(start) => format!("[{start}]"),
+            Range::StartEnd(start, end) => format!("[{start}:{end}]"),
+            Range::StartOpen(start) => format!("[{start}:]"),
+            Range::OpenEnd(end) => format!("[:{end}]"),
+        };
+        let value_text = match value {
+            Value::None => String::new(),
+            Value::Int(v) => format!("={v}"),
+            Value::Bool(true) => "=on".into(),
+            Value::Bool(false) => "=off".into(),
+        };
+        let spec = format!("{sign}{tag}{range_text}{value_text}");
+
+        let parsed =
+            Feature::from_str(&spec).unwrap_or_else(|e| panic!("parsing {spec:?} failed: {e}"));
+        assert_eq!(
+            parsed.tag,
+            Tag::from_bytes_lossy(tag.as_bytes()),
+            "{spec:?}"
+        );
+
+        let expected_value = match value {
+            Value::None => u32::from(sign != "-"),
+            Value::Int(v) => v as u32,
+            Value::Bool(b) => u32::from(b),
+        };
+        assert_eq!(parsed.value, expected_value, "{spec:?}");
+
+        // A bare `[n]` covers the single index n, which the parser spells as
+        // the pair (n, n + 1); the open forms use the whole range on the side
+        // they leave out. Negative indices are documented to wrap (see
+        // `parse_15` and `parse_16`).
+        let expected_range = match range {
+            Range::None | Range::Empty | Range::Colon => (0, u32::MAX),
+            Range::Start(start) => {
+                let start = start as u32;
+                if start == u32::MAX {
+                    (u32::MAX, u32::MAX)
+                } else {
+                    (start, start + 1)
+                }
+            }
+            Range::StartEnd(start, end) => (start as u32, end as u32),
+            Range::StartOpen(start) => (start as u32, u32::MAX),
+            Range::OpenEnd(end) => (0, end as u32),
+        };
+        assert_eq!((parsed.start, parsed.end), expected_range, "{spec:?}");
+    }
+
+    /// Property: `Feature::from_str` and `Feature::new` agree on ranges.
+    ///
+    /// The two build `start`/`end` independently — one from a spec string, one
+    /// from a `RangeBounds` — and `tests_features` compares them for fixed
+    /// inputs.
+    #[hegel::test]
+    fn feature_from_str_agrees_with_feature_new(tc: hegel::TestCase) {
+        let tag = draw_tag_text(&tc);
+        // The spec's numbers are read as `i32`, so a spec cannot name a value
+        // or index above `i32::MAX`;
+        // `feature_from_str_reads_back_a_constructed_spec` covers the negative
+        // half of that range, which wraps.
+        let value = tc.draw(generators::integers::<u32>().max_value(i32::MAX as u32));
+        let start = tc.draw(generators::integers::<u32>().max_value(i32::MAX as u32));
+        let end = tc.draw(generators::integers::<u32>().max_value(i32::MAX as u32));
+        let spec = format!("{tag}[{start}:{end}]={value}");
+        assert_eq!(
+            Feature::from_str(&spec).unwrap(),
+            Feature::new(
+                Tag::from_bytes_lossy(tag.as_bytes()),
+                value,
+                start as usize..=end as usize
+            ),
+            "{spec:?}"
+        );
+    }
+
+    /// Property: `Variation::from_str` reads back a tag and a decimal value.
+    ///
+    /// The oracle is Rust's own `f32` parser: `TextParser::consume_f32`
+    /// accepts an optional sign, digits and one fractional part, and hands
+    /// exactly that substring to `str::parse`.
+    #[hegel::test]
+    fn variation_from_str_reads_back_a_constructed_spec(tc: hegel::TestCase) {
+        let tag = draw_tag_text(&tc);
+        let sign = tc.draw(generators::sampled_from(vec!["", "-"]));
+        let number = tc.draw(generators::from_regex(r"[0-9]{1,9}(\.[0-9]{1,6})?"));
+        // The `=` is optional, but the tag is read as a greedy run of
+        // alphanumerics, so leaving it out only parses when a sign follows.
+        let separator = if sign.is_empty() {
+            "="
+        } else {
+            tc.draw(generators::sampled_from(vec!["=", ""]))
+        };
+
+        let spec = format!("{tag}{separator}{sign}{number}");
+        let parsed = Variation::from_str(&spec).unwrap_or_else(|e| panic!("{spec:?}: {e}"));
+        assert_eq!(
+            parsed.tag,
+            Tag::from_bytes_lossy(tag.as_bytes()),
+            "{spec:?}"
+        );
+        assert_eq!(
+            parsed.value.to_bits(),
+            format!("{sign}{number}").parse::<f32>().unwrap().to_bits(),
+            "{spec:?}"
+        );
+    }
+
+    /// Property: the `FromStr` impls in this module reject what they cannot
+    /// read rather than panicking.
+    ///
+    /// These parsers are the obvious entry point for untrusted input — a
+    /// `--features` command line, a config file — and `TextParser` walks the
+    /// string by byte index with a `debug_assert!` on its bounds.
+    #[hegel::test]
+    fn parsing_arbitrary_strings_never_panics(tc: hegel::TestCase) {
+        let s: String = tc.draw(hegel::one_of!(
+            generators::text().max_size(32).boxed(),
+            generators::from_regex(
+                r#"[+-]?['"]?[A-Za-z0-9_]{0,6}['"]?(\[[0-9:;+-]{0,8}\])?(=(-?[0-9]{0,12}(\.[0-9]{0,6})?|on|off))?"#
+            )
+            .boxed(),
+        )
+        .print_as_debug());
+        let _ = Feature::from_str(&s);
+        let _ = Variation::from_str(&s);
+        let _ = Language::from_str(&s);
+        let _ = Script::from_str(&s);
+        let _ = Direction::from_str(&s);
+    }
+
+    /// Property: `Language` lowercases ASCII and turns `_` into `-`, and
+    /// changes nothing else.
+    ///
+    /// Those are the two substitutions `Language::from_bytes` documents in its
+    /// own comment; `new_lowercases` and `new_replaces_underscore` pin one
+    /// example of each.
+    #[hegel::test]
+    fn language_lowercases_and_replaces_underscores(tc: hegel::TestCase) {
+        let text: String = tc.draw(generators::text().min_size(1).max_size(24));
+        let expected: Vec<u8> = text
+            .bytes()
+            .map(|b| match b {
+                b'A'..=b'Z' => b.to_ascii_lowercase(),
+                b'_' => b'-',
+                _ => b,
+            })
+            .collect();
+        assert_eq!(
+            Language::new(&text).unwrap().as_bytes(),
+            expected.as_slice()
+        );
+    }
+
+    /// Property: normalising an already-normalised language changes nothing.
+    ///
+    /// `Language::new` accepts bytes, so feeding it `as_bytes()` is how a
+    /// caller round-trips a language back through the API.
+    #[hegel::test]
+    fn language_normalisation_is_idempotent(tc: hegel::TestCase) {
+        let text: String = tc.draw(generators::text().min_size(1).max_size(24));
+        let once = Language::new(&text).unwrap();
+        assert_eq!(Language::new(once.as_bytes()), Some(once));
+    }
+
+    /// Property: `Language::new` and `Language::from_str` agree.
+    ///
+    /// `new_matches_from_str` asserts this for two fixed tags.
+    #[hegel::test]
+    fn language_new_matches_from_str(tc: hegel::TestCase) {
+        let text: String = tc.draw(generators::text().max_size(24));
+        assert_eq!(Language::new(&text), Language::from_str(&text).ok());
+    }
+
+    /// Scripts whose ISO 15924 variant tag maps onto another script.
+    const SCRIPT_VARIANTS: &[&str] = &[
+        "aran", "cyrs", "geok", "hans", "hant", "jamo", "latf", "latg", "syre", "syrj", "syrn",
+    ];
+
+    /// Property: a four-letter script tag is read case-insensitively and
+    /// normalised to one capital followed by three lowercase letters.
+    ///
+    /// `Script::from_iso15924_tag` says it is "lenient, adjust case (one
+    /// capital letter followed by three small letters)", which is the form
+    /// ISO 15924 registers codes in.
+    #[hegel::test]
+    fn script_from_str_normalises_the_case_of_a_letters_only_tag(tc: hegel::TestCase) {
+        let tag: String = tc.draw(generators::from_regex(r"[A-Za-z]{4}"));
+        tc.assume(!SCRIPT_VARIANTS.contains(&tag.to_ascii_lowercase().as_str()));
+
+        let mut expected = tag.to_ascii_lowercase();
+        expected[..1].make_ascii_uppercase();
+        assert_eq!(
+            Script::from_str(&tag).unwrap().tag(),
+            Tag::from_bytes_lossy(expected.as_bytes()),
+            "{tag:?}"
+        );
+    }
+
+    /// Property: a tag containing a digit is not a script.
+    ///
+    /// ISO 15924 registers four-letter codes, and
+    /// `Script::from_iso15924_tag` answers `Zzzz` for anything that does not
+    /// fit that shape.
+    #[hegel::test]
+    fn script_from_str_rejects_tags_containing_a_digit(tc: hegel::TestCase) {
+        let tag: String = tc.draw(generators::from_regex(r"[A-Za-z0-9]{4}"));
+        tc.assume(tag.chars().any(|c| c.is_ascii_digit()));
+        assert_eq!(Script::from_str(&tag).unwrap(), script::UNKNOWN, "{tag:?}");
+    }
+
+    /// Property: `Direction::from_str` looks at nothing but the first byte.
+    ///
+    /// "harfbuzz also matches only the first letter", as the impl says.
+    #[hegel::test]
+    fn direction_from_str_depends_only_on_the_first_byte(tc: hegel::TestCase) {
+        let first = tc.draw(generators::characters().max_codepoint(0x7F));
+        let tail: String = tc.draw(generators::text().max_size(8));
+        let other: String = tc.draw(generators::text().max_size(8));
+        assert_eq!(
+            Direction::from_str(&format!("{first}{tail}")),
+            Direction::from_str(&format!("{first}{other}"))
+        );
+    }
+}

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -882,7 +882,7 @@ mod tests {
 
             let ideal = f64::from(advance) * f64::from(factor) / f64::from(upem);
             // Above this the `i32` result truncates rather than saturating,
-            // which is what HarfBuzz's `em_mult` does too.
+            // as HarfBuzz's `hb_font_t::em_mult` does.
             if ideal.abs() >= f64::from(1 << 30) {
                 return;
             }
@@ -901,11 +901,12 @@ mod tests {
         /// `mult` is `(scale << 16) / upem`, which reaches 2^47 for a `upem`
         /// of 1, and nothing bounds the product: a debug build panics and the
         /// workspace release profile (`overflow-checks = false`) wraps.
-        /// HarfBuzz computes the same expression in `hb_font_t::em_mult`,
-        /// where it wraps silently. The values that reach `scale_x` through
-        /// shaping today are `u16`-wide advances, which stay just inside
-        /// `i64::MAX` at the largest possible scale, so this is not
-        /// demonstrated through the public API.
+        /// HarfBuzz 14.4.0 computes the same expression, unguarded, in
+        /// `hb_font_t::em_mult` (11.3.3 took an `int16_t`, which cannot
+        /// overflow it). The values that reach `scale_x` through shaping
+        /// today are `u16`-wide advances, which stay just inside `i64::MAX`
+        /// at the largest possible scale, so this is not demonstrated
+        /// through the public API.
         #[test]
         #[ignore = "unguarded i64 multiply in Scale::scale_by_mult"]
         fn known_failure_scaling_a_wide_value_overflows() {

--- a/harfrust/src/hb/face.rs
+++ b/harfrust/src/hb/face.rs
@@ -824,4 +824,93 @@ mod tests {
         assert_eq!(scaled.width, i32::MAX);
         assert_eq!(scaled.height, i32::MIN);
     }
+
+    /// Gated on `std` because `#[hegel::test]`'s generated code uses the std
+    /// prelude.
+    #[cfg(feature = "std")]
+    mod properties {
+        use super::*;
+        use hegel::generators;
+
+        /// `upem` reaches `Scale` as `units_per_em as i32`, so it is a `u16`;
+        /// the scale is whatever the caller passed to `ShapeOptions::scale`.
+        fn draw_scale(tc: &hegel::TestCase) -> Scale {
+            let upem = i32::from(tc.draw(generators::integers::<u16>()));
+            let scale = tc.draw(generators::optional(generators::tuples!(
+                generators::integers::<i32>(),
+                generators::integers::<i32>(),
+            )));
+            Scale::new(scale, upem)
+        }
+
+        /// Property: scaling extents saturates rather than overflowing.
+        ///
+        /// `full_range_extents_saturate` above asserts that for the identity
+        /// scale and `i32` extremes; the scale factor is caller-supplied, so
+        /// it has to hold for any scale and any `upem`.
+        #[hegel::test]
+        fn extent_scaling_saturates(tc: hegel::TestCase) {
+            let scale = draw_scale(&tc);
+            let _ = scale.scale_extents(GlyphExtents {
+                x_bearing: tc.draw(generators::integers::<i32>()),
+                y_bearing: tc.draw(generators::integers::<i32>()),
+                width: tc.draw(generators::integers::<i32>()),
+                height: tc.draw(generators::integers::<i32>()),
+            });
+        }
+
+        /// Property: scaling an advance agrees with the same scaling done in
+        /// floating point.
+        ///
+        /// `scale_x` is `(v * ((scale << 16) / upem) + 32768) >> 16`, a fixed
+        /// point form of `v * scale / upem`; the fixed point rounding leaves
+        /// it within a unit or two of the real quotient. The value is bounded
+        /// to what reaches `scale_x` in practice — an `hmtx` advance is a
+        /// `u16`, and the fallback space widths derive from `upem` — because
+        /// wider values overflow, see
+        /// `known_failure_scaling_a_wide_value_overflows`.
+        #[hegel::test]
+        fn advance_scaling_agrees_with_floating_point(tc: hegel::TestCase) {
+            let upem = i32::from(tc.draw(generators::integers::<u16>().min_value(1)));
+            let factor = tc.draw(generators::integers::<i32>());
+            let advance = tc.draw(
+                generators::integers::<i32>()
+                    .min_value(-i32::from(u16::MAX))
+                    .max_value(i32::from(u16::MAX)),
+            );
+            let scale = Scale::new(Some((factor, factor)), upem);
+
+            let ideal = f64::from(advance) * f64::from(factor) / f64::from(upem);
+            // Above this the `i32` result truncates rather than saturating,
+            // which is what HarfBuzz's `em_mult` does too.
+            if ideal.abs() >= f64::from(1 << 30) {
+                return;
+            }
+            for scaled in [scale.scale_x(advance), scale.scale_y(advance)] {
+                assert!(
+                    (f64::from(scaled) - ideal).abs() <= 2.0,
+                    "{advance} at {factor}/{upem} scaled to {scaled}, not {ideal}"
+                );
+            }
+        }
+
+        /// KNOWN FAILURE: `scale_by_mult` multiplies in `i64` without
+        /// guarding, so a value beyond the `u16` range overflows once the
+        /// scale factor is extreme.
+        ///
+        /// `mult` is `(scale << 16) / upem`, which reaches 2^47 for a `upem`
+        /// of 1, and nothing bounds the product: a debug build panics and the
+        /// workspace release profile (`overflow-checks = false`) wraps.
+        /// HarfBuzz computes the same expression in `hb_font_t::em_mult`,
+        /// where it wraps silently. The values that reach `scale_x` through
+        /// shaping today are `u16`-wide advances, which stay just inside
+        /// `i64::MAX` at the largest possible scale, so this is not
+        /// demonstrated through the public API.
+        #[test]
+        #[ignore = "unguarded i64 multiply in Scale::scale_by_mult"]
+        fn known_failure_scaling_a_wide_value_overflows() {
+            let scale = Scale::new(Some((118_798, 0)), 1);
+            let _ = scale.scale_x(1_184_678_937);
+        }
+    }
 }

--- a/harfrust/src/hb/ot_shape_plan.rs
+++ b/harfrust/src/hb/ot_shape_plan.rs
@@ -191,4 +191,212 @@ mod tests {
         fn ensure_send_and_sync<T: Send + Sync>() {}
         ensure_send_and_sync::<hb_ot_shape_plan_t>();
     }
+
+    /// Gated on `std` because `#[hegel::test]`'s generated code uses the std
+    /// prelude.
+    #[cfg(all(test, feature = "std"))]
+    mod properties {
+        use crate::hb::common::{TagExt, HB_FEATURE_GLOBAL_END, HB_FEATURE_GLOBAL_START};
+        use crate::{
+            script, Direction, Feature, FontRef, Language, Script, ShapePlan, ShapePlanKey,
+            ShaperData, Tag,
+        };
+        use hegel::generators::{self, Generator};
+
+        const DIRECTIONS: &[Direction] = &[
+            Direction::LeftToRight,
+            Direction::RightToLeft,
+            Direction::TopToBottom,
+            Direction::BottomToTop,
+        ];
+
+        const SCRIPTS: &[Script] = &[
+            script::LATIN,
+            script::ARABIC,
+            script::DEVANAGARI,
+            script::HAN,
+            script::UNKNOWN,
+        ];
+
+        const LANGUAGES: &[&str] = &["en", "ar", "hi", "zh-cn"];
+
+        /// The properties a plan is built for and a key is matched against.
+        #[derive(Debug, Clone)]
+        struct PlanProperties {
+            direction: Direction,
+            script: Option<Script>,
+            language: Option<Language>,
+            features: Vec<Feature>,
+        }
+
+        fn draw_properties(tc: &hegel::TestCase) -> PlanProperties {
+            let properties = PlanProperties {
+                // `ShapePlan::new` asserts on `Direction::Invalid`.
+                direction: tc.draw_silent(generators::sampled_from(DIRECTIONS.to_vec())),
+                script: tc.draw_silent(generators::optional(generators::sampled_from(
+                    SCRIPTS.to_vec(),
+                ))),
+                language: tc
+                    .draw_silent(generators::optional(generators::sampled_from(
+                        LANGUAGES.to_vec(),
+                    )))
+                    .and_then(Language::new),
+                features: draw_features(tc),
+            };
+            tc.note(&format!("{properties:?}"));
+            properties
+        }
+
+        fn draw_features(tc: &hegel::TestCase) -> Vec<Feature> {
+            let n = tc.draw_silent(generators::integers::<usize>().max_value(3));
+            (0..n)
+                .map(|_| {
+                    let bytes: [u8; 4] = tc.draw_silent(generators::arrays(
+                        generators::integers::<u8>().min_value(b'a').max_value(b'z'),
+                    ));
+                    let tag = Tag::from_bytes_lossy(&bytes);
+                    let value = tc.draw_silent(generators::integers::<u32>().max_value(3));
+                    let (start, end) = draw_range(tc);
+                    Feature {
+                        tag,
+                        value,
+                        start,
+                        end,
+                    }
+                })
+                .collect()
+        }
+
+        fn draw_range(tc: &hegel::TestCase) -> (u32, u32) {
+            if tc.draw_silent(generators::booleans()) {
+                (HB_FEATURE_GLOBAL_START, HB_FEATURE_GLOBAL_END)
+            } else {
+                let start = tc.draw_silent(generators::integers::<u32>().max_value(8));
+                (
+                    start,
+                    start + tc.draw_silent(generators::integers::<u32>().max_value(8)),
+                )
+            }
+        }
+
+        fn font() -> FontRef<'static> {
+            FontRef::new(include_bytes!("../../benches/fonts/Roboto-Regular.ttf")).unwrap()
+        }
+
+        fn key(properties: &PlanProperties) -> ShapePlanKey<'_> {
+            ShapePlanKey::new(properties.script, properties.direction)
+                .language(properties.language.as_ref())
+                .features(&properties.features)
+        }
+
+        fn plan(font: &FontRef, data: &ShaperData, properties: &PlanProperties) -> ShapePlan {
+            let shaper = data.shaper(font).build();
+            ShapePlan::new(
+                &shaper,
+                properties.direction,
+                properties.script,
+                properties.language.as_ref(),
+                &properties.features,
+            )
+        }
+
+        /// Property: a key matches the plan built from the same properties.
+        ///
+        /// That is what a plan cache is for: `ShapePlanKey::matches` decides
+        /// whether a cached plan can be reused, so it has to accept the plan
+        /// its own properties produced.
+        #[hegel::test]
+        fn a_key_matches_the_plan_built_from_the_same_properties(tc: hegel::TestCase) {
+            let font = font();
+            let data = ShaperData::new(&font);
+            let properties = draw_properties(&tc);
+            assert!(key(&properties).matches(&plan(&font, &data, &properties)));
+        }
+
+        /// Property: a key with a different direction, script or language does
+        /// not match.
+        ///
+        /// Reusing a plan across those would shape with the wrong lookups;
+        /// `Shaper::shape_buffer` refuses a plan whose direction or script
+        /// disagrees with the buffer for the same reason.
+        #[hegel::test]
+        fn a_key_with_different_segment_properties_does_not_match(tc: hegel::TestCase) {
+            let font = font();
+            let data = ShaperData::new(&font);
+            let properties = draw_properties(&tc);
+            let mut other = properties.clone();
+            match tc.draw(generators::integers::<u8>().max_value(2)) {
+                0 => {
+                    other.direction = tc.draw(
+                        generators::sampled_from(
+                            DIRECTIONS
+                                .iter()
+                                .copied()
+                                .filter(|d| *d != properties.direction)
+                                .collect::<Vec<_>>(),
+                        )
+                        .print_as_debug(),
+                    );
+                }
+                1 => {
+                    other.script = tc.draw(
+                        generators::sampled_from(
+                            SCRIPTS
+                                .iter()
+                                .copied()
+                                .map(Some)
+                                .chain([None])
+                                .filter(|s| *s != properties.script)
+                                .collect::<Vec<_>>(),
+                        )
+                        .print_as_debug(),
+                    );
+                }
+                _ => {
+                    other.language = tc.draw(
+                        generators::sampled_from(
+                            LANGUAGES
+                                .iter()
+                                .filter_map(Language::new)
+                                .map(Some)
+                                .chain([None])
+                                .filter(|l| *l != properties.language)
+                                .collect::<Vec<_>>(),
+                        )
+                        .print_as_debug(),
+                    );
+                }
+            }
+            assert!(!key(&other).matches(&plan(&font, &data, &properties)));
+        }
+
+        /// Property: where a non-global feature applies does not affect
+        /// whether a key matches.
+        ///
+        /// `features_equivalent` compares tags and values but only asks of the
+        /// range whether it is global, matching HarfBuzz's
+        /// `hb_shape_plan_key_t::user_features_match`. Non-global features are
+        /// applied per cluster at shaping time rather than compiled into the
+        /// plan, so two runs differing only in where they apply can share one.
+        #[hegel::test]
+        fn a_non_global_features_range_does_not_affect_matching(tc: hegel::TestCase) {
+            let font = font();
+            let data = ShaperData::new(&font);
+            let properties = draw_properties(&tc);
+            let mut other = properties.clone();
+            for feature in &mut other.features {
+                if feature.start != HB_FEATURE_GLOBAL_START || feature.end != HB_FEATURE_GLOBAL_END
+                {
+                    (feature.start, feature.end) = draw_range(&tc);
+                    // Keep it non-global, or the key stops being equivalent.
+                    if feature.start == HB_FEATURE_GLOBAL_START
+                        && feature.end == HB_FEATURE_GLOBAL_END
+                    {
+                        feature.end = HB_FEATURE_GLOBAL_END - 1;
+                    }
+                }
+            }
+            assert!(key(&other).matches(&plan(&font, &data, &properties)));
+        }
+    }
 }

--- a/harfrust/src/hb/set_digest.rs
+++ b/harfrust/src/hb/set_digest.rs
@@ -214,4 +214,101 @@ mod tests {
         b.add(123);
         assert!(a.may_intersect(&b));
     }
+    /// Gated on `std` because `#[hegel::test]`'s generated code uses the std
+    /// prelude.
+    #[cfg(feature = "std")]
+    mod properties {
+        use super::*;
+        use hegel::generators::{self, Generator};
+
+        /// Glyph ids the digest is asked about in practice are small, but it is
+        /// indexed by arbitrary `u32`, and the bit arithmetic is where a digest
+        /// goes wrong.
+        fn glyphs(tc: &hegel::TestCase) -> Vec<u32> {
+            tc.draw(
+                generators::vecs(hegel::one_of!(
+                    generators::integers::<u32>().max_value(0xFFFF),
+                    generators::integers::<u32>(),
+                ))
+                .max_size(32)
+                .print_as_debug(),
+            )
+        }
+
+        /// Property: the digest has no false negatives.
+        ///
+        /// That is the whole contract of a set digest: `may_have` is allowed to
+        /// say yes about a glyph that was never added, but never no about one that
+        /// was. `ot_layout.rs` skips a lookup outright when `may_intersect` says
+        /// no, so a false negative drops shaping work.
+        #[hegel::test]
+        fn everything_added_may_be_had(tc: hegel::TestCase) {
+            let glyphs = glyphs(&tc);
+            let mut digest = hb_set_digest_t::new();
+            digest.add_array(glyphs.iter().copied());
+            for glyph in &glyphs {
+                assert!(digest.may_have(*glyph), "{glyph} was added");
+            }
+        }
+
+        /// Property: `add_range` has no false negatives either.
+        ///
+        /// Ranges take a separate path that folds a whole span into each mask in
+        /// one go (`mb + (mb - ma) - (mb < ma)`), rather than one bit at a time.
+        #[hegel::test]
+        fn everything_in_an_added_range_may_be_had(tc: hegel::TestCase) {
+            let start = tc.draw(generators::integers::<u32>());
+            // A span wider than a mask covers every bit anyway, so keep it narrow
+            // enough that the test can enumerate it.
+            let width = tc.draw(generators::integers::<u32>().max_value(300));
+            let end = start.saturating_add(width);
+
+            let mut digest = hb_set_digest_t::new();
+            digest.add_range(start, end);
+            for glyph in start..=end {
+                assert!(digest.may_have(glyph), "{glyph} is in {start}..={end}");
+            }
+        }
+
+        /// Property: a union has no false negatives about either side.
+        ///
+        /// `ot/lookup.rs` builds a lookup's digest by unioning its subtables',
+        /// so a glyph lost here is a subtable that never gets tried.
+        #[hegel::test]
+        fn a_union_may_have_everything_either_side_had(tc: hegel::TestCase) {
+            let left = glyphs(&tc);
+            let right = glyphs(&tc);
+
+            let mut a = hb_set_digest_t::new();
+            a.add_array(left.iter().copied());
+            let mut b = hb_set_digest_t::new();
+            b.add_array(right.iter().copied());
+            a.union(&b);
+
+            for glyph in left.iter().chain(&right) {
+                assert!(a.may_have(*glyph), "{glyph} was added to one side");
+            }
+        }
+
+        /// Property: two digests that share a glyph may intersect.
+        ///
+        /// `may_intersect` is the guard `ot_layout.rs` uses to skip a lookup whose
+        /// coverage cannot match the buffer, so saying no about a shared glyph
+        /// would drop a substitution.
+        #[hegel::test]
+        fn digests_sharing_a_glyph_may_intersect(tc: hegel::TestCase) {
+            let left = glyphs(&tc);
+            let right = glyphs(&tc);
+            let shared = tc.draw(generators::integers::<u32>());
+
+            let mut a = hb_set_digest_t::new();
+            a.add_array(left.iter().copied());
+            a.add(shared);
+            let mut b = hb_set_digest_t::new();
+            b.add_array(right.iter().copied());
+            b.add(shared);
+
+            assert!(a.may_intersect(&b), "both hold {shared}");
+        }
+    }
 }

--- a/harfrust/tests/buffer.rs
+++ b/harfrust/tests/buffer.rs
@@ -414,6 +414,11 @@ fn properties_round_trip() {
 }
 
 /// Property-based tests for the buffer's documented behaviour.
+///
+/// The settings and the items are drawn with `draw_silent` and recorded with
+/// `tc.note`, so a failing case prints each of them as one line rather than
+/// draw by draw. `.print_as_debug()` marks a `draw` of a type hegel cannot
+/// otherwise print.
 mod properties {
     use harfrust::{
         script, BufferClusterLevel, BufferContentType, Direction, GlyphId, Language, ShapeError,

--- a/harfrust/tests/buffer.rs
+++ b/harfrust/tests/buffer.rs
@@ -412,3 +412,444 @@ fn properties_round_trip() {
     assert_eq!(buffer.invisible_glyph(), Some(harfrust::GlyphId::new(3)));
     assert_eq!(buffer.not_found_variation_selector_glyph(), Some(7));
 }
+
+/// Property-based tests for the buffer's documented behaviour.
+mod properties {
+    use harfrust::{
+        script, BufferClusterLevel, BufferContentType, Direction, GlyphId, Language, ShapeError,
+        ShapeOptions, ShapePlan,
+    };
+    use hegel::generators::{self, Generator};
+
+    use super::{ids_and_clusters, test_instance, Buffer, UnicodeBuffer};
+
+    const DIRECTIONS: &[Direction] = &[
+        Direction::Invalid,
+        Direction::LeftToRight,
+        Direction::RightToLeft,
+        Direction::TopToBottom,
+        Direction::BottomToTop,
+    ];
+
+    const CLUSTER_LEVELS: &[BufferClusterLevel] = &[
+        BufferClusterLevel::MonotoneGraphemes,
+        BufferClusterLevel::MonotoneCharacters,
+        BufferClusterLevel::Characters,
+        BufferClusterLevel::Graphemes,
+    ];
+
+    /// The buffer's settings, all of them generated.
+    #[derive(Debug, Clone)]
+    struct Settings {
+        direction: Direction,
+        script: harfrust::Script,
+        language: Option<Language>,
+        cluster_level: BufferClusterLevel,
+        flags: harfrust::BufferFlags,
+        invisible_glyph: Option<GlyphId>,
+        not_found_variation_selector_glyph: Option<u32>,
+    }
+
+    fn draw_settings(tc: &hegel::TestCase) -> Settings {
+        let settings = Settings {
+            direction: tc.draw_silent(generators::sampled_from(DIRECTIONS.to_vec())),
+            script: harfrust::Script::from_iso15924_tag(harfrust::Tag::new(&tc.draw_silent(
+                generators::arrays(generators::integers::<u8>().min_value(b'A').max_value(b'z')),
+            )))
+            .unwrap_or(script::UNKNOWN),
+            language: Language::new(
+                tc.draw_silent(generators::text().min_size(1).max_size(12).codec("ascii")),
+            ),
+            cluster_level: tc.draw_silent(generators::sampled_from(CLUSTER_LEVELS.to_vec())),
+            flags: harfrust::BufferFlags::from_bits_truncate(
+                tc.draw_silent(generators::integers::<u32>()),
+            ),
+            invisible_glyph: tc.draw_silent(generators::optional(
+                generators::integers::<u32>().map(GlyphId::new),
+            )),
+            not_found_variation_selector_glyph: tc
+                .draw_silent(generators::optional(generators::integers::<u32>())),
+        };
+        tc.note(&format!("{settings:?}"));
+        settings
+    }
+
+    fn apply(buffer: &mut Buffer, s: &Settings) {
+        buffer.set_direction(s.direction);
+        buffer.set_script(s.script);
+        if let Some(language) = &s.language {
+            buffer.set_language(language.clone());
+        }
+        buffer.set_cluster_level(s.cluster_level);
+        buffer.set_flags(s.flags);
+        buffer.set_invisible_glyph(s.invisible_glyph);
+        buffer.set_not_found_variation_selector_glyph(s.not_found_variation_selector_glyph);
+    }
+
+    fn read(buffer: &Buffer) -> Settings {
+        Settings {
+            direction: buffer.direction(),
+            script: buffer.script(),
+            language: buffer.language(),
+            cluster_level: buffer.cluster_level(),
+            flags: buffer.flags(),
+            invisible_glyph: buffer.invisible_glyph(),
+            not_found_variation_selector_glyph: buffer.not_found_variation_selector_glyph(),
+        }
+    }
+
+    fn same(a: &Settings, b: &Settings) -> bool {
+        a.direction == b.direction
+            && a.script == b.script
+            && a.language == b.language
+            && a.cluster_level == b.cluster_level
+            && a.flags.bits() == b.flags.bits()
+            && a.invisible_glyph == b.invisible_glyph
+            && a.not_found_variation_selector_glyph == b.not_found_variation_selector_glyph
+    }
+
+    /// Draws (codepoint, cluster) pairs, with clusters in no particular order
+    /// so that cluster grouping is exercised rather than only the monotone
+    /// shape `push_str` produces.
+    fn draw_items(tc: &hegel::TestCase) -> Vec<(u32, u32)> {
+        let items = tc.draw_silent(
+            generators::vecs(generators::tuples!(
+                generators::integers::<u32>(),
+                generators::integers::<u32>().max_value(6),
+            ))
+            .max_size(24),
+        );
+        tc.note(&format!("items = {items:?}"));
+        items
+    }
+
+    fn filled(items: &[(u32, u32)]) -> Buffer {
+        let mut buffer = Buffer::new();
+        for &(codepoint, cluster) in items {
+            buffer.push(codepoint, cluster);
+        }
+        buffer
+    }
+
+    /// Property: `push_str` gives each character its UTF-8 byte offset as its
+    /// cluster value, and stores the codepoint itself as the item.
+    ///
+    /// Both halves are documented on `Buffer::push_str` and
+    /// `GlyphInfo::glyph_id`; the oracle is `str::char_indices`.
+    #[hegel::test]
+    fn push_str_records_codepoints_at_their_byte_offsets(tc: hegel::TestCase) {
+        let text: String = tc.draw(generators::text().max_size(64));
+        let mut buffer = Buffer::new();
+        buffer.push_str(&text);
+        assert_eq!(
+            ids_and_clusters(buffer.glyph_infos()),
+            text.char_indices()
+                .map(|(i, c)| (c as u32, i as u32))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Property: every buffer setting survives the trip through
+    /// `UnicodeBuffer` and back.
+    ///
+    /// `round_trip_through_unicode_buffer` asserts this for the direction of
+    /// one fixed buffer; the conversions are documented to change nothing but
+    /// the content type.
+    #[hegel::test]
+    fn settings_survive_the_unicode_buffer_round_trip(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let settings = draw_settings(&tc);
+        let mut buffer = filled(&items);
+        apply(&mut buffer, &settings);
+
+        let typed = UnicodeBuffer::try_from(buffer).expect("unicode content converts");
+        let back = Buffer::from(typed);
+        assert!(same(&read(&back), &settings), "{:?}", read(&back));
+    }
+
+    /// Property: the buffer contents survive the trip through `UnicodeBuffer`
+    /// and back.
+    ///
+    /// Both conversions are documented to touch nothing but the content type,
+    /// and `round_trip_through_glyph_buffer` asserts the same for a shaped
+    /// buffer.
+    #[hegel::test]
+    fn contents_survive_the_unicode_buffer_round_trip(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let buffer = filled(&items);
+        let before = ids_and_clusters(buffer.glyph_infos());
+
+        let typed = UnicodeBuffer::try_from(buffer).expect("unicode content converts");
+        let back = Buffer::from(typed);
+        assert_eq!(ids_and_clusters(back.glyph_infos()), before);
+    }
+
+    /// Property: `reverse` is its own inverse.
+    ///
+    /// `reverse_and_reverse_clusters` asserts the forward half for one fixed
+    /// buffer.
+    #[hegel::test]
+    fn reverse_is_an_involution(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let mut buffer = filled(&items);
+        let before = ids_and_clusters(buffer.glyph_infos());
+        buffer.reverse();
+        buffer.reverse();
+        assert_eq!(ids_and_clusters(buffer.glyph_infos()), before);
+    }
+
+    /// Property: `reverse_clusters` reverses the order of the runs of equal
+    /// cluster while leaving the items within each run in their original
+    /// order.
+    ///
+    /// That is the documented behaviour ("keeping the items within each
+    /// cluster in their original order"); `reverse_and_reverse_clusters`
+    /// asserts one instance of it.
+    #[hegel::test]
+    fn reverse_clusters_reverses_runs_and_not_their_contents(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let mut buffer = filled(&items);
+        buffer.reverse_clusters();
+
+        let mut expected: Vec<Vec<(u32, u32)>> = Vec::new();
+        for item in &items {
+            match expected.last_mut() {
+                Some(run) if run[0].1 == item.1 => run.push(*item),
+                _ => expected.push(vec![*item]),
+            }
+        }
+        let expected: Vec<(u32, u32)> = expected.into_iter().rev().flatten().collect();
+        assert_eq!(ids_and_clusters(buffer.glyph_infos()), expected);
+    }
+
+    /// Property: `reset_clusters` replaces every cluster value with the item's
+    /// index, leaving the items themselves alone.
+    ///
+    /// "Resets the cluster value of each item to its index" is what the method
+    /// documents.
+    #[hegel::test]
+    fn reset_clusters_numbers_items_from_zero(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let mut buffer = filled(&items);
+        buffer.reset_clusters();
+        assert_eq!(
+            ids_and_clusters(buffer.glyph_infos()),
+            items
+                .iter()
+                .enumerate()
+                .map(|(i, (codepoint, _))| (*codepoint, i as u32))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Property: `set_length` keeps the first `len` items when shrinking and
+    /// zero-fills when growing.
+    ///
+    /// "Growing the buffer fills the new items with zeros" is documented on
+    /// `Buffer::set_length`.
+    #[hegel::test]
+    fn set_length_truncates_or_zero_fills(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let len = tc.draw(generators::integers::<usize>().max_value(64));
+        let mut buffer = filled(&items);
+
+        let mut expected = ids_and_clusters(buffer.glyph_infos());
+        expected.truncate(len);
+        expected.resize(len, (0, 0));
+
+        assert!(buffer.set_length(len));
+        assert_eq!(ids_and_clusters(buffer.glyph_infos()), expected);
+    }
+
+    /// Property: `clear` empties the buffer and drops its segment properties.
+    ///
+    /// `clear` matches HarfBuzz's `hb_buffer_clear_contents`;
+    /// `clear_resets_content_type` covers one instance.
+    #[hegel::test]
+    fn clear_empties_the_buffer_and_drops_the_segment_properties(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let settings = draw_settings(&tc);
+        let mut buffer = filled(&items);
+        apply(&mut buffer, &settings);
+        buffer.clear();
+
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.content_type(), None);
+        assert_eq!(buffer.direction(), Direction::Invalid);
+        assert_eq!(buffer.script(), script::UNKNOWN);
+        assert_eq!(buffer.language(), None);
+        assert_eq!(
+            buffer.cluster_level(),
+            BufferClusterLevel::MonotoneGraphemes
+        );
+    }
+
+    /// Property: `clear` keeps the flags and the invisible glyph.
+    ///
+    /// Like HarfBuzz's `hb_buffer_clear_contents`, `clear` leaves the buffer's
+    /// configuration in place; `reset` is the call that clears that too.
+    #[hegel::test]
+    fn clear_keeps_the_flags_and_the_invisible_glyph(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let settings = draw_settings(&tc);
+        let mut buffer = filled(&items);
+        apply(&mut buffer, &settings);
+        buffer.clear();
+
+        assert_eq!(buffer.flags().bits(), settings.flags.bits());
+        assert_eq!(buffer.invisible_glyph(), settings.invisible_glyph);
+    }
+
+    /// Property: `reset` restores a buffer to the state of a fresh one.
+    ///
+    /// `reset` is documented as resetting "to its default state";
+    /// `reset_restores_defaults` checks four of those defaults against
+    /// literals rather than against a fresh buffer.
+    #[hegel::test]
+    fn reset_leaves_a_buffer_indistinguishable_from_a_new_one(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let settings = draw_settings(&tc);
+        let mut buffer = filled(&items);
+        apply(&mut buffer, &settings);
+        buffer.reset();
+
+        let fresh = Buffer::new();
+        assert!(same(&read(&buffer), &read(&fresh)), "{:?}", read(&buffer));
+        assert_eq!(buffer.len(), fresh.len());
+        assert_eq!(buffer.content_type(), fresh.content_type());
+    }
+
+    /// Property: `set_content_type` relabels the buffer without touching its
+    /// contents.
+    ///
+    /// "This only relabels the buffer; it never clears it" is documented on
+    /// `Buffer::set_content_type`.
+    #[hegel::test]
+    fn set_content_type_only_relabels(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let content_type = tc.draw(generators::optional(
+            generators::booleans()
+                .map(|glyphs| {
+                    if glyphs {
+                        BufferContentType::Glyphs
+                    } else {
+                        BufferContentType::Unicode
+                    }
+                })
+                .print_as_debug(),
+        ));
+        let mut buffer = filled(&items);
+        let before = ids_and_clusters(buffer.glyph_infos());
+        buffer.set_content_type(content_type);
+        assert_eq!(ids_and_clusters(buffer.glyph_infos()), before);
+        assert_eq!(buffer.content_type(), content_type);
+    }
+
+    /// Property: `guess_segment_properties` only fills in what is unset.
+    ///
+    /// That is what the method documents ("Only properties that are still
+    /// unset are filled in"), so a second call cannot change anything and a
+    /// preset direction or script has to survive.
+    #[hegel::test]
+    fn guess_segment_properties_is_idempotent(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let mut buffer = filled(&items);
+        if tc.draw(generators::booleans()) {
+            buffer.set_direction(
+                tc.draw(generators::sampled_from(DIRECTIONS.to_vec()).print_as_debug()),
+            );
+        }
+        if tc.draw(generators::booleans()) {
+            buffer.set_script(script::ARABIC);
+        }
+
+        buffer.guess_segment_properties();
+        let (direction, script, language) =
+            (buffer.direction(), buffer.script(), buffer.language());
+        buffer.guess_segment_properties();
+        assert_eq!(
+            (buffer.direction(), buffer.script(), buffer.language()),
+            (direction, script, language)
+        );
+    }
+
+    /// Property: `guess_segment_properties` always resolves a direction.
+    ///
+    /// Shaping refuses a buffer with `Direction::Invalid`
+    /// (`ShapeError::DirectionUnset`), and `guess_segment_properties` is what
+    /// its documentation points callers at, so it has to produce one.
+    #[hegel::test]
+    fn guess_segment_properties_always_resolves_a_direction(tc: hegel::TestCase) {
+        let items = draw_items(&tc);
+        let mut buffer = filled(&items);
+        buffer.guess_segment_properties();
+        assert_ne!(buffer.direction(), Direction::Invalid);
+    }
+
+    /// Property: a refused `shape` call leaves the buffer exactly as it
+    /// arrived.
+    ///
+    /// `Buffer::shape` documents every `ShapeError` as "a misuse of the API,
+    /// caught before anything is touched, so a failure leaves the buffer
+    /// exactly as it arrived". Each of the refusals is provoked here in turn.
+    #[hegel::test]
+    fn a_refused_shape_call_changes_nothing(tc: hegel::TestCase) {
+        let instance = test_instance();
+        let items = draw_items(&tc);
+        let mut buffer = filled(&items);
+
+        // 0: no direction, 1: already shaped, 2: plan built for another
+        // direction, 3: plan built for another script.
+        let refusal = tc.draw(generators::integers::<u8>().max_value(3));
+        let plan = match refusal {
+            0 => {
+                buffer.set_direction(Direction::Invalid);
+                None
+            }
+            1 => {
+                buffer.set_direction(Direction::LeftToRight);
+                buffer.set_content_type(Some(BufferContentType::Glyphs));
+                None
+            }
+            2 => {
+                buffer.set_direction(Direction::LeftToRight);
+                Some(ShapePlan::new(
+                    &instance,
+                    Direction::RightToLeft,
+                    Some(script::LATIN),
+                    None,
+                    &[],
+                ))
+            }
+            _ => {
+                buffer.set_direction(Direction::LeftToRight);
+                buffer.set_script(script::LATIN);
+                Some(ShapePlan::new(
+                    &instance,
+                    Direction::LeftToRight,
+                    Some(script::ARABIC),
+                    None,
+                    &[],
+                ))
+            }
+        };
+
+        let before = ids_and_clusters(buffer.glyph_infos());
+        let content_type = buffer.content_type();
+        let err = buffer
+            .shape(&instance, ShapeOptions::new().plan(plan.as_ref()))
+            .expect_err("this call is a misuse and must be refused");
+        assert!(
+            matches!(
+                err,
+                ShapeError::DirectionUnset
+                    | ShapeError::AlreadyShaped
+                    | ShapeError::DirectionMismatch { .. }
+                    | ShapeError::ScriptMismatch { .. }
+            ),
+            "{err:?}"
+        );
+        assert_eq!(ids_and_clusters(buffer.glyph_infos()), before);
+        assert_eq!(buffer.content_type(), content_type);
+    }
+}

--- a/harfrust/tests/shaping/main.rs
+++ b/harfrust/tests/shaping/main.rs
@@ -4,6 +4,7 @@ mod in_house;
 mod macos;
 #[cfg(target_os = "macos")]
 mod macos_lazy_tables;
+mod properties;
 mod regressions;
 mod text_rendering_tests;
 

--- a/harfrust/tests/shaping/properties.rs
+++ b/harfrust/tests/shaping/properties.rs
@@ -1,0 +1,970 @@
+//! Property-based tests for the shaping API.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use harfrust::{
+    script, BufferClusterLevel, BufferFlags, Direction, Feature, FontRef, GlyphBuffer, Language,
+    SerializeFlags, ShapeOptions, ShapePlan, ShaperData, ShaperInstance, Tag, UnicodeBuffer,
+    Variation,
+};
+use hegel::generators::{self, Generator};
+
+/// Fonts spanning the shapers: OpenType GSUB/GPOS, the complex-script shapers
+/// (Arabic, Indic, USE, Myanmar, Khmer, Hangul), AAT (`morx`/`kerx`/`trak`),
+/// variable fonts, CFF outlines, and legacy/edge-case cmaps.
+const PROPERTY_FONTS: &[&str] = &[
+    "benches/fonts/Roboto-Regular.ttf",
+    "benches/fonts/Amiri-Regular.ttf",
+    "benches/fonts/NotoSansDevanagari-Regular.ttf",
+    "benches/fonts/NotoNastaliqUrdu-Regular.ttf",
+    "benches/fonts/SourceSerifVariable-Roman.ttf",
+    "tests/fonts/rb_custom/OpenSans.subset1.ttf",
+    "tests/fonts/rb_custom/NotoSansCJK.subset1.otf",
+    "tests/fonts/rb_custom/NotoSansMalayalam.subset1.ttf",
+    "tests/fonts/rb_custom/NotoSansMyanmarUI-Regular.subset1.otf",
+    "tests/fonts/rb_custom/NotoSansSinhala.subset1.otf",
+    "tests/fonts/rb_custom/Rasa.subset1.otf",
+    "tests/fonts/rb_custom/BungeeTint-Regular.ttf",
+    "tests/fonts/in-house/HBTest-VF.ttf",
+    "tests/fonts/in-house/TRAK.ttf",
+    "tests/fonts/in-house/MORXTwentyeight.ttf",
+    "tests/fonts/in-house/NotoSerifHK-subset.ttf",
+    "tests/fonts/in-house/FallbackPlus-Javanese-no-GDEF.otf",
+    "tests/fonts/in-house/TradArabicTest.ttf",
+    "tests/fonts/text-rendering-tests/NotoSansBalinese-Regular.ttf",
+    "tests/fonts/text-rendering-tests/NotoSansKannada-Regular.ttf",
+    "tests/fonts/text-rendering-tests/AdobeVFPrototype-Subset.otf",
+    "tests/fonts/text-rendering-tests/TestShapeEthi.ttf",
+    "tests/fonts/text-rendering-tests/TestShapeLana.ttf",
+    "tests/fonts/text-rendering-tests/TestCMAP14.otf",
+    "tests/fonts/text-rendering-tests/TestAATMorx.ttf",
+    "tests/fonts/text-rendering-tests/TestKERNOne.otf",
+    "tests/fonts/text-rendering-tests/TestGPOSFour.ttf",
+    "tests/fonts/text-rendering-tests/Zycon.ttf",
+    "tests/fonts/aots/gsub4_1_multiple_ligatures_f1.otf",
+    "tests/fonts/aots/gpos2_1_lookupflag_f1.otf",
+];
+
+fn font_path(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn font_bytes() -> &'static [Vec<u8>] {
+    static BYTES: OnceLock<Vec<Vec<u8>>> = OnceLock::new();
+    BYTES.get_or_init(|| {
+        PROPERTY_FONTS
+            .iter()
+            .map(|p| fs::read(font_path(p)).unwrap_or_else(|e| panic!("read {p}: {e}")))
+            .collect()
+    })
+}
+
+/// Parsed fonts with their shaping caches, in `PROPERTY_FONTS` order.
+///
+/// Built once per test rather than once per case: `ShaperData` construction
+/// resolves every layout table, which would otherwise dominate the runtime.
+fn test_fonts() -> Vec<(FontRef<'static>, ShaperData)> {
+    font_bytes()
+        .iter()
+        .zip(PROPERTY_FONTS)
+        .map(|(bytes, name)| {
+            let font = FontRef::new(bytes).unwrap_or_else(|e| panic!("parse {name}: {e}"));
+            let data = ShaperData::new(&font);
+            (font, data)
+        })
+        .collect()
+}
+
+fn draw_font_index(tc: &hegel::TestCase) -> usize {
+    let index = tc.draw_silent(generators::integers::<usize>().max_value(PROPERTY_FONTS.len() - 1));
+    tc.note(&format!("font = {}", PROPERTY_FONTS[index]));
+    index
+}
+
+/// Unicode blocks matching the scripts of `PROPERTY_FONTS`, plus a few generic
+/// ones. The complex shapers only engage when several characters of the same
+/// script appear in a run, so most characters of a generated string come from
+/// one block.
+const SCRIPT_BLOCKS: &[(u32, u32)] = &[
+    (0x0020, 0x007E),   // ASCII
+    (0x00A0, 0x00FF),   // Latin-1
+    (0x0300, 0x036F),   // combining marks
+    (0x0590, 0x05FF),   // Hebrew
+    (0x0600, 0x06FF),   // Arabic
+    (0x0900, 0x097F),   // Devanagari
+    (0x0C80, 0x0CFF),   // Kannada
+    (0x0D00, 0x0D7F),   // Malayalam
+    (0x0D80, 0x0DFF),   // Sinhala
+    (0x0E00, 0x0E7F),   // Thai
+    (0x1000, 0x109F),   // Myanmar
+    (0x1100, 0x11FF),   // Hangul Jamo
+    (0x1200, 0x137F),   // Ethiopic
+    (0x1780, 0x17FF),   // Khmer
+    (0x1A20, 0x1AAF),   // Tai Tham
+    (0x1B00, 0x1B7F),   // Balinese
+    (0x4E00, 0x4E7F),   // CJK
+    (0xAC00, 0xAC7F),   // Hangul syllables
+    (0x1F300, 0x1F6FF), // emoji
+];
+
+/// Characters the shapers give special meaning to: joiners, default
+/// ignorables, variation selectors, dotted circle, tatweel, matras, and
+/// whitespace.
+const SPECIAL_CHARS: &[char] = &[
+    '\u{200C}', '\u{200D}', '\u{00AD}', '\u{25CC}', '\u{FE00}', '\u{FE0F}', '\u{FFFD}', '\u{034F}',
+    '\u{180B}', '\n', '\r', '\t', '\u{0640}', '\u{093F}', '\u{0E33}', '\u{1B35}', '\u{0}', ' ',
+];
+
+fn draw_codepoint_in(tc: &hegel::TestCase, lo: u32, hi: u32) -> char {
+    let n = tc.draw_silent(generators::integers::<u32>().min_value(lo).max_value(hi));
+    char::from_u32(n).unwrap_or('\u{FFFD}')
+}
+
+/// Draws text biased towards a single script run, with special characters and
+/// fully arbitrary codepoints mixed in.
+fn draw_text(tc: &hegel::TestCase, max_len: usize) -> String {
+    let text = if tc.draw_silent(generators::integers::<u8>().max_value(4)) == 0 {
+        tc.draw_silent(generators::text().max_size(max_len))
+    } else {
+        let block = tc.draw_silent(generators::sampled_from(SCRIPT_BLOCKS.to_vec()));
+        let len = tc.draw_silent(generators::integers::<usize>().max_value(max_len));
+        let mut text = String::new();
+        for _ in 0..len {
+            text.push(
+                // Weighted rather than a `one_of!`: eight of the ten indices
+                // fall through to the block, so most of the text is in the
+                // script under test.
+                match tc.draw_silent(generators::integers::<u8>().max_value(9)) {
+                    0 => tc.draw_silent(generators::sampled_from(SPECIAL_CHARS.to_vec())),
+                    1 => draw_codepoint_in(tc, 0, 0x10_FFFF),
+                    _ => draw_codepoint_in(tc, block.0, block.1),
+                },
+            );
+        }
+        text
+    };
+    tc.note(&format!("text = {text:?}"));
+    text
+}
+
+const COMMON_FEATURE_TAGS: &[&[u8; 4]] = &[
+    b"kern", b"liga", b"dlig", b"smcp", b"calt", b"ccmp", b"mark", b"mkmk", b"rlig", b"init",
+    b"medi", b"fina", b"isol", b"ss01", b"aalt", b"vert", b"frac", b"locl", b"test",
+];
+
+const VARIATION_TAGS: &[&[u8; 4]] = &[b"wght", b"wdth", b"slnt", b"ital", b"opsz", b"CNTR"];
+
+fn draw_tag(tc: &hegel::TestCase, common: &[&'static [u8; 4]]) -> Tag {
+    if tc.draw_silent(generators::booleans()) {
+        Tag::new(tc.draw_silent(generators::sampled_from(common.to_vec())))
+    } else {
+        Tag::new(&tc.draw_silent(generators::arrays(generators::integers::<u8>())))
+    }
+}
+
+fn draw_features(tc: &hegel::TestCase) -> Vec<Feature> {
+    let n = tc.draw_silent(generators::integers::<usize>().max_value(3));
+    (0..n)
+        .map(|_| {
+            let tag = draw_tag(tc, COMMON_FEATURE_TAGS);
+            let value = tc.draw_silent(hegel::one_of!(
+                generators::integers::<u32>().max_value(1),
+                generators::integers::<u32>(),
+            ));
+            // A feature is global unless it carries a range, and the two are
+            // handled by different code paths, so generate both.
+            let (start, end) = if tc.draw_silent(generators::booleans()) {
+                (0, u32::MAX)
+            } else {
+                (
+                    tc.draw_silent(generators::integers::<u32>()),
+                    tc.draw_silent(generators::integers::<u32>()),
+                )
+            };
+            Feature {
+                tag,
+                value,
+                start,
+                end,
+            }
+        })
+        .collect()
+}
+
+fn draw_variations(tc: &hegel::TestCase) -> Vec<Variation> {
+    let n = tc.draw_silent(generators::integers::<usize>().max_value(3));
+    (0..n)
+        .map(|_| Variation {
+            tag: draw_tag(tc, VARIATION_TAGS),
+            value: tc.draw_silent(generators::floats::<f32>()),
+        })
+        .collect()
+}
+
+const DIRECTIONS: &[Direction] = &[
+    Direction::LeftToRight,
+    Direction::RightToLeft,
+    Direction::TopToBottom,
+    Direction::BottomToTop,
+];
+
+const CLUSTER_LEVELS: &[BufferClusterLevel] = &[
+    BufferClusterLevel::MonotoneGraphemes,
+    BufferClusterLevel::MonotoneCharacters,
+    BufferClusterLevel::Characters,
+    BufferClusterLevel::Graphemes,
+];
+
+const SCRIPTS: &[harfrust::Script] = &[
+    script::LATIN,
+    script::ARABIC,
+    script::HEBREW,
+    script::DEVANAGARI,
+    script::KANNADA,
+    script::MALAYALAM,
+    script::SINHALA,
+    script::MYANMAR,
+    script::KHMER,
+    script::BALINESE,
+    script::TAI_THAM,
+    script::JAVANESE,
+    script::ETHIOPIC,
+    script::HAN,
+    script::HANGUL,
+    script::THAI,
+    script::COMMON,
+    script::UNKNOWN,
+];
+
+const LANGUAGES: &[&str] = &["en", "ar", "hi", "tr", "ja", "URD", "zh-cn", "az-ir", "sa"];
+
+/// The buffer settings that shaping reads, all of them generated.
+#[derive(Debug, Clone)]
+struct Settings {
+    direction: Direction,
+    script: Option<harfrust::Script>,
+    language: Option<Language>,
+    cluster_level: BufferClusterLevel,
+    flags: BufferFlags,
+    pre_context: Option<String>,
+    post_context: Option<String>,
+    not_found_variation_selector_glyph: Option<u32>,
+}
+
+fn draw_settings(tc: &hegel::TestCase) -> Settings {
+    // A direction is required: shaping without one is refused (see
+    // `shaping_without_a_direction_is_refused` in tests/buffer.rs).
+    let direction = tc.draw_silent(generators::sampled_from(DIRECTIONS.to_vec()));
+    let script = tc.draw_silent(generators::optional(generators::sampled_from(
+        SCRIPTS.to_vec(),
+    )));
+    let language = tc
+        .draw_silent(generators::optional(generators::sampled_from(
+            LANGUAGES.to_vec(),
+        )))
+        .and_then(Language::new);
+    let cluster_level = tc.draw_silent(generators::sampled_from(CLUSTER_LEVELS.to_vec()));
+    let flags = BufferFlags::from_bits_truncate(tc.draw_silent(generators::integers::<u32>()));
+    let pre_context = if tc.draw_silent(generators::booleans()) {
+        Some(draw_text(tc, 8))
+    } else {
+        None
+    };
+    let post_context = if tc.draw_silent(generators::booleans()) {
+        Some(draw_text(tc, 8))
+    } else {
+        None
+    };
+    // Values above `u16::MAX` are excluded here because they end up in
+    // `GlyphInfo::glyph_id`, which is documented to stay within `u16::MAX`;
+    // see `known_failure_not_found_variation_selector_glyph_exceeds_u16` for
+    // the pinned case.
+    let not_found_variation_selector_glyph = tc.draw_silent(generators::optional(
+        generators::integers::<u32>().max_value(u32::from(u16::MAX)),
+    ));
+    let settings = Settings {
+        direction,
+        script,
+        language,
+        cluster_level,
+        flags,
+        pre_context,
+        post_context,
+        not_found_variation_selector_glyph,
+    };
+    tc.note(&format!("settings = {settings:?}"));
+    settings
+}
+
+/// `Direction::is_forward` is crate-private, so mirror it here.
+fn is_forward(direction: Direction) -> bool {
+    matches!(direction, Direction::LeftToRight | Direction::TopToBottom)
+}
+
+fn fill_buffer(text: &str, s: &Settings) -> UnicodeBuffer {
+    let mut buffer = UnicodeBuffer::new();
+    buffer.push_str(text);
+    apply_settings(buffer, s)
+}
+
+/// Everything shaping produces, in a form two runs can be compared by.
+fn output(glyphs: &GlyphBuffer) -> Vec<(u32, u32, u32, i32, i32, i32, i32)> {
+    glyphs
+        .glyph_infos()
+        .iter()
+        .zip(glyphs.glyph_positions())
+        .map(|(i, p)| {
+            (
+                i.glyph_id,
+                i.cluster,
+                i.flags().to_bits(),
+                p.x_advance,
+                p.y_advance,
+                p.x_offset,
+                p.y_offset,
+            )
+        })
+        .collect()
+}
+
+/// Everything shaping produces except the glyph flags, which describe the run
+/// as a whole rather than the glyph.
+fn placement(glyphs: &GlyphBuffer) -> Vec<(u32, u32, i32, i32, i32, i32)> {
+    glyphs
+        .glyph_infos()
+        .iter()
+        .zip(glyphs.glyph_positions())
+        .map(|(i, p)| {
+            (
+                i.glyph_id,
+                i.cluster,
+                p.x_advance,
+                p.y_advance,
+                p.x_offset,
+                p.y_offset,
+            )
+        })
+        .collect()
+}
+
+fn ids_and_clusters(glyphs: &GlyphBuffer) -> Vec<(u32, u32)> {
+    glyphs
+        .glyph_infos()
+        .iter()
+        .map(|i| (i.glyph_id, i.cluster))
+        .collect()
+}
+
+/// Property: shaping and serializing never panic, whatever the font, text,
+/// features, variations, scale or buffer settings.
+///
+/// This is the contract the crate's own fuzz target asserts
+/// (`fuzz/fuzz_targets/fuzz_shape.rs`), widened from that target's fixed text
+/// and auto-detected properties to generated text and generated buffer
+/// settings.
+#[test]
+fn shaping_never_panics() {
+    let fonts = test_fonts();
+    hegel::Hegel::new(|tc| {
+        let (font, data) = &fonts[draw_font_index(&tc)];
+        let variations = draw_variations(&tc);
+        let instance = ShaperInstance::from_variations(font, &variations);
+        let shaper = data.shaper(font).instance(Some(&instance)).build();
+
+        let text = draw_text(&tc, 32);
+        let settings = draw_settings(&tc);
+        let features = draw_features(&tc);
+        let mut options = ShapeOptions::new().features(&features);
+        if tc.draw_silent(generators::booleans()) {
+            options = options.scale(Some(tc.draw(generators::integers::<i32>())));
+        }
+        if tc.draw_silent(generators::booleans()) {
+            options = options.point_size(Some(tc.draw(generators::floats::<f32>())));
+        }
+
+        let glyphs = shaper.shape(fill_buffer(&text, &settings), options);
+        drop(glyphs.serialize(
+            &shaper,
+            SerializeFlags::GLYPH_EXTENTS | SerializeFlags::GLYPH_FLAGS,
+        ));
+    })
+    .run();
+}
+
+/// Property: shaping the same input twice gives the same output.
+///
+/// The shaper caches lookups and cmap lookups across calls (`ShaperData`), so
+/// a second run over the same input goes through warmed caches; the result
+/// must not depend on that.
+#[test]
+fn shaping_is_deterministic() {
+    let fonts = test_fonts();
+    hegel::Hegel::new(|tc| {
+        let (font, data) = &fonts[draw_font_index(&tc)];
+        let variations = draw_variations(&tc);
+        let instance = ShaperInstance::from_variations(font, &variations);
+        let shaper = data.shaper(font).instance(Some(&instance)).build();
+
+        let text = draw_text(&tc, 32);
+        let settings = draw_settings(&tc);
+        let features = draw_features(&tc);
+
+        let once = shaper.shape(
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features),
+        );
+        let twice = shaper.shape(
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features),
+        );
+        assert_eq!(output(&once), output(&twice));
+    })
+    .run();
+}
+
+/// Property: shaping with a plan built for the buffer's properties gives the
+/// same result as letting `shape` build the plan itself.
+///
+/// `Shaper::shape_buffer` compiles exactly this plan when none is supplied, so
+/// the two paths must agree. `a_matching_plan_shapes` in tests/buffer.rs
+/// asserts the same thing for one fixed string.
+#[test]
+fn an_explicit_plan_matches_the_implicit_one() {
+    let fonts = test_fonts();
+    hegel::Hegel::new(|tc| {
+        let (font, data) = &fonts[draw_font_index(&tc)];
+        let shaper = data.shaper(font).build();
+
+        let text = draw_text(&tc, 32);
+        let settings = draw_settings(&tc);
+        let features = draw_features(&tc);
+
+        let implicit = shaper.shape(
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features),
+        );
+
+        let plan = ShapePlan::new(
+            &shaper,
+            settings.direction,
+            settings.script,
+            settings.language.as_ref(),
+            &features,
+        );
+        let explicit = shaper.shape(
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features).plan(Some(&plan)),
+        );
+
+        assert_eq!(output(&implicit), output(&explicit));
+    })
+    .run();
+}
+
+/// Property: shaping through `font::FontInstance` matches shaping through
+/// `FontRef`.
+///
+/// The two entry points reach different implementations of the font-data
+/// accessors (`FontKind::FontInstance` vs `FontKind::FontRef` in
+/// src/hb/face.rs) and must produce the same glyphs.
+/// `buffer_matches_typed_buffer_shaping` in tests/buffer.rs asserts the same
+/// thing for one fixed string.
+#[test]
+fn the_font_instance_path_matches_the_font_ref_path() {
+    use harfrust::font::{Font, FontInstance};
+
+    let fonts = test_fonts();
+    let instances: Vec<FontInstance> = font_bytes()
+        .iter()
+        .map(|bytes| {
+            let font = Font::new(bytes.clone(), 0).expect("model font should parse");
+            FontInstance::builder(&font).build()
+        })
+        .collect();
+
+    hegel::Hegel::new(|tc| {
+        let index = draw_font_index(&tc);
+        let (font, data) = &fonts[index];
+        let shaper = data.shaper(font).build();
+
+        let text = draw_text(&tc, 32);
+        let settings = draw_settings(&tc);
+        let features = draw_features(&tc);
+
+        let via_font_ref = shaper.shape(
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features),
+        );
+        let via_instance = harfrust::shape(
+            &instances[index],
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features),
+        );
+        assert_eq!(output(&via_font_ref), output(&via_instance));
+    })
+    .run();
+}
+
+/// Property: at the monotone cluster levels, output cluster values are
+/// non-decreasing in a forward direction and non-increasing in a backward one.
+///
+/// This is what "monotone" in the level names means, and what
+/// <https://harfbuzz.github.io/clusters.html> promises of levels 0 and 1.
+#[test]
+fn clusters_are_monotone_at_the_monotone_cluster_levels() {
+    let fonts = test_fonts();
+    hegel::Hegel::new(|tc| {
+        let (font, data) = &fonts[draw_font_index(&tc)];
+        let shaper = data.shaper(font).build();
+
+        let text = draw_text(&tc, 32);
+        let mut settings = draw_settings(&tc);
+        settings.cluster_level = tc.draw(
+            generators::sampled_from(vec![
+                BufferClusterLevel::MonotoneGraphemes,
+                BufferClusterLevel::MonotoneCharacters,
+            ])
+            .print_as_debug(),
+        );
+        let features = draw_features(&tc);
+
+        let glyphs = shaper.shape(
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features),
+        );
+        let clusters: Vec<u32> = glyphs.glyph_infos().iter().map(|i| i.cluster).collect();
+        let forward = is_forward(settings.direction);
+        for pair in clusters.windows(2) {
+            if forward {
+                assert!(pair[0] <= pair[1], "clusters not ascending: {clusters:?}");
+            } else {
+                assert!(pair[0] >= pair[1], "clusters not descending: {clusters:?}");
+            }
+        }
+    })
+    .run();
+}
+
+/// Property: every output cluster value is the UTF-8 byte offset of one of the
+/// input characters.
+///
+/// `UnicodeBuffer::push_str` documents that it assigns each character's byte
+/// offset as its cluster value, and shaping only ever merges clusters (taking
+/// the minimum) or copies them, so no other value can appear.
+#[test]
+fn clusters_are_input_character_offsets() {
+    let fonts = test_fonts();
+    hegel::Hegel::new(|tc| {
+        let (font, data) = &fonts[draw_font_index(&tc)];
+        let shaper = data.shaper(font).build();
+
+        let text = draw_text(&tc, 32);
+        let settings = draw_settings(&tc);
+        let features = draw_features(&tc);
+
+        let glyphs = shaper.shape(
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features),
+        );
+        let offsets: HashSet<u32> = text.char_indices().map(|(i, _)| i as u32).collect();
+        for info in glyphs.glyph_infos() {
+            assert!(
+                offsets.contains(&info.cluster),
+                "cluster {} is not a character offset of {text:?}",
+                info.cluster
+            );
+        }
+    })
+    .run();
+}
+
+/// Property: at a cluster start that is not flagged unsafe-to-break, shaping
+/// the two halves of the text separately and concatenating gives the same
+/// glyphs and positions as shaping the whole.
+///
+/// This is what `GlyphFlags::UNSAFE_TO_BREAK` documents: without the flag
+/// "it's safe to break the glyph-run at the beginning of this cluster, and the
+/// two sides represent the exact same result one would get if breaking input
+/// text at the beginning of this cluster and shaping the two sides
+/// separately".
+///
+/// The comparison leaves out the glyph flags: `UNSAFE_TO_CONCAT` describes
+/// whether a run can be joined onto its neighbours, which is a different
+/// question for a half than for the whole.
+///
+/// Ignored because it does not hold, and HarfBuzz does not uphold it either:
+/// see `known_failure_a_safe_break_can_change_an_arabic_joining_form`. The
+/// cases fall into two groups — a cluster's Arabic joining form changing, and
+/// a sequence recomposing or not depending on what follows it. Run it with
+/// `cargo test --test shaping -- --ignored safe_break`.
+#[test]
+#[ignore = "the unsafe-to-break flag does not cover joining or normalisation context"]
+fn safe_break_positions_shape_independently() {
+    let fonts = test_fonts();
+    hegel::Hegel::new(|tc| {
+        let (font, data) = &fonts[draw_font_index(&tc)];
+        let shaper = data.shaper(font).build();
+
+        let text = draw_text(&tc, 32);
+        let mut settings = draw_settings(&tc);
+        // The beginning/end-of-text flags describe the whole run, so they
+        // would legitimately differ between the halves and the whole.
+        settings.flags &= !(BufferFlags::BEGINNING_OF_TEXT | BufferFlags::END_OF_TEXT);
+        // Splitting the text moves what the context is; keep it unset so the
+        // halves see the same context the whole run did.
+        settings.pre_context = None;
+        settings.post_context = None;
+        // A monotone cluster level is what makes "the beginning of a cluster"
+        // a single position: at the other levels a cluster value can turn up
+        // in several places in the run, so there is no one break to test.
+        settings.cluster_level = tc.draw(
+            generators::sampled_from(vec![
+                BufferClusterLevel::MonotoneGraphemes,
+                BufferClusterLevel::MonotoneCharacters,
+            ])
+            .print_as_debug(),
+        );
+        let features = draw_features(&tc);
+        let options = || ShapeOptions::new().features(&features);
+
+        // Output is in visual order, so a backward run has to be turned back
+        // into logical order before its clusters can be lined up with the
+        // text's byte offsets or with a second run's.
+        let forward = is_forward(settings.direction);
+        let logical = |glyphs: &GlyphBuffer| {
+            let mut items = placement(glyphs);
+            if !forward {
+                items.reverse();
+            }
+            items
+        };
+
+        let whole = shaper.shape(fill_buffer(&text, &settings), options());
+        let items = logical(&whole);
+        // The flag is set on every glyph of an unsafe cluster, so a cluster is
+        // safe to break at when none of its glyphs carries it.
+        let unsafe_clusters: HashSet<u32> = whole
+            .glyph_infos()
+            .iter()
+            .filter(|info| info.unsafe_to_break())
+            .map(|info| info.cluster)
+            .collect();
+        let breaks: Vec<usize> = items
+            .windows(2)
+            .filter(|pair| pair[0].1 != pair[1].1 && !unsafe_clusters.contains(&pair[1].1))
+            .map(|pair| pair[1].1 as usize)
+            .filter(|split| *split > 0 && *split < text.len())
+            .collect();
+        if breaks.is_empty() {
+            return;
+        }
+        let split = breaks[tc.draw(generators::integers::<usize>().max_value(breaks.len() - 1))];
+        tc.note(&format!("split at byte {split}"));
+
+        let head = shaper.shape(fill_buffer(&text[..split], &settings), options());
+        let tail = shaper.shape(fill_buffer(&text[split..], &settings), options());
+
+        // Clusters in the tail restart from zero, so shift them back onto the
+        // whole run's offsets before comparing.
+        let mut joined = logical(&head);
+        joined.extend(logical(&tail).into_iter().map(|mut item| {
+            item.1 += split as u32;
+            item
+        }));
+        assert_eq!(items, joined);
+    })
+    .run();
+}
+
+/// Property: a font whose bytes have been truncated or corrupted either fails
+/// to parse or shapes without panicking.
+///
+/// Font data is untrusted input; this is the contract
+/// `fuzz/fuzz_targets/fuzz_shape.rs` asserts, with mutations of the repo's own
+/// fonts standing in for the fuzzer's corpus.
+#[test]
+fn shaping_mutated_fonts_never_panics() {
+    hegel::Hegel::new(|tc| {
+        let mut bytes = font_bytes()[draw_font_index(&tc)].clone();
+        if tc.draw(generators::booleans()) {
+            let len = tc.draw(generators::integers::<usize>().max_value(bytes.len()));
+            bytes.truncate(len);
+        }
+        let flips = tc.draw(generators::integers::<usize>().max_value(16));
+        for _ in 0..flips {
+            if bytes.is_empty() {
+                break;
+            }
+            let at = tc.draw(generators::integers::<usize>().max_value(bytes.len() - 1));
+            bytes[at] = tc.draw(generators::integers::<u8>());
+        }
+
+        let Ok(font) = FontRef::new(&bytes) else {
+            return;
+        };
+        let data = ShaperData::new(&font);
+        let variations = draw_variations(&tc);
+        let instance = ShaperInstance::from_variations(&font, &variations);
+        let shaper = data.shaper(&font).instance(Some(&instance)).build();
+
+        let text = draw_text(&tc, 16);
+        let settings = draw_settings(&tc);
+        let features = draw_features(&tc);
+        let glyphs = shaper.shape(
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features),
+        );
+        drop(glyphs.serialize(&shaper, SerializeFlags::GLYPH_EXTENTS));
+    })
+    .run();
+}
+
+/// Property: shaping into a buffer recycled with `GlyphBuffer::clear` gives
+/// the same result as shaping into a fresh one.
+///
+/// `clear` is documented as the way to get the `UnicodeBuffer` back "without
+/// allocating a new one", so nothing of the previous run may survive it. It
+/// resets direction, script, language and cluster level, so the settings are
+/// re-applied on both sides.
+#[test]
+fn a_recycled_buffer_matches_a_fresh_one() {
+    let fonts = test_fonts();
+    hegel::Hegel::new(|tc| {
+        let (font, data) = &fonts[draw_font_index(&tc)];
+        let shaper = data.shaper(font).build();
+
+        let first = draw_text(&tc, 32);
+        let second = draw_text(&tc, 32);
+        let settings = draw_settings(&tc);
+        let features = draw_features(&tc);
+        let options = || ShapeOptions::new().features(&features);
+
+        let used = shaper.shape(fill_buffer(&first, &settings), options());
+        let mut recycled = used.clear();
+        recycled.push_str(&second);
+        let recycled = apply_settings(recycled, &settings);
+        let recycled = shaper.shape(recycled, options());
+
+        let fresh = shaper.shape(fill_buffer(&second, &settings), options());
+        assert_eq!(output(&recycled), output(&fresh));
+    })
+    .run();
+}
+
+fn apply_settings(mut buffer: UnicodeBuffer, s: &Settings) -> UnicodeBuffer {
+    buffer.set_direction(s.direction);
+    if let Some(script) = s.script {
+        buffer.set_script(script);
+    }
+    if let Some(language) = &s.language {
+        buffer.set_language(language.clone());
+    }
+    buffer.set_cluster_level(s.cluster_level);
+    buffer.set_flags(s.flags);
+    if let Some(text) = &s.pre_context {
+        buffer.set_pre_context(text);
+    }
+    if let Some(text) = &s.post_context {
+        buffer.set_post_context(text);
+    }
+    if let Some(glyph) = s.not_found_variation_selector_glyph {
+        buffer.set_not_found_variation_selector_glyph(glyph);
+    }
+    buffer
+}
+
+/// KNOWN FAILURE: breaking the run at a cluster the shaper flagged as safe
+/// changes the Arabic joining form of the cluster before it.
+///
+/// `GlyphFlags::UNSAFE_TO_BREAK` promises that a break at an unflagged cluster
+/// gives "the exact same result" as shaping the two sides separately. Here
+/// U+0620 shapes to three glyphs in the whole run and to one on its own, while
+/// the cluster the break lands on carries no flag. HarfBuzz 11.3.3, through
+/// the `harfbuzz_rs` bindings in the dev-dependencies, produces the same
+/// glyphs and the same flags, so this is the flag's analysis falling short
+/// rather than a porting mistake.
+#[test]
+#[ignore = "the unsafe-to-break flag does not cover joining context"]
+fn known_failure_a_safe_break_can_change_an_arabic_joining_form() {
+    let bytes = fs::read(font_path("benches/fonts/NotoNastaliqUrdu-Regular.ttf")).unwrap();
+    let font = FontRef::new(&bytes).unwrap();
+    let data = ShaperData::new(&font);
+    let shaper = data.shaper(&font).build();
+
+    let text = "\u{0620}\u{200C}\u{200C}";
+    let split = 5;
+    let shape = |text: &str| {
+        let mut buffer = UnicodeBuffer::new();
+        buffer.push_str(text);
+        buffer.set_direction(Direction::LeftToRight);
+        buffer.set_script(script::SINHALA);
+        shaper.shape(buffer, ShapeOptions::new())
+    };
+
+    let whole = shape(text);
+    assert!(
+        !whole
+            .glyph_infos()
+            .iter()
+            .any(|i| i.cluster == split as u32 && i.unsafe_to_break()),
+        "the break has to be flagged safe for the rest to mean anything"
+    );
+
+    let head = shape(&text[..split]);
+    let tail = shape(&text[split..]);
+    let mut joined = ids_and_clusters(&head);
+    joined.extend(
+        ids_and_clusters(&tail)
+            .into_iter()
+            .map(|(id, cluster)| (id, cluster + split as u32)),
+    );
+    assert_eq!(ids_and_clusters(&whole), joined);
+}
+
+/// KNOWN FAILURE (harfbuzz/harfrust#409): a not-found variation-selector glyph
+/// above `u16::MAX` reaches `GlyphInfo::glyph_id`, which is documented as
+/// "Guarantee to be <= `u16::MAX`".
+///
+/// `deal_with_variation_selectors` (src/hb/ot_shape.rs) writes the value
+/// straight into `glyph_id`. The maintainer's response on #409 was that the
+/// documented bound should go rather than the value be clamped, so this pins
+/// the divergence between code and docs rather than asserting a contract the
+/// project has accepted.
+#[test]
+#[ignore = "harfbuzz/harfrust#409"]
+fn known_failure_not_found_variation_selector_glyph_exceeds_u16() {
+    let bytes = fs::read(font_path("tests/fonts/rb_custom/OpenSans.subset1.ttf")).unwrap();
+    let font = FontRef::new(&bytes).unwrap();
+    let data = ShaperData::new(&font);
+    let shaper = data.shaper(&font).build();
+
+    let mut buffer = UnicodeBuffer::new();
+    buffer.push_str("A\u{FE00}");
+    buffer.guess_segment_properties();
+    buffer.set_not_found_variation_selector_glyph(0x1_0000);
+
+    let glyphs: GlyphBuffer = shaper.shape(buffer, ShapeOptions::new());
+    assert!(
+        glyphs
+            .glyph_infos()
+            .iter()
+            .all(|i| u16::try_from(i.glyph_id).is_ok()),
+        "{:?}",
+        glyphs.glyph_infos()
+    );
+}
+
+/// Property: HarfRust picks the same glyphs, for the same clusters, as
+/// HarfBuzz.
+///
+/// This is the differential harness asked for in harfbuzz/harfrust#288, using
+/// the `harfbuzz_rs` bindings already in the dev-dependencies. It is scoped to
+/// what can be compared meaningfully through those bindings and against the
+/// HarfBuzz they vendor:
+///
+/// - Glyph ids and clusters only. Offsets diverge systematically wherever
+///   fallback mark positioning runs, because `GlyphMetrics`
+///   (src/hb/glyph_metrics.rs) reads extents from `glyf` only, so CFF glyphs
+///   have no extents to position marks against.
+/// - Global features only. `harfbuzz_rs::Feature::new` takes a cluster range
+///   rather than raw `start`/`end`, so a generated range cannot be handed over
+///   unambiguously.
+/// - No buffer flags and cluster levels 0 to 2: `harfbuzz_rs` exposes neither
+///   `hb_buffer_set_flags` nor cluster level 3.
+///
+/// Ignored because the oracle is behind: `harfbuzz_rs` vendors HarfBuzz
+/// 11.3.3 while HarfRust tracks a newer HarfBuzz (harfbuzz/harfrust#412), so a
+/// divergence has to be triaged against current HarfBuzz before it means
+/// anything. Run it with
+/// `cargo test --test shaping -- --ignored harfbuzz`.
+#[test]
+#[ignore = "oracle is the HarfBuzz 11.3.3 that harfbuzz_rs vendors; divergences need triage"]
+fn matches_harfbuzz() {
+    let fonts = test_fonts();
+    hegel::Hegel::new(|tc| {
+        let index = draw_font_index(&tc);
+        let (font, data) = &fonts[index];
+        let shaper = data.shaper(font).build();
+
+        let text = draw_text(&tc, 32);
+        let mut settings = draw_settings(&tc);
+        settings.flags = BufferFlags::empty();
+        settings.pre_context = None;
+        settings.post_context = None;
+        settings.not_found_variation_selector_glyph = None;
+        tc.assume(settings.cluster_level != BufferClusterLevel::Graphemes);
+        // HarfBuzz fills unset properties in from the locale, so pin both.
+        let script = settings.script.unwrap_or(script::LATIN);
+        settings.script = Some(script);
+        let language = settings.language.clone().or_else(|| Language::new("en"));
+        settings.language = language.clone();
+        let language = language.unwrap();
+
+        let features: Vec<Feature> = draw_features(&tc)
+            .into_iter()
+            .map(|f| Feature {
+                start: 0,
+                end: u32::MAX,
+                ..f
+            })
+            .collect();
+
+        let ours = ids_and_clusters(&shaper.shape(
+            fill_buffer(&text, &settings),
+            ShapeOptions::new().features(&features),
+        ));
+
+        let face = harfbuzz_rs::Face::from_bytes(&font_bytes()[index], 0);
+        let hb_font = harfbuzz_rs::Font::new(face);
+        let buffer = harfbuzz_rs::UnicodeBuffer::new()
+            .add_str(&text)
+            .set_direction(hb_direction(settings.direction))
+            .set_script(hb_tag(script.tag()))
+            .set_language(language.as_str().parse().expect("non-empty language"))
+            .set_cluster_level(match settings.cluster_level {
+                BufferClusterLevel::MonotoneGraphemes => {
+                    harfbuzz_rs::ClusterLevel::MonotoneGraphemes
+                }
+                BufferClusterLevel::MonotoneCharacters => {
+                    harfbuzz_rs::ClusterLevel::MonotoneCharacters
+                }
+                _ => harfbuzz_rs::ClusterLevel::Characters,
+            });
+        let hb_features: Vec<harfbuzz_rs::Feature> = features
+            .iter()
+            .map(|f| harfbuzz_rs::Feature::new(hb_tag(f.tag), f.value, ..))
+            .collect();
+        let shaped = harfbuzz_rs::shape(&hb_font, buffer, &hb_features);
+        // Reading the glyph arrays of an empty HarfBuzz buffer through
+        // `harfbuzz_rs` dereferences a null pointer, so stop short of it.
+        let theirs: Vec<(u32, u32)> = if shaped.is_empty() {
+            Vec::new()
+        } else {
+            shaped
+                .get_glyph_infos()
+                .iter()
+                .map(|i| (i.codepoint, i.cluster))
+                .collect()
+        };
+
+        assert_eq!(ours, theirs, "{}", PROPERTY_FONTS[index]);
+    })
+    .run();
+}
+
+fn hb_tag(tag: Tag) -> harfbuzz_rs::Tag {
+    harfbuzz_rs::Tag(u32::from_be_bytes(tag.to_be_bytes()))
+}
+
+fn hb_direction(direction: Direction) -> harfbuzz_rs::Direction {
+    match direction {
+        Direction::Invalid => harfbuzz_rs::Direction::Invalid,
+        Direction::LeftToRight => harfbuzz_rs::Direction::Ltr,
+        Direction::RightToLeft => harfbuzz_rs::Direction::Rtl,
+        Direction::TopToBottom => harfbuzz_rs::Direction::Ttb,
+        Direction::BottomToTop => harfbuzz_rs::Direction::Btt,
+    }
+}

--- a/harfrust/tests/shaping/properties.rs
+++ b/harfrust/tests/shaping/properties.rs
@@ -1,4 +1,15 @@
 //! Property-based tests for the shaping API.
+//!
+//! Each test runs 100 cases (`HEGEL_TEST_CASES` changes that) and calls
+//! `hegel::Hegel::new` rather than using `#[hegel::test]`, so that `test_fonts()`
+//! runs once per test rather than once per case. A failing case is shrunk and
+//! printed, but a run built this way has no database key, so unlike a
+//! `#[hegel::test]` function it is not saved under `.hegel/` for replay.
+//! Composite inputs are drawn with `draw_silent` and recorded with `tc.note`, so
+//! the report names the font, the text, the settings, the features and the
+//! variations rather than every draw that built them. A test that adjusts a
+//! drawn input before using it draws the `_silent` variant and notes the
+//! adjusted value.
 
 use std::collections::HashSet;
 use std::fs;
@@ -10,7 +21,7 @@ use harfrust::{
     SerializeFlags, ShapeOptions, ShapePlan, ShaperData, ShaperInstance, Tag, UnicodeBuffer,
     Variation,
 };
-use hegel::generators::{self, Generator};
+use hegel::generators;
 
 /// Fonts spanning the shapers: OpenType GSUB/GPOS, the complex-script shapers
 /// (Arabic, Indic, USE, Myanmar, Khmer, Hangul), AAT (`morx`/`kerx`/`trak`),
@@ -125,8 +136,14 @@ fn draw_codepoint_in(tc: &hegel::TestCase, lo: u32, hi: u32) -> char {
 
 /// Draws text biased towards a single script run, with special characters and
 /// fully arbitrary codepoints mixed in.
-fn draw_text(tc: &hegel::TestCase, max_len: usize) -> String {
-    let text = if tc.draw_silent(generators::integers::<u8>().max_value(4)) == 0 {
+fn draw_text(tc: &hegel::TestCase, name: &str, max_len: usize) -> String {
+    let text = draw_text_silent(tc, max_len);
+    tc.note(&format!("{name} = {text:?}"));
+    text
+}
+
+fn draw_text_silent(tc: &hegel::TestCase, max_len: usize) -> String {
+    if tc.draw_silent(generators::integers::<u8>().max_value(4)) == 0 {
         tc.draw_silent(generators::text().max_size(max_len))
     } else {
         let block = tc.draw_silent(generators::sampled_from(SCRIPT_BLOCKS.to_vec()));
@@ -145,9 +162,7 @@ fn draw_text(tc: &hegel::TestCase, max_len: usize) -> String {
             );
         }
         text
-    };
-    tc.note(&format!("text = {text:?}"));
-    text
+    }
 }
 
 const COMMON_FEATURE_TAGS: &[&[u8; 4]] = &[
@@ -166,6 +181,12 @@ fn draw_tag(tc: &hegel::TestCase, common: &[&'static [u8; 4]]) -> Tag {
 }
 
 fn draw_features(tc: &hegel::TestCase) -> Vec<Feature> {
+    let features = draw_features_silent(tc);
+    tc.note(&format!("features = {features:?}"));
+    features
+}
+
+fn draw_features_silent(tc: &hegel::TestCase) -> Vec<Feature> {
     let n = tc.draw_silent(generators::integers::<usize>().max_value(3));
     (0..n)
         .map(|_| {
@@ -196,12 +217,14 @@ fn draw_features(tc: &hegel::TestCase) -> Vec<Feature> {
 
 fn draw_variations(tc: &hegel::TestCase) -> Vec<Variation> {
     let n = tc.draw_silent(generators::integers::<usize>().max_value(3));
-    (0..n)
+    let variations: Vec<Variation> = (0..n)
         .map(|_| Variation {
             tag: draw_tag(tc, VARIATION_TAGS),
             value: tc.draw_silent(generators::floats::<f32>()),
         })
-        .collect()
+        .collect();
+    tc.note(&format!("variations = {variations:?}"));
+    variations
 }
 
 const DIRECTIONS: &[Direction] = &[
@@ -255,6 +278,12 @@ struct Settings {
 }
 
 fn draw_settings(tc: &hegel::TestCase) -> Settings {
+    let settings = draw_settings_silent(tc);
+    tc.note(&format!("settings = {settings:?}"));
+    settings
+}
+
+fn draw_settings_silent(tc: &hegel::TestCase) -> Settings {
     // A direction is required: shaping without one is refused (see
     // `shaping_without_a_direction_is_refused` in tests/buffer.rs).
     let direction = tc.draw_silent(generators::sampled_from(DIRECTIONS.to_vec()));
@@ -269,12 +298,12 @@ fn draw_settings(tc: &hegel::TestCase) -> Settings {
     let cluster_level = tc.draw_silent(generators::sampled_from(CLUSTER_LEVELS.to_vec()));
     let flags = BufferFlags::from_bits_truncate(tc.draw_silent(generators::integers::<u32>()));
     let pre_context = if tc.draw_silent(generators::booleans()) {
-        Some(draw_text(tc, 8))
+        Some(draw_text_silent(tc, 8))
     } else {
         None
     };
     let post_context = if tc.draw_silent(generators::booleans()) {
-        Some(draw_text(tc, 8))
+        Some(draw_text_silent(tc, 8))
     } else {
         None
     };
@@ -285,7 +314,7 @@ fn draw_settings(tc: &hegel::TestCase) -> Settings {
     let not_found_variation_selector_glyph = tc.draw_silent(generators::optional(
         generators::integers::<u32>().max_value(u32::from(u16::MAX)),
     ));
-    let settings = Settings {
+    Settings {
         direction,
         script,
         language,
@@ -294,9 +323,7 @@ fn draw_settings(tc: &hegel::TestCase) -> Settings {
         pre_context,
         post_context,
         not_found_variation_selector_glyph,
-    };
-    tc.note(&format!("settings = {settings:?}"));
-    settings
+    }
 }
 
 /// `Direction::is_forward` is crate-private, so mirror it here.
@@ -374,7 +401,7 @@ fn shaping_never_panics() {
         let instance = ShaperInstance::from_variations(font, &variations);
         let shaper = data.shaper(font).instance(Some(&instance)).build();
 
-        let text = draw_text(&tc, 32);
+        let text = draw_text(&tc, "text", 32);
         let settings = draw_settings(&tc);
         let features = draw_features(&tc);
         let mut options = ShapeOptions::new().features(&features);
@@ -408,7 +435,7 @@ fn shaping_is_deterministic() {
         let instance = ShaperInstance::from_variations(font, &variations);
         let shaper = data.shaper(font).instance(Some(&instance)).build();
 
-        let text = draw_text(&tc, 32);
+        let text = draw_text(&tc, "text", 32);
         let settings = draw_settings(&tc);
         let features = draw_features(&tc);
 
@@ -438,7 +465,7 @@ fn an_explicit_plan_matches_the_implicit_one() {
         let (font, data) = &fonts[draw_font_index(&tc)];
         let shaper = data.shaper(font).build();
 
-        let text = draw_text(&tc, 32);
+        let text = draw_text(&tc, "text", 32);
         let settings = draw_settings(&tc);
         let features = draw_features(&tc);
 
@@ -490,7 +517,7 @@ fn the_font_instance_path_matches_the_font_ref_path() {
         let (font, data) = &fonts[index];
         let shaper = data.shaper(font).build();
 
-        let text = draw_text(&tc, 32);
+        let text = draw_text(&tc, "text", 32);
         let settings = draw_settings(&tc);
         let features = draw_features(&tc);
 
@@ -520,15 +547,13 @@ fn clusters_are_monotone_at_the_monotone_cluster_levels() {
         let (font, data) = &fonts[draw_font_index(&tc)];
         let shaper = data.shaper(font).build();
 
-        let text = draw_text(&tc, 32);
-        let mut settings = draw_settings(&tc);
-        settings.cluster_level = tc.draw(
-            generators::sampled_from(vec![
-                BufferClusterLevel::MonotoneGraphemes,
-                BufferClusterLevel::MonotoneCharacters,
-            ])
-            .print_as_debug(),
-        );
+        let text = draw_text(&tc, "text", 32);
+        let mut settings = draw_settings_silent(&tc);
+        settings.cluster_level = tc.draw_silent(generators::sampled_from(vec![
+            BufferClusterLevel::MonotoneGraphemes,
+            BufferClusterLevel::MonotoneCharacters,
+        ]));
+        tc.note(&format!("settings = {settings:?}"));
         let features = draw_features(&tc);
 
         let glyphs = shaper.shape(
@@ -561,7 +586,7 @@ fn clusters_are_input_character_offsets() {
         let (font, data) = &fonts[draw_font_index(&tc)];
         let shaper = data.shaper(font).build();
 
-        let text = draw_text(&tc, 32);
+        let text = draw_text(&tc, "text", 32);
         let settings = draw_settings(&tc);
         let features = draw_features(&tc);
 
@@ -597,9 +622,11 @@ fn clusters_are_input_character_offsets() {
 ///
 /// Ignored because it does not hold, and HarfBuzz does not uphold it either:
 /// see `known_failure_a_safe_break_can_change_an_arabic_joining_form`. The
-/// cases fall into two groups — a cluster's Arabic joining form changing, and
-/// a sequence recomposing or not depending on what follows it. Run it with
-/// `cargo test --test shaping -- --ignored safe_break`.
+/// failures seen so far include a cluster's Arabic joining form changing, a
+/// sequence recomposing or not depending on what follows it, and default
+/// ignorables at the start of the tail merging into one cluster. Failing
+/// cases are rare enough that the default 100 usually pass, so run it as
+/// `HEGEL_TEST_CASES=20000 cargo test --test shaping -- --ignored safe_break`.
 #[test]
 #[ignore = "the unsafe-to-break flag does not cover joining or normalisation context"]
 fn safe_break_positions_shape_independently() {
@@ -608,8 +635,8 @@ fn safe_break_positions_shape_independently() {
         let (font, data) = &fonts[draw_font_index(&tc)];
         let shaper = data.shaper(font).build();
 
-        let text = draw_text(&tc, 32);
-        let mut settings = draw_settings(&tc);
+        let text = draw_text(&tc, "text", 32);
+        let mut settings = draw_settings_silent(&tc);
         // The beginning/end-of-text flags describe the whole run, so they
         // would legitimately differ between the halves and the whole.
         settings.flags &= !(BufferFlags::BEGINNING_OF_TEXT | BufferFlags::END_OF_TEXT);
@@ -620,13 +647,11 @@ fn safe_break_positions_shape_independently() {
         // A monotone cluster level is what makes "the beginning of a cluster"
         // a single position: at the other levels a cluster value can turn up
         // in several places in the run, so there is no one break to test.
-        settings.cluster_level = tc.draw(
-            generators::sampled_from(vec![
-                BufferClusterLevel::MonotoneGraphemes,
-                BufferClusterLevel::MonotoneCharacters,
-            ])
-            .print_as_debug(),
-        );
+        settings.cluster_level = tc.draw_silent(generators::sampled_from(vec![
+            BufferClusterLevel::MonotoneGraphemes,
+            BufferClusterLevel::MonotoneCharacters,
+        ]));
+        tc.note(&format!("settings = {settings:?}"));
         let features = draw_features(&tc);
         let options = || ShapeOptions::new().features(&features);
 
@@ -661,7 +686,8 @@ fn safe_break_positions_shape_independently() {
         if breaks.is_empty() {
             return;
         }
-        let split = breaks[tc.draw(generators::integers::<usize>().max_value(breaks.len() - 1))];
+        let split =
+            breaks[tc.draw_silent(generators::integers::<usize>().max_value(breaks.len() - 1))];
         tc.note(&format!("split at byte {split}"));
 
         let head = shaper.shape(fill_buffer(&text[..split], &settings), options());
@@ -710,7 +736,7 @@ fn shaping_mutated_fonts_never_panics() {
         let instance = ShaperInstance::from_variations(&font, &variations);
         let shaper = data.shaper(&font).instance(Some(&instance)).build();
 
-        let text = draw_text(&tc, 16);
+        let text = draw_text(&tc, "text", 16);
         let settings = draw_settings(&tc);
         let features = draw_features(&tc);
         let glyphs = shaper.shape(
@@ -736,8 +762,8 @@ fn a_recycled_buffer_matches_a_fresh_one() {
         let (font, data) = &fonts[draw_font_index(&tc)];
         let shaper = data.shaper(font).build();
 
-        let first = draw_text(&tc, 32);
-        let second = draw_text(&tc, 32);
+        let first = draw_text(&tc, "first", 32);
+        let second = draw_text(&tc, "second", 32);
         let settings = draw_settings(&tc);
         let features = draw_features(&tc);
         let options = || ShapeOptions::new().features(&features);
@@ -889,8 +915,8 @@ fn matches_harfbuzz() {
         let (font, data) = &fonts[index];
         let shaper = data.shaper(font).build();
 
-        let text = draw_text(&tc, 32);
-        let mut settings = draw_settings(&tc);
+        let text = draw_text(&tc, "text", 32);
+        let mut settings = draw_settings_silent(&tc);
         settings.flags = BufferFlags::empty();
         settings.pre_context = None;
         settings.post_context = None;
@@ -902,8 +928,9 @@ fn matches_harfbuzz() {
         let language = settings.language.clone().or_else(|| Language::new("en"));
         settings.language = language.clone();
         let language = language.unwrap();
+        tc.note(&format!("settings = {settings:?}"));
 
-        let features: Vec<Feature> = draw_features(&tc)
+        let features: Vec<Feature> = draw_features_silent(&tc)
             .into_iter()
             .map(|f| Feature {
                 start: 0,
@@ -911,6 +938,7 @@ fn matches_harfbuzz() {
                 ..f
             })
             .collect();
+        tc.note(&format!("features = {features:?}"));
 
         let ours = ids_and_clusters(&shaper.shape(
             fill_buffer(&text, &settings),


### PR DESCRIPTION
Following up on #409, where you said tests for that bug would be nice to have. Claude Code wrote the tests and this description. Please read this as an offer of code rather than an imposition: if it is more than you want to own, or the wrong shape for the repo, say so and no offence will be taken.

The last commit adds a differential harness that shapes the same input through HarfBuzz itself, which brings in a dev-dependency on `harfbuzz_rs`. It is `#[ignore]`d, because `harfbuzz_rs` vendors HarfBuzz 11.3.3 while HarfRust tracks something newer (#412), so a divergence it reports has to be triaged against current HarfBuzz before it means anything. Say if you'd rather it went.

Six tests are `#[ignore]`d: that harness, a pin for #409, and four things I haven't filed. The #409 pin is the not-found variation selector glyph above `u16::MAX` reaching `GlyphInfo::glyph_id`, and it pins the disagreement between the code and the docs rather than the bound you said should go. Each of the four unfiled ones has its reason in a comment above it. One is a cmap entry resolving to glyph 0, which HarfRust treats as a hit and HarfBuzz treats as a miss, and which may belong in `read-fonts` rather than here. One is the `i64` multiply in `Scale::scale_by_mult`, which is unguarded but not reachable through the public API at any advance that fits in a `u16`. The other two are cases where breaking at a cluster that isn't flagged `UNSAFE_TO_BREAK` still changes the result, which HarfBuzz 11.3.3 doesn't uphold either. Say if you'd like any of those filed as issues, or the pins dropped.
