### PR TITLE
Port HarfBuzz shaping-loop and digest optimizations

### DIFF
--- a/harfrust/src/hb/buffer.rs
+++ b/harfrust/src/hb/buffer.rs
@@ -1099,12 +1099,6 @@ impl Buffer {
         self.idx += 1;
     }
 
-    pub(crate) fn reset_masks(&mut self, mask: hb_mask_t) {
-        for info in &mut self.info[..self.len] {
-            info.mask = mask;
-        }
-    }
-
     pub(crate) fn set_masks(
         &mut self,
         mut value: hb_mask_t,

--- a/harfrust/src/hb/ot/contextual.rs
+++ b/harfrust/src/hb/ot/contextual.rs
@@ -1,12 +1,14 @@
-use super::{coverage_binary_cached, coverage_index, covered, glyph_class};
+use alloc::boxed::Box;
+
+use super::{coverage_binary_cached, coverage_index, covered, glyph_class, glyph_class_cached};
 use crate::hb::buffer::GlyphInfo;
 use crate::hb::ot::{ClassDefInfo, CoverageInfo};
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
     apply_lookup, match_always, match_backtrack, match_glyph, match_input, match_lookahead,
-    may_skip_t, skipping_iterator_t, Apply, BinaryCache, ChainContextFormat2Cache,
-    ContextFormat2Cache, SubtableExternalCache, SubtableExternalCacheMode, WouldApply,
-    WouldApplyContext,
+    may_skip_t, skipping_iterator_t, Apply, BinaryCache, ChainContextClassCaches,
+    ChainContextFormat2Cache, ContextFormat2Cache, MappingCache, SubtableExternalCache,
+    SubtableExternalCacheMode, WouldApply, WouldApplyContext,
 };
 use read_fonts::tables::gsub::ClassDef;
 use read_fonts::tables::layout::{
@@ -360,18 +362,53 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
             glyph,
             &cache.coverage_cache,
         )?;
-        let index = cache.input.class(&offset_data, glyph) as usize;
+        let input_class = |gid| cache.input.class(&offset_data, gid);
+        let lookahead_class = |gid| cache.lookahead.class(&offset_data, gid);
+        let class_caches = cache.class_caches.as_deref();
+        let index = class_caches.map_or_else(
+            || input_class(glyph),
+            |caches| glyph_class_cached(input_class, glyph, &caches.input),
+        ) as usize;
         let set = self.chained_class_seq_rule_sets().get(index)?.ok()?;
-        apply_chain_context_rules(
-            ctx,
-            set.offset_data(),
-            set.chained_class_seq_rule_offsets(),
-            (
-                |info, val| u32::from(cache.backtrack.class(&offset_data, info.as_glyph())) == val,
-                |info, val| u32::from(cache.input.class(&offset_data, info.as_glyph())) == val,
-                |info, val| u32::from(cache.lookahead.class(&offset_data, info.as_glyph())) == val,
-            ),
-        )
+        if let Some(class_caches) = class_caches {
+            apply_chain_context_rules(
+                ctx,
+                set.offset_data(),
+                set.chained_class_seq_rule_offsets(),
+                (
+                    |info, val| {
+                        u32::from(cache.backtrack.class(&offset_data, info.as_glyph())) == val
+                    },
+                    |info, val| {
+                        u32::from(glyph_class_cached(
+                            input_class,
+                            info.as_glyph(),
+                            &class_caches.input,
+                        )) == val
+                    },
+                    |info, val| {
+                        u32::from(glyph_class_cached(
+                            lookahead_class,
+                            info.as_glyph(),
+                            &class_caches.lookahead,
+                        )) == val
+                    },
+                ),
+            )
+        } else {
+            apply_chain_context_rules(
+                ctx,
+                set.offset_data(),
+                set.chained_class_seq_rule_offsets(),
+                (
+                    |info, val| {
+                        u32::from(cache.backtrack.class(&offset_data, info.as_glyph())) == val
+                    },
+                    |info, val| u32::from(input_class(info.as_glyph())) == val,
+                    |info, val| u32::from(lookahead_class(info.as_glyph())) == val,
+                ),
+            )
+        }
     }
     fn apply_cached(
         &self,
@@ -413,7 +450,7 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
                 .map_or(0, |class_def| class_def.cost())
     }
 
-    fn external_cache_create(&self, _mode: SubtableExternalCacheMode) -> SubtableExternalCache {
+    fn external_cache_create(&self, mode: SubtableExternalCacheMode) -> SubtableExternalCache {
         let data = self.offset_data();
         SubtableExternalCache::ChainContextFormat2Cache(ChainContextFormat2Cache {
             coverage_cache: BinaryCache::new(),
@@ -425,6 +462,13 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
                 .unwrap_or_default(),
             lookahead: ClassDefInfo::new(&data, self.lookahead_class_def_offset().to_u32() as u16)
                 .unwrap_or_default(),
+            class_caches: match mode {
+                SubtableExternalCacheMode::Full => Some(Box::new(ChainContextClassCaches {
+                    input: MappingCache::new(),
+                    lookahead: MappingCache::new(),
+                })),
+                SubtableExternalCacheMode::Small | SubtableExternalCacheMode::None => None,
+            },
         })
     }
 }

--- a/harfrust/src/hb/ot/contextual.rs
+++ b/harfrust/src/hb/ot/contextual.rs
@@ -1,4 +1,4 @@
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 
 use super::{coverage_binary_cached, coverage_index, covered, glyph_class, glyph_class_cached};
 use crate::hb::buffer::GlyphInfo;
@@ -7,8 +7,8 @@ use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
 use crate::hb::ot_layout_gsubgpos::{
     apply_lookup, match_always, match_backtrack, match_glyph, match_input, match_lookahead,
     may_skip_t, skipping_iterator_t, Apply, BinaryCache, ChainContextClassCaches,
-    ChainContextFormat2Cache, ContextFormat2Cache, MappingCache, SubtableExternalCache,
-    SubtableExternalCacheMode, WouldApply, WouldApplyContext,
+    ChainContextFormat2Cache, ContextFormat2Cache, MappingCache, RuleSetDigest,
+    SubtableExternalCache, SubtableExternalCacheMode, WouldApply, WouldApplyContext,
 };
 use read_fonts::tables::gsub::ClassDef;
 use read_fonts::tables::layout::{
@@ -18,6 +18,42 @@ use read_fonts::tables::layout::{
 };
 use read_fonts::types::{BigEndian, FixedSize, GlyphId, Offset16};
 use read_fonts::FontData;
+
+fn context_rule_set_digests(table: &SequenceContextFormat2<'_>) -> Box<[RuleSetDigest]> {
+    table
+        .class_seq_rule_sets()
+        .iter()
+        .map(|rule_set| match rule_set {
+            None => RuleSetDigest::default(),
+            Some(Err(_)) => RuleSetDigest::full(),
+            Some(Ok(rule_set)) => rule_set_digest(
+                rule_set.offset_data(),
+                rule_set.class_seq_rule_offsets(),
+                plain_rule_data_at,
+                plain_rule_first_input,
+            ),
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+fn chain_rule_set_digests(table: &ChainedSequenceContextFormat2<'_>) -> Box<[RuleSetDigest]> {
+    table
+        .chained_class_seq_rule_sets()
+        .iter()
+        .map(|rule_set| match rule_set {
+            None => RuleSetDigest::default(),
+            Some(Err(_)) => RuleSetDigest::full(),
+            Some(Ok(rule_set)) => rule_set_digest(
+                rule_set.offset_data(),
+                rule_set.chained_class_seq_rule_offsets(),
+                chain_rule_data_at,
+                chain_rule_first_input,
+            ),
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
 
 impl WouldApply for SequenceContextFormat1<'_> {
     fn would_apply(&self, ctx: &WouldApplyContext) -> bool {
@@ -52,7 +88,14 @@ impl Apply for SequenceContextFormat1<'_> {
         let glyph = ctx.buffer.cur(0).as_glyph();
         let index = self.coverage().ok()?.get(glyph)? as usize;
         let set = self.seq_rule_sets().get(index)?.ok()?;
-        apply_context_rules(ctx, set.offset_data(), set.seq_rule_offsets(), match_glyph)
+        apply_context_rules(
+            ctx,
+            set.offset_data(),
+            set.seq_rule_offsets(),
+            match_glyph,
+            None,
+            |_| 0,
+        )
     }
 }
 
@@ -102,12 +145,15 @@ impl Apply for SequenceContextFormat2<'_> {
         )?;
         let input_class = |gid| cache.input.class(&offset_data, gid);
         let index = input_class(glyph) as usize;
+        let digest = cache.rule_sets.get(index).copied();
         let set = self.class_seq_rule_sets().get(index)?.ok()?;
         apply_context_rules(
             ctx,
             set.offset_data(),
             set.class_seq_rule_offsets(),
             |info, value| u32::from(input_class(info.as_glyph())) == value,
+            digest,
+            |info| input_class(info.as_glyph()),
         )
     }
 
@@ -128,12 +174,15 @@ impl Apply for SequenceContextFormat2<'_> {
         )?;
         let input_class = |gid| cache.input.class(&offset_data, gid);
         let index = get_class_cached(&input_class, &mut ctx.buffer.info[ctx.buffer.idx]) as usize;
+        let digest = cache.rule_sets.get(index).copied();
         let set = self.class_seq_rule_sets().get(index)?.ok()?;
         apply_context_rules(
             ctx,
             set.offset_data(),
             set.class_seq_rule_offsets(),
-            match_class_cached(&input_class),
+            |info, value| u32::from(get_class_cached(&input_class, info)) == value,
+            digest,
+            |info| get_class_cached(&input_class, info),
         )
     }
 
@@ -151,6 +200,7 @@ impl Apply for SequenceContextFormat2<'_> {
                 .unwrap_or_default(),
             input: ClassDefInfo::new(&data, self.class_def_offset().to_u32() as u16)
                 .unwrap_or_default(),
+            rule_sets: context_rule_set_digests(self),
         })
     }
 }
@@ -242,6 +292,8 @@ impl Apply for ChainedSequenceContextFormat1<'_> {
             set.offset_data(),
             set.chained_seq_rule_offsets(),
             (match_glyph, match_glyph, match_glyph),
+            None,
+            |_| 0,
         )
     }
 }
@@ -299,12 +351,6 @@ fn get_class_cached(class_def: &impl Fn(GlyphId) -> u16, info: &mut GlyphInfo) -
     }
 
     klass
-}
-
-fn match_class_cached<'a>(
-    class_def: impl Fn(GlyphId) -> u16 + 'a,
-) -> impl Fn(&mut GlyphInfo, u32) -> bool + 'a {
-    move |info: &mut GlyphInfo, value| u32::from(get_class_cached(&class_def, info)) == value
 }
 
 fn get_class_cached1(class_def: &impl Fn(GlyphId) -> u16, info: &mut GlyphInfo) -> u16 {
@@ -369,6 +415,7 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
             || input_class(glyph),
             |caches| glyph_class_cached(input_class, glyph, &caches.input),
         ) as usize;
+        let digest = cache.rule_sets.get(index).copied();
         let set = self.chained_class_seq_rule_sets().get(index)?.ok()?;
         if let Some(class_caches) = class_caches {
             apply_chain_context_rules(
@@ -394,6 +441,8 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
                         )) == val
                     },
                 ),
+                digest,
+                |info| glyph_class_cached(input_class, info.as_glyph(), &class_caches.input),
             )
         } else {
             apply_chain_context_rules(
@@ -407,6 +456,8 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
                     |info, val| u32::from(input_class(info.as_glyph())) == val,
                     |info, val| u32::from(lookahead_class(info.as_glyph())) == val,
                 ),
+                digest,
+                |info| input_class(info.as_glyph()),
             )
         }
     }
@@ -428,6 +479,7 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
         let input_class = |gid| cache.input.class(&offset_data, gid);
         let lookahead_class = |gid| cache.lookahead.class(&offset_data, gid);
         let index = get_class_cached2(&input_class, &mut ctx.buffer.info[ctx.buffer.idx]) as usize;
+        let digest = cache.rule_sets.get(index).copied();
         let set = self.chained_class_seq_rule_sets().get(index)?.ok()?;
         apply_chain_context_rules(
             ctx,
@@ -438,6 +490,8 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
                 match_class_cached2(&input_class),
                 match_class_cached1(&lookahead_class),
             ),
+            digest,
+            |info| get_class_cached2(&input_class, info),
         )
     }
     fn cache_cost(&self) -> u32 {
@@ -469,6 +523,7 @@ impl Apply for ChainedSequenceContextFormat2<'_> {
                 })),
                 SubtableExternalCacheMode::Small | SubtableExternalCacheMode::None => None,
             },
+            rule_sets: chain_rule_set_digests(self),
         })
     }
 }
@@ -769,6 +824,25 @@ fn chain_rule_data_at<'a>(
     (data.len() >= ChainedSequenceRule::MIN_SIZE).then_some(data)
 }
 
+fn rule_set_digest<'a>(
+    set_data: FontData<'a>,
+    rule_offsets: &[BigEndian<Offset16>],
+    rule_data_at: fn(FontData<'a>, &BigEndian<Offset16>) -> Option<FontData<'a>>,
+    first_input: fn(&FontData<'a>) -> Option<u16>,
+) -> RuleSetDigest {
+    let mut digest = RuleSetDigest::default();
+    for offset in rule_offsets {
+        let Some(data) = rule_data_at(set_data, offset) else {
+            return RuleSetDigest::full();
+        };
+        let Some(value) = first_input(&data) else {
+            return RuleSetDigest::full();
+        };
+        digest.add(value);
+    }
+    digest
+}
+
 #[inline]
 fn parse_chain_rule_at<'a>(
     set_data: FontData<'a>,
@@ -783,6 +857,8 @@ fn apply_context_rules(
     set_data: FontData<'_>,
     rule_offsets: &[BigEndian<Offset16>],
     match_func: impl Fn(&mut GlyphInfo, u32) -> bool,
+    rule_set_digest: Option<RuleSetDigest>,
+    first_value: impl Fn(&mut GlyphInfo) -> u16,
 ) -> Option<()> {
     // HarfBuzz bypasses the first/second-component pre-match below for rule
     // sets of at most 4 rules, because its pre-match setup costs more than
@@ -820,6 +896,16 @@ fn apply_context_rules(
             return None;
         }
         unsafe_to1 = skippy_iter.index() + 1;
+        if !rule_offsets.is_empty()
+            && rule_set_digest.is_some_and(|digest| {
+                !digest.is_full() && !digest.may_have(first_value(&mut skippy_iter.buffer.info[g1]))
+            })
+        {
+            skippy_iter
+                .buffer
+                .unsafe_to_concat(Some(skippy_iter.buffer.idx), Some(unsafe_to1));
+            return None;
+        }
         g1
     } else {
         // Failed to match a next glyph. Only try applying rules that have no
@@ -979,11 +1065,14 @@ fn apply_chain_context_rules<
     F1: Fn(&mut GlyphInfo, u32) -> bool,
     F2: Fn(&mut GlyphInfo, u32) -> bool,
     F3: Fn(&mut GlyphInfo, u32) -> bool,
+    F4: Fn(&mut GlyphInfo) -> u16,
 >(
     ctx: &mut hb_ot_apply_context_t,
     set_data: FontData<'_>,
     rule_offsets: &[BigEndian<Offset16>],
     match_funcs: (F1, F2, F3),
+    rule_set_digest: Option<RuleSetDigest>,
+    first_input_value: F4,
 ) -> Option<()> {
     // No small-rule-set bypass here either; see apply_context_rules.
     //
@@ -1017,6 +1106,17 @@ fn apply_chain_context_rules<
             return None;
         }
         unsafe_to1 = skippy_iter.index() + 1;
+        if !rule_offsets.is_empty()
+            && rule_set_digest.is_some_and(|digest| {
+                !digest.is_full()
+                    && !digest.may_have(first_input_value(&mut skippy_iter.buffer.info[g1]))
+            })
+        {
+            skippy_iter
+                .buffer
+                .unsafe_to_concat(Some(skippy_iter.buffer.idx), Some(unsafe_to1));
+            return None;
+        }
         g1
     } else {
         // Failed to match a next glyph. Only try applying rules that have no

--- a/harfrust/src/hb/ot/gpos/pair.rs
+++ b/harfrust/src/hb/ot/gpos/pair.rs
@@ -5,8 +5,31 @@ use crate::hb::ot_layout_gsubgpos::{
     skipping_iterator_t, Apply, PairPosFormat1Cache, PairPosFormat1SmallCache, PairPosFormat2Cache,
     PairPosFormat2SmallCache, SubtableExternalCache, SubtableExternalCacheMode,
 };
+use crate::hb::set_digest::hb_set_digest_t;
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 use read_fonts::tables::gpos::{PairPosFormat1, PairPosFormat2};
+
+fn collect_pair_set_digests(table: &PairPosFormat1) -> Box<[hb_set_digest_t]> {
+    table
+        .pair_sets()
+        .iter()
+        .map(|pair_set| {
+            let Ok(pair_set) = pair_set else {
+                return hb_set_digest_t::full();
+            };
+            let mut digest = hb_set_digest_t::new();
+            for pair_value in pair_set.pair_value_records().iter() {
+                let Ok(pair_value) = pair_value else {
+                    return hb_set_digest_t::full();
+                };
+                digest.add(pair_value.second_glyph().to_u32());
+            }
+            digest
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
 
 impl Apply for PairPosFormat1<'_> {
     fn apply_with_external_cache(
@@ -16,16 +39,20 @@ impl Apply for PairPosFormat1<'_> {
     ) -> Option<()> {
         let first_glyph = ctx.buffer.cur(0).as_glyph();
 
-        let first_glyph_coverage_index = match external_cache {
-            SubtableExternalCache::PairPosFormat1Cache(cache) => coverage_index_cached(
-                |gid| self.coverage().ok()?.get(gid),
-                first_glyph,
-                &cache.coverage,
-            )?,
-            SubtableExternalCache::PairPosFormat1SmallCache(cache) => {
-                cache.coverage.index(&self.offset_data(), first_glyph)?
-            }
-            _ => coverage_index(self.coverage(), first_glyph)?,
+        let (first_glyph_coverage_index, pair_set_digests) = match external_cache {
+            SubtableExternalCache::PairPosFormat1Cache(cache) => (
+                coverage_index_cached(
+                    |gid| self.coverage().ok()?.get(gid),
+                    first_glyph,
+                    &cache.coverage,
+                )?,
+                Some(&cache.pair_sets),
+            ),
+            SubtableExternalCache::PairPosFormat1SmallCache(cache) => (
+                cache.coverage.index(&self.offset_data(), first_glyph)?,
+                Some(&cache.pair_sets),
+            ),
+            _ => (coverage_index(self.coverage(), first_glyph)?, None),
         };
 
         let mut iter = skipping_iterator_t::new(ctx, false);
@@ -40,6 +67,15 @@ impl Apply for PairPosFormat1<'_> {
 
         let second_glyph_index = iter.index();
         let second_glyph = iter.buffer.info[second_glyph_index].as_glyph();
+
+        if pair_set_digests
+            .and_then(|digests| digests.get(first_glyph_coverage_index as usize))
+            .is_some_and(|digest| !digest.may_have(second_glyph.to_u32()))
+        {
+            ctx.buffer
+                .unsafe_to_concat(Some(ctx.buffer.idx), Some(second_glyph_index + 1));
+            return None;
+        }
 
         let finish = |ctx: &mut hb_ot_apply_context_t, iter_index: &mut usize, has_record2| {
             if has_record2 {
@@ -127,15 +163,16 @@ impl Apply for PairPosFormat1<'_> {
 
     fn external_cache_create(&self, mode: SubtableExternalCacheMode) -> SubtableExternalCache {
         match mode {
-            SubtableExternalCacheMode::Full => {
-                SubtableExternalCache::PairPosFormat1Cache(Box::new(PairPosFormat1Cache::new()))
-            }
+            SubtableExternalCacheMode::Full => SubtableExternalCache::PairPosFormat1Cache(
+                Box::new(PairPosFormat1Cache::new(collect_pair_set_digests(self))),
+            ),
             SubtableExternalCacheMode::Small => {
                 if let Some(coverage) =
                     CoverageInfo::new(&self.offset_data(), self.coverage_offset().to_u32() as u16)
                 {
                     SubtableExternalCache::PairPosFormat1SmallCache(PairPosFormat1SmallCache {
                         coverage,
+                        pair_sets: collect_pair_set_digests(self),
                     })
                 } else {
                     SubtableExternalCache::None

--- a/harfrust/src/hb/ot/gsub/ligature.rs
+++ b/harfrust/src/hb/ot/gsub/ligature.rs
@@ -207,7 +207,7 @@ impl Apply for LigatureSubstFormat1<'_> {
     }
 }
 
-fn collect_seconds(lig_subst: &LigatureSubstFormat1) -> hb_set_digest_t {
+pub(crate) fn collect_seconds(lig_subst: &LigatureSubstFormat1) -> hb_set_digest_t {
     let mut seconds = hb_set_digest_t::new();
     let mut remaining_work = MAX_LIGATURE_CACHE_WORK;
     let ligature_sets = lig_subst.ligature_sets();

--- a/harfrust/src/hb/ot/gsub/mod.rs
+++ b/harfrust/src/hb/ot/gsub/mod.rs
@@ -2,6 +2,7 @@
 
 mod alternate;
 mod ligature;
+pub(crate) use ligature::collect_seconds;
 mod multiple;
 mod reverse_chain;
 mod single;

--- a/harfrust/src/hb/ot/lookup.rs
+++ b/harfrust/src/hb/ot/lookup.rs
@@ -22,8 +22,9 @@ use read_fonts::{
         },
         layout::{
             ChainedSequenceContext, ChainedSequenceContextFormat1, ChainedSequenceContextFormat2,
-            ChainedSequenceContextFormat3, CoverageTable, Lookup, LookupFlag, SequenceContext,
-            SequenceContextFormat1, SequenceContextFormat2, SequenceContextFormat3,
+            ChainedSequenceContextFormat3, ClassDef, CoverageTable, Lookup, LookupFlag,
+            SequenceContext, SequenceContextFormat1, SequenceContextFormat2,
+            SequenceContextFormat3,
         },
     },
     FontData, FontRead, Offset, ReadError,
@@ -183,6 +184,7 @@ pub struct LookupInfo {
     pub is_subst: bool,
     pub is_reversed: bool,
     pub digest: hb_set_digest_t,
+    pub digest_second: hb_set_digest_t,
     pub subtable_cache_user_idx: Option<usize>,
     pub subtables: Vec<SubtableInfo>,
 }
@@ -214,7 +216,7 @@ impl LookupInfo {
                 SubtableExternalCacheMode::Small
             };
             let subtable_offset = subtable_offset.get().to_usize() + data.offset;
-            if let Some((subtable_info, cache_cost)) = SubtableInfo::new(
+            if let Some((subtable_info, cache_cost, digest_second)) = SubtableInfo::new(
                 data.table_data,
                 subtable_offset as u32,
                 data.is_subst,
@@ -222,6 +224,7 @@ impl LookupInfo {
                 cache_mode,
             ) {
                 info.digest.union(&subtable_info.digest);
+                info.digest_second.union(&digest_second);
                 if cache_cost > subtable_cache_user_cost {
                     info.subtable_cache_user_idx = Some(info.subtables.len());
                     subtable_cache_user_cost = cache_cost;
@@ -251,6 +254,10 @@ impl LookupInfo {
 
     pub fn digest(&self) -> &hb_set_digest_t {
         &self.digest
+    }
+
+    pub fn digest_second(&self) -> &hb_set_digest_t {
+        &self.digest_second
     }
 }
 
@@ -410,6 +417,156 @@ impl SubtableInfo {
     }
 }
 
+fn coverage_digest(coverage: Result<CoverageTable, ReadError>) -> hb_set_digest_t {
+    match coverage {
+        Ok(coverage) => hb_set_digest_t::from_coverage(&coverage),
+        Err(_) => hb_set_digest_t::full(),
+    }
+}
+
+fn add_class(digest: &mut hb_set_digest_t, class_def: &ClassDef, class: u16) {
+    if class == 0 {
+        *digest = hb_set_digest_t::full();
+        return;
+    }
+
+    for (glyph, glyph_class) in class_def.iter() {
+        if glyph_class == class {
+            digest.add(glyph.to_u32());
+        }
+    }
+}
+
+fn context_format1_digest(table: &SequenceContextFormat1) -> hb_set_digest_t {
+    let mut digest = hb_set_digest_t::new();
+    for rule_set in table.seq_rule_sets().iter() {
+        let Some(rule_set) = rule_set else { continue };
+        let Ok(rule_set) = rule_set else {
+            return hb_set_digest_t::full();
+        };
+        for rule in rule_set.seq_rules().iter() {
+            let Ok(rule) = rule else {
+                return hb_set_digest_t::full();
+            };
+            let Some(second) = rule.input_sequence().first() else {
+                return hb_set_digest_t::full();
+            };
+            digest.add(second.get().to_u32());
+        }
+    }
+    digest
+}
+
+fn context_format2_digest(table: &SequenceContextFormat2) -> hb_set_digest_t {
+    let Ok(class_def) = table.class_def() else {
+        return hb_set_digest_t::full();
+    };
+    let mut digest = hb_set_digest_t::new();
+    for rule_set in table.class_seq_rule_sets().iter() {
+        let Some(rule_set) = rule_set else { continue };
+        let Ok(rule_set) = rule_set else {
+            return hb_set_digest_t::full();
+        };
+        for rule in rule_set.class_seq_rules().iter() {
+            let Ok(rule) = rule else {
+                return hb_set_digest_t::full();
+            };
+            let Some(second) = rule.input_sequence().first() else {
+                return hb_set_digest_t::full();
+            };
+            add_class(&mut digest, &class_def, second.get());
+        }
+    }
+    digest
+}
+
+fn context_format3_digest(table: &SequenceContextFormat3) -> hb_set_digest_t {
+    if table.coverages().len() <= 1 {
+        hb_set_digest_t::full()
+    } else {
+        coverage_digest(table.coverages().get(1))
+    }
+}
+
+fn chained_context_format1_digest(table: &ChainedSequenceContextFormat1) -> hb_set_digest_t {
+    let mut digest = hb_set_digest_t::new();
+    for rule_set in table.chained_seq_rule_sets().iter() {
+        let Some(rule_set) = rule_set else { continue };
+        let Ok(rule_set) = rule_set else {
+            return hb_set_digest_t::full();
+        };
+        for rule in rule_set.chained_seq_rules().iter() {
+            let Ok(rule) = rule else {
+                return hb_set_digest_t::full();
+            };
+            let second = rule
+                .input_sequence()
+                .first()
+                .or_else(|| rule.lookahead_sequence().first());
+            let Some(second) = second else {
+                return hb_set_digest_t::full();
+            };
+            digest.add(second.get().to_u32());
+        }
+    }
+    digest
+}
+
+fn chained_context_format2_digest(table: &ChainedSequenceContextFormat2) -> hb_set_digest_t {
+    let Ok(input_class_def) = table.input_class_def() else {
+        return hb_set_digest_t::full();
+    };
+    let Ok(lookahead_class_def) = table.lookahead_class_def() else {
+        return hb_set_digest_t::full();
+    };
+    let mut digest = hb_set_digest_t::new();
+    for rule_set in table.chained_class_seq_rule_sets().iter() {
+        let Some(rule_set) = rule_set else { continue };
+        let Ok(rule_set) = rule_set else {
+            return hb_set_digest_t::full();
+        };
+        for rule in rule_set.chained_class_seq_rules().iter() {
+            let Ok(rule) = rule else {
+                return hb_set_digest_t::full();
+            };
+            if let Some(second) = rule.input_sequence().first() {
+                add_class(&mut digest, &input_class_def, second.get());
+            } else if let Some(second) = rule.lookahead_sequence().first() {
+                add_class(&mut digest, &lookahead_class_def, second.get());
+            } else {
+                return hb_set_digest_t::full();
+            }
+        }
+    }
+    digest
+}
+
+fn chained_context_format3_digest(table: &ChainedSequenceContextFormat3) -> hb_set_digest_t {
+    if table.input_coverages().len() > 1 {
+        coverage_digest(table.input_coverages().get(1))
+    } else if !table.lookahead_coverages().is_empty() {
+        coverage_digest(table.lookahead_coverages().get(0))
+    } else {
+        hb_set_digest_t::full()
+    }
+}
+
+fn pair_pos_format1_digest(table: &PairPosFormat1) -> hb_set_digest_t {
+    let mut digest = hb_set_digest_t::new();
+    for pair_set in table.pair_sets().iter() {
+        let Ok(pair_set) = pair_set else {
+            return hb_set_digest_t::full();
+        };
+        for pair_value in pair_set.pair_value_records().iter() {
+            let Ok(pair_value) = pair_value else {
+                return hb_set_digest_t::full();
+            };
+            digest.add(pair_value.second_glyph().to_u32());
+        }
+    }
+    digest
+}
+
 macro_rules! apply_fns {
     ($apply:ident, $apply_cached:ident, $ty:ident) => {
         fn $apply(
@@ -513,24 +670,27 @@ impl SubtableInfo {
         is_subst: bool,
         lookup_type: u8,
         cache_mode: SubtableExternalCacheMode,
-    ) -> Option<(Self, u32)> {
+    ) -> Option<(Self, u32, hb_set_digest_t)> {
         let data = table_data.split_off(subtable_offset as usize)?;
         let maybe_external_cache = |s: &dyn Apply| s.external_cache_create(cache_mode);
-        let (kind, (external_cache, cache_cost, coverage), apply_fns): (
+        let (kind, (external_cache, cache_cost, coverage), apply_fns, digest_second): (
             SubtableKind,
             (SubtableExternalCache, u32, CoverageTable),
             [SubtableApplyFn; 2],
+            hb_set_digest_t,
         ) = match (is_subst, lookup_type) {
             (true, 1) => match SingleSubst::read(data).ok()? {
                 SingleSubst::Format1(s) => (
                     SubtableKind::SingleSubst1,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [single_subst1, single_subst1_cached as _],
+                    hb_set_digest_t::full(),
                 ),
                 SingleSubst::Format2(s) => (
                     SubtableKind::SingleSubst2,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [single_subst2, single_subst2_cached as _],
+                    hb_set_digest_t::full(),
                 ),
             },
             (false, 1) => match SinglePos::read(data).ok()? {
@@ -538,74 +698,90 @@ impl SubtableInfo {
                     SubtableKind::SinglePos1,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [single_pos1, single_pos1_cached as _],
+                    hb_set_digest_t::full(),
                 ),
                 SinglePos::Format2(s) => (
                     SubtableKind::SinglePos2,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [single_pos2, single_pos2_cached as _],
+                    hb_set_digest_t::full(),
                 ),
             },
-            (true, 2) => (
-                SubtableKind::MultipleSubst1,
-                MultipleSubstFormat1::read(data).ok().and_then(|t| {
-                    Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
-                })?,
-                [multiple_subst1, multiple_subst1_cached as _],
-            ),
+            (true, 2) => {
+                let s = MultipleSubstFormat1::read(data).ok()?;
+                (
+                    SubtableKind::MultipleSubst1,
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
+                    [multiple_subst1, multiple_subst1_cached as _],
+                    hb_set_digest_t::full(),
+                )
+            }
             (false, 2) => match PairPos::read(data).ok()? {
                 PairPos::Format1(s) => (
                     SubtableKind::PairPos1,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [pair_pos1, pair_pos1_cached as _],
+                    pair_pos_format1_digest(&s),
                 ),
                 PairPos::Format2(s) => (
                     SubtableKind::PairPos2,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [pair_pos2, pair_pos2_cached as _],
+                    hb_set_digest_t::full(),
                 ),
             },
-            (true, 3) => (
-                SubtableKind::AlternateSubst1,
-                AlternateSubstFormat1::read(data).ok().and_then(|t| {
-                    Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
-                })?,
-                [alternate_subst1, alternate_subst1_cached as _],
-            ),
-            (false, 3) => (
-                SubtableKind::CursivePos1,
-                CursivePosFormat1::read(data).ok().and_then(|t| {
-                    Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
-                })?,
-                [cursive_pos1, cursive_pos1_cached as _],
-            ),
-            (true, 4) => (
-                SubtableKind::LigatureSubst1,
-                LigatureSubstFormat1::read(data).ok().and_then(|t| {
-                    Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
-                })?,
-                [ligature_subst1, ligature_subst1_cached as _],
-            ),
-            (false, 4) => (
-                SubtableKind::MarkBasePos1,
-                MarkBasePosFormat1::read(data).ok().and_then(|t| {
-                    Some((
-                        maybe_external_cache(&t),
-                        t.cache_cost(),
-                        t.mark_coverage().ok()?,
-                    ))
-                })?,
-                [mark_base_pos1, mark_base_pos1_cached as _],
-            ),
+            (true, 3) => {
+                let s = AlternateSubstFormat1::read(data).ok()?;
+                (
+                    SubtableKind::AlternateSubst1,
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
+                    [alternate_subst1, alternate_subst1_cached as _],
+                    hb_set_digest_t::full(),
+                )
+            }
+            (false, 3) => {
+                let s = CursivePosFormat1::read(data).ok()?;
+                (
+                    SubtableKind::CursivePos1,
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
+                    [cursive_pos1, cursive_pos1_cached as _],
+                    coverage_digest(s.coverage()),
+                )
+            }
+            (true, 4) => {
+                let s = LigatureSubstFormat1::read(data).ok()?;
+                (
+                    SubtableKind::LigatureSubst1,
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
+                    [ligature_subst1, ligature_subst1_cached as _],
+                    super::gsub::collect_seconds(&s),
+                )
+            }
+            (false, 4) => {
+                let s = MarkBasePosFormat1::read(data).ok()?;
+                (
+                    SubtableKind::MarkBasePos1,
+                    (
+                        maybe_external_cache(&s),
+                        s.cache_cost(),
+                        s.mark_coverage().ok()?,
+                    ),
+                    [mark_base_pos1, mark_base_pos1_cached as _],
+                    coverage_digest(s.base_coverage()),
+                )
+            }
             (true, 5) | (false, 7) => match SequenceContext::read(data).ok()? {
                 SequenceContext::Format1(s) => (
                     SubtableKind::ContextFormat1,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [context1, context1_cached as _],
+                    context_format1_digest(&s),
                 ),
                 SequenceContext::Format2(s) => (
                     SubtableKind::ContextFormat2,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [context2, context2_cached as _],
+                    context_format2_digest(&s),
                 ),
                 SequenceContext::Format3(s) => (
                     SubtableKind::ContextFormat3,
@@ -615,29 +791,34 @@ impl SubtableInfo {
                         s.coverages().get(0).ok()?,
                     ),
                     [context3, context3_cached as _],
+                    context_format3_digest(&s),
                 ),
             },
-            (false, 5) => (
-                SubtableKind::MarkLigPos1,
-                MarkLigPosFormat1::read(data).ok().and_then(|t| {
-                    Some((
-                        maybe_external_cache(&t),
-                        t.cache_cost(),
-                        t.mark_coverage().ok()?,
-                    ))
-                })?,
-                [mark_lig_pos1, mark_lig_pos1_cached as _],
-            ),
+            (false, 5) => {
+                let s = MarkLigPosFormat1::read(data).ok()?;
+                (
+                    SubtableKind::MarkLigPos1,
+                    (
+                        maybe_external_cache(&s),
+                        s.cache_cost(),
+                        s.mark_coverage().ok()?,
+                    ),
+                    [mark_lig_pos1, mark_lig_pos1_cached as _],
+                    coverage_digest(s.ligature_coverage()),
+                )
+            }
             (true, 6) | (false, 8) => match ChainedSequenceContext::read(data).ok()? {
                 ChainedSequenceContext::Format1(s) => (
                     SubtableKind::ChainedContextFormat1,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [chained_context1, chained_context1_cached as _],
+                    chained_context_format1_digest(&s),
                 ),
                 ChainedSequenceContext::Format2(s) => (
                     SubtableKind::ChainedContextFormat2,
                     (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
                     [chained_context2, chained_context2_cached as _],
+                    chained_context_format2_digest(&s),
                 ),
                 ChainedSequenceContext::Format3(s) => (
                     SubtableKind::ChainedContextFormat3,
@@ -647,6 +828,7 @@ impl SubtableInfo {
                         s.input_coverages().get(0).ok()?,
                     ),
                     [chained_context3, chained_context3_cached as _],
+                    chained_context_format3_digest(&s),
                 ),
             },
             (true, 7) | (false, 9) => {
@@ -664,26 +846,28 @@ impl SubtableInfo {
                     cache_mode,
                 );
             }
-            (false, 6) => (
-                SubtableKind::MarkMarkPos1,
-                MarkMarkPosFormat1::read(data).ok().and_then(|t| {
-                    Some((
-                        maybe_external_cache(&t),
-                        t.cache_cost(),
-                        t.mark1_coverage().ok()?,
-                    ))
-                })?,
-                [mark_mark_pos1, mark_mark_pos1_cached as _],
-            ),
-            (true, 8) => (
-                SubtableKind::ReverseChainContext,
-                ReverseChainSingleSubstFormat1::read(data)
-                    .ok()
-                    .and_then(|t| {
-                        Some((maybe_external_cache(&t), t.cache_cost(), t.coverage().ok()?))
-                    })?,
-                [rev_chain_single_subst1, rev_chain_single_subst1_cached as _],
-            ),
+            (false, 6) => {
+                let s = MarkMarkPosFormat1::read(data).ok()?;
+                (
+                    SubtableKind::MarkMarkPos1,
+                    (
+                        maybe_external_cache(&s),
+                        s.cache_cost(),
+                        s.mark1_coverage().ok()?,
+                    ),
+                    [mark_mark_pos1, mark_mark_pos1_cached as _],
+                    coverage_digest(s.mark2_coverage()),
+                )
+            }
+            (true, 8) => {
+                let s = ReverseChainSingleSubstFormat1::read(data).ok()?;
+                (
+                    SubtableKind::ReverseChainContext,
+                    (maybe_external_cache(&s), s.cache_cost(), s.coverage().ok()?),
+                    [rev_chain_single_subst1, rev_chain_single_subst1_cached as _],
+                    hb_set_digest_t::full(),
+                )
+            }
             _ => return None,
         };
         let mut digest = hb_set_digest_t::new();
@@ -697,6 +881,7 @@ impl SubtableInfo {
                 external_cache,
             },
             cache_cost,
+            digest_second,
         ))
     }
 }

--- a/harfrust/src/hb/ot_layout.rs
+++ b/harfrust/src/hb/ot_layout.rs
@@ -11,6 +11,7 @@ use super::set_digest::hb_set_digest_t;
 use super::{hb_font_t, GlyphInfo};
 use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use crate::unicode::{hb_unicode_funcs_t, GeneralCategory};
+use crate::BufferFlags;
 
 impl GlyphInfo {
     declare_buffer_var!(u16, 1, 0, GLYPH_PROPS_VAR, glyph_props, set_glyph_props);
@@ -171,7 +172,13 @@ pub fn apply_layout_table<T: LayoutTable>(
                     continue;
                 };
 
-                if lookup.digest().may_intersect(&ctx.buffer.digest) {
+                if lookup.digest().may_intersect(&ctx.buffer.digest)
+                    && (ctx
+                        .buffer
+                        .flags
+                        .contains(BufferFlags::PRODUCE_UNSAFE_TO_CONCAT)
+                        || lookup.digest_second().may_intersect(&ctx.buffer.digest))
+                {
                     ctx.lookup_index = lookup_map.index;
                     ctx.set_lookup_mask(lookup_map.mask);
                     ctx.auto_zwj = lookup_map.auto_zwj;

--- a/harfrust/src/hb/ot_layout.rs
+++ b/harfrust/src/hb/ot_layout.rs
@@ -7,6 +7,7 @@ use super::font_funcs::FontFuncsDispatch;
 use super::ot::lookup::LookupInfo;
 use super::ot_layout_gsubgpos::OT;
 use super::ot_shape_plan::hb_ot_shape_plan_t;
+use super::set_digest::hb_set_digest_t;
 use super::{hb_font_t, GlyphInfo};
 use crate::hb::ot_layout_gsubgpos::OT::check_glyph_property;
 use crate::unicode::{hb_unicode_funcs_t, GeneralCategory};
@@ -82,11 +83,17 @@ pub fn hb_ot_layout_has_cross_kerning(face: &hb_font_t) -> bool {
 
 // hb_ot_layout_kern
 
-pub fn _hb_ot_layout_set_glyph_props(face: &hb_font_t, buffer: &mut Buffer) {
+pub fn _hb_ot_layout_set_glyph_props<const SET_DIGEST: bool>(
+    face: &hb_font_t,
+    buffer: &mut Buffer,
+) {
     buffer.assert_gsubgpos_vars();
 
     let len = buffer.len;
     for info in &mut buffer.info[..len] {
+        if SET_DIGEST {
+            buffer.digest.add(info.glyph_id);
+        }
         info.set_glyph_props(face.ot_tables.glyph_props(info.as_glyph()));
         info.set_lig_props(0);
     }
@@ -139,7 +146,12 @@ pub trait LayoutTable {
 /// Called before substitution lookups are performed, to ensure that glyph
 /// class and other properties are set on the glyphs in the buffer.
 pub fn hb_ot_layout_substitute_start(face: &hb_font_t, buffer: &mut Buffer) {
-    _hb_ot_layout_set_glyph_props(face, buffer);
+    _hb_ot_layout_set_glyph_props::<false>(face, buffer);
+}
+
+pub fn hb_ot_layout_substitute_start_with_digest(face: &hb_font_t, buffer: &mut Buffer) {
+    buffer.digest = hb_set_digest_t::new();
+    _hb_ot_layout_set_glyph_props::<true>(face, buffer);
 }
 
 /// Applies the lookups in the given GSUB or GPOS table.

--- a/harfrust/src/hb/ot_layout_gsubgpos.rs
+++ b/harfrust/src/hb/ot_layout_gsubgpos.rs
@@ -747,6 +747,12 @@ pub(crate) struct ChainContextFormat2Cache {
     pub input: ClassDefInfo,
     pub lookahead: ClassDefInfo,
     pub coverage_cache: BinaryCache,
+    pub class_caches: Option<Box<ChainContextClassCaches>>,
+}
+
+pub(crate) struct ChainContextClassCaches {
+    pub input: MappingCache,
+    pub lookahead: MappingCache,
 }
 
 pub(crate) enum SubtableExternalCache {

--- a/harfrust/src/hb/ot_layout_gsubgpos.rs
+++ b/harfrust/src/hb/ot_layout_gsubgpos.rs
@@ -739,6 +739,7 @@ pub(crate) struct ContextFormat2Cache {
     pub coverage: CoverageInfo,
     pub input: ClassDefInfo,
     pub coverage_cache: BinaryCache,
+    pub rule_sets: Box<[RuleSetDigest]>,
 }
 
 pub(crate) struct ChainContextFormat2Cache {
@@ -748,11 +749,34 @@ pub(crate) struct ChainContextFormat2Cache {
     pub lookahead: ClassDefInfo,
     pub coverage_cache: BinaryCache,
     pub class_caches: Option<Box<ChainContextClassCaches>>,
+    pub rule_sets: Box<[RuleSetDigest]>,
 }
 
 pub(crate) struct ChainContextClassCaches {
     pub input: MappingCache,
     pub lookahead: MappingCache,
+}
+
+#[derive(Copy, Clone, Default)]
+// One word per rule set; collisions only admit extra work.
+pub(crate) struct RuleSetDigest(u64);
+
+impl RuleSetDigest {
+    pub fn full() -> Self {
+        Self(u64::MAX)
+    }
+
+    pub fn add(&mut self, value: u16) {
+        self.0 |= 1 << (value & 63);
+    }
+
+    pub fn is_full(self) -> bool {
+        self.0 == u64::MAX
+    }
+
+    pub fn may_have(self, value: u16) -> bool {
+        self.0 & (1 << (value & 63)) != 0
+    }
 }
 
 pub(crate) enum SubtableExternalCache {

--- a/harfrust/src/hb/ot_layout_gsubgpos.rs
+++ b/harfrust/src/hb/ot_layout_gsubgpos.rs
@@ -696,18 +696,21 @@ pub(crate) struct LigatureSubstFormat1SmallCache {
 
 pub(crate) struct PairPosFormat1Cache {
     pub coverage: MappingCache,
+    pub pair_sets: Box<[hb_set_digest_t]>,
 }
 
 impl PairPosFormat1Cache {
-    pub fn new() -> Self {
+    pub fn new(pair_sets: Box<[hb_set_digest_t]>) -> Self {
         PairPosFormat1Cache {
             coverage: MappingCache::new(),
+            pair_sets,
         }
     }
 }
 
 pub(crate) struct PairPosFormat1SmallCache {
     pub coverage: CoverageInfo,
+    pub pair_sets: Box<[hb_set_digest_t]>,
 }
 
 pub(crate) struct PairPosFormat2Cache {

--- a/harfrust/src/hb/ot_shape.rs
+++ b/harfrust/src/hb/ot_shape.rs
@@ -322,8 +322,7 @@ impl OtShapeContext<'_, '_> {
     pub(crate) fn shape_internal(&mut self) {
         self.buffer.allocate_unicode_vars();
 
-        self.initialize_masks();
-        self.set_unicode_props();
+        self.set_unicode_props(self.plan.ot_map.get_global_mask());
         self.insert_dotted_circle();
 
         form_clusters(self.buffer);
@@ -405,13 +404,13 @@ impl OtShapeContext<'_, '_> {
 
     // hb_ot_substitute_plan: <https://github.com/harfbuzz/harfbuzz/blob/22ea52f42fa4fc168be91ef4e56aee3affda6e28/src/hb-ot-shape.cc#L911>
     fn substitute_plan(&mut self) {
-        hb_ot_layout_substitute_start(self.face, self.buffer);
-
-        if self.plan.fallback_glyph_classes {
-            hb_synthesize_glyph_classes(self.buffer);
-        }
-
         if self.plan.apply_morx {
+            hb_ot_layout_substitute_start(self.face, self.buffer);
+
+            if self.plan.fallback_glyph_classes {
+                hb_synthesize_glyph_classes(self.buffer);
+            }
+
             aat::layout::substitute(self.plan, self.face, self.buffer, self.features);
             // The digest is only read by the OT lookup-apply loop; without
             // GPOS ahead, nothing consumes it.
@@ -419,7 +418,12 @@ impl OtShapeContext<'_, '_> {
                 self.buffer.update_digest();
             }
         } else {
-            self.buffer.update_digest();
+            hb_ot_layout_substitute_start_with_digest(self.face, self.buffer);
+
+            if self.plan.fallback_glyph_classes {
+                hb_synthesize_glyph_classes(self.buffer);
+            }
+
             ot_layout_gsub_table::substitute(self.plan, self.face, self.font_funcs, self.buffer);
         }
     }
@@ -541,12 +545,6 @@ impl OtShapeContext<'_, '_> {
         }
     }
 
-    // hb_ot_shape_initialize_masks: <https://github.com/harfbuzz/harfbuzz/blob/22ea52f42fa4fc168be91ef4e56aee3affda6e28/src/hb-ot-shape.cc#L747>
-    fn initialize_masks(&mut self) {
-        let global_mask = self.plan.ot_map.get_global_mask();
-        self.buffer.reset_masks(global_mask);
-    }
-
     // hb_ot_shape_setup_masks: <https://github.com/harfbuzz/harfbuzz/blob/22ea52f42fa4fc168be91ef4e56aee3affda6e28/src/hb-ot-shape.cc#L757>
     fn setup_masks(&mut self) {
         self.setup_masks_fraction();
@@ -637,7 +635,7 @@ impl OtShapeContext<'_, '_> {
     }
 
     // hb_set_unicode_props: <https://github.com/harfbuzz/harfbuzz/blob/22ea52f42fa4fc168be91ef4e56aee3affda6e28/src/hb-ot-shape.cc#L471>
-    fn set_unicode_props(&mut self) {
+    fn set_unicode_props(&mut self, global_mask: hb_mask_t) {
         let buffer = &mut *self.buffer;
         // Implement enough of Unicode Graphemes here that shaping
         // in reverse-direction wouldn't break graphemes.  Namely,
@@ -652,6 +650,7 @@ impl OtShapeContext<'_, '_> {
         let mut i = 0;
         while i < len {
             let info = &mut buffer.info[i];
+            info.mask = global_mask;
             info.init_unicode_props(&mut buffer.scratch_flags);
 
             if info.glyph_id < 0x80 {
@@ -696,6 +695,7 @@ impl OtShapeContext<'_, '_> {
                 info.set_continuation(&mut buffer.scratch_flags);
                 if let Some(next) = buffer.info[..len].get_mut(i + 1) {
                     if next.as_codepoint().is_emoji_extended_pictographic() {
+                        next.mask = global_mask;
                         next.init_unicode_props(&mut buffer.scratch_flags);
                         next.set_continuation(&mut buffer.scratch_flags);
                         i += 1;


### PR DESCRIPTION
This ports five winning HarfBuzz optimization units to HarfRust, as five separate commits:

- Fuse mask initialization with Unicode-property setup and GDEF glyph-property setup with digest rebuilding, from [HarfBuzz PR #6231](https://github.com/harfbuzz/harfbuzz/pull/6231).
- Add the lookup-wide second-glyph digest from [HarfBuzz 087e432](https://github.com/harfbuzz/harfbuzz/commit/087e432312618900f1104ef72683cecebe36da92). The gate is bypassed when `PRODUCE_UNSAFE_TO_CONCAT` is requested.
- Add per-PairSet second-glyph digests to the existing PairPos1 external caches, from [HarfBuzz 8fa0d5d](https://github.com/harfbuzz/harfbuzz/commit/8fa0d5da39ab165c51f9d1cbf035f411de909130).
- Cache ChainContext format 2 input and lookahead ClassDef results during recursive lookup application, from [HarfBuzz PR #6233](https://github.com/harfbuzz/harfbuzz/pull/6233). Full-cache subtables receive persistent mapping caches; top-level application retains the glyph-info scratch-cache path.
- Add a compact first-input class digest per Context and ChainContext format 2 RuleSet, from [HarfBuzz PR #6234](https://github.com/harfbuzz/harfbuzz/pull/6234). Once the first non-skipped input glyph is known, an impossible class rejects the entire RuleSet. Input-less and malformed rules saturate the digest, so the shortcut is conservative.

Performance before versus after this branch:

| Benchmark | Time | CPU |
| --- | ---: | ---: |
| Roboto little prince | 32.91% faster | 32.90% faster |
| Roboto words | 28.65% faster | 28.63% faster |
| Source Serif react-dom | 15.05% faster | 15.04% faster |
| Noto Sans Devanagari words | 18.85% faster | 18.84% faster |
| Amiri little prince | 9.20% faster | 9.18% faster |
| Noto Nastaliq little prince | 14.77% faster | 14.73% faster |
| Noto Nastaliq words | 12.99% faster | 13.01% faster |
| Gulzar little prince | 47.11% faster | 47.13% faster |
| Gulzar words | 37.04% faster | 37.02% faster |
| Noto Sans Duployan | 0.06% slower | 0.09% slower |
| **Overall geomean** | **22.92% faster** | **22.91% faster** |

Validation:

- `cargo test --workspace --all-features`
- 219 unit tests and 6,054 shaping tests pass
- Differential output checks against the preceding commit pass for all ten benchmark corpora, including glyph flags and verification
- `cargo build --no-default-features --features=libm`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check` and `git diff --check`
