### PR TITLE
[ot] Keep chain-context matching out of line

### DIFF
--- a/harfrust/src/hb/ot/contextual.rs
+++ b/harfrust/src/hb/ot/contextual.rs
@@ -1072,6 +1072,8 @@ fn apply_chain_with_sequences<
     Some(())
 }
 
+// Keep this large generic matcher out of the format-specific dispatchers.
+#[inline(never)]
 fn apply_chain_context_rules<
     F1: Fn(&mut GlyphInfo, u32) -> bool,
     F2: Fn(&mut GlyphInfo, u32) -> bool,


### PR DESCRIPTION
## Summary

Keep the generic chained-context rule matcher out of the format-specific
dispatchers.

With release LTO, LLVM was inlining this large generic function into each
format 2 specialization. The resulting hot-path code was substantially larger
and executed more instructions on contextual-heavy fonts.

For one `chained_context2` specialization, the generated function shrank from
about 9.4 KiB to 818 bytes. On the Gulzar words workload, a five-iteration
`perf stat` run changed from 70.55B to 66.88B instructions and from 18.75B to
18.12B cycles.

Direct C API benchmark results:

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| Gulzar words | 651 ms | 624 ms | -4.2% |
| Gulzar Little Prince | 784 ms | 734 ms | -6.4% |

The structurally similar non-chained matcher was also tested with
`#[inline(never)]`, but did not produce a consistent additional improvement,
so this change remains limited to the demonstrated hot path.

## Testing

```text
cargo fmt --all -- --check
cargo test --workspace --all-features
```
