### PR TITLE
[ot] Hoist reverse iterator output access

### DIFF
--- a/harfrust/src/hb/ot/gpos/mark.rs
+++ b/harfrust/src/hb/ot/gpos/mark.rs
@@ -2,7 +2,7 @@ use crate::hb::buffer::{Buffer, GlyphPosition, HB_BUFFER_SCRATCH_FLAG_HAS_GPOS_A
 use crate::hb::ot_layout_common::lookup_flags;
 use crate::hb::ot_layout_gpos_table::attach_type;
 use crate::hb::ot_layout_gsubgpos::OT::hb_ot_apply_context_t;
-use crate::hb::ot_layout_gsubgpos::{match_t, skipping_iterator_t, Apply, MatchSource};
+use crate::hb::ot_layout_gsubgpos::{match_t, skipping_iterator_t, Apply};
 use read_fonts::tables::gpos::{
     AnchorTable, MarkArray, MarkBasePosFormat1, MarkLigPosFormat1, MarkMarkPosFormat1,
 };
@@ -114,7 +114,7 @@ impl Apply for MarkBasePosFormat1<'_> {
 
         let mut j = iter.buffer.idx;
         while j > last_base_until as usize {
-            let mut _match = iter.match_at(j - 1, MatchSource::Info);
+            let mut _match = iter.match_at(j - 1);
             if _match == match_t::MATCH {
                 // https://github.com/harfbuzz/harfbuzz/issues/4124
                 if !accept(iter.buffer, j - 1)
@@ -269,7 +269,7 @@ impl Apply for MarkLigPosFormat1<'_> {
 
         let mut j = iter.buffer.idx;
         while j > last_base_until as usize {
-            let mut _match = iter.match_at(j - 1, MatchSource::Info);
+            let mut _match = iter.match_at(j - 1);
             if _match == match_t::MATCH
                 && !accept_mark_ligature(iter.buffer, j - 1)
                 && ligature_coverage

--- a/harfrust/src/hb/ot_layout_gsubgpos.rs
+++ b/harfrust/src/hb/ot_layout_gsubgpos.rs
@@ -309,6 +309,37 @@ impl matcher_t {
     }
 }
 
+#[inline(always)]
+fn match_info<F: Fn(&mut GlyphInfo, u32) -> bool>(
+    matcher: &matcher_t,
+    info: &mut GlyphInfo,
+    face: &hb_font_t,
+    lookup_props: u32,
+    glyph_data: u32,
+    match_func: Option<&F>,
+    syllable: u8,
+) -> match_t {
+    let skip = matcher.may_skip(info, face, lookup_props);
+
+    if skip == may_skip_t::SKIP_YES {
+        return match_t::SKIP;
+    }
+
+    let _match = matcher.may_match(info, glyph_data, match_func, syllable);
+
+    if _match == may_match_t::MATCH_YES
+        || (_match == may_match_t::MATCH_MAYBE && skip == may_skip_t::SKIP_NO)
+    {
+        return match_t::MATCH;
+    }
+
+    if skip == may_skip_t::SKIP_NO {
+        return match_t::NOT_MATCH;
+    }
+
+    match_t::SKIP
+}
+
 // In harfbuzz, skipping iterator works quite differently than it works here. In harfbuzz,
 // hb_ot_apply_context contains a skipping iterator that itself contains references to font
 // and buffer, meaning that we multiple borrows issue. Due to ownership rules in Rust,
@@ -332,11 +363,6 @@ impl<'f, 'c> skipping_iterator_t<'f, 'c, fn(&mut GlyphInfo, u32) -> bool> {
     pub fn new(ctx: &'c mut hb_ot_apply_context_t<'f>, context_match: bool) -> Self {
         Self::with_match_fn(ctx, context_match, None)
     }
-}
-
-pub(crate) enum MatchSource {
-    Info,
-    OutInfo,
 }
 
 impl<'f, 'c, F> skipping_iterator_t<'f, 'c, F>
@@ -400,7 +426,7 @@ where
         while self.buf_idx < stop {
             self.buf_idx += 1;
 
-            match self.match_at(self.buf_idx, MatchSource::Info) {
+            match self.match_at(self.buf_idx) {
                 match_t::MATCH => {
                     self.advance_glyph_data();
                     return true;
@@ -426,11 +452,21 @@ where
     #[inline]
     pub fn prev(&mut self, unsafe_from: Option<&mut usize>) -> bool {
         let stop: usize = 0;
+        let start = self.buf_idx;
+        let out_info = &mut self.buffer.out_info_mut()[..start];
 
         while self.buf_idx > stop {
             self.buf_idx -= 1;
 
-            match self.match_at(self.buf_idx, MatchSource::OutInfo) {
+            match match_info(
+                self.matcher,
+                &mut out_info[self.buf_idx],
+                self.face,
+                self.lookup_props,
+                self.glyph_data,
+                self.match_func.as_ref(),
+                self.syllable,
+            ) {
                 match_t::MATCH => {
                     self.advance_glyph_data();
                     return true;
@@ -478,35 +514,17 @@ where
     }
 
     #[inline]
-    pub fn match_at(&mut self, idx: usize, source: MatchSource) -> match_t {
-        let info = match source {
-            MatchSource::Info => &mut self.buffer.info[idx],
-            MatchSource::OutInfo => &mut self.buffer.out_info_mut()[idx],
-        };
-        let skip = self.matcher.may_skip(info, self.face, self.lookup_props);
-
-        if skip == may_skip_t::SKIP_YES {
-            return match_t::SKIP;
-        }
-
-        let _match = self.matcher.may_match(
+    pub fn match_at(&mut self, idx: usize) -> match_t {
+        let info = &mut self.buffer.info[idx];
+        match_info(
+            self.matcher,
             info,
+            self.face,
+            self.lookup_props,
             self.glyph_data,
             self.match_func.as_ref(),
             self.syllable,
-        );
-
-        if _match == may_match_t::MATCH_YES
-            || (_match == may_match_t::MATCH_MAYBE && skip == may_skip_t::SKIP_NO)
-        {
-            return match_t::MATCH;
-        }
-
-        if skip == may_skip_t::SKIP_NO {
-            return match_t::NOT_MATCH;
-        }
-
-        match_t::SKIP
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Hoist the output-info slice lookup out of the reverse skipping-iterator loop.

`skipping_iterator_t::prev()` previously called `out_info_mut()` through
`match_at()` for every glyph it visited. That repeatedly selected the backing
buffer and performed slice bounds checks. Long chained-context backtracks with
mark filtering amplify this cost substantially.

This selects and bounds the active output slice once before the walk. The
matching logic is extracted unchanged so indexed input matching can continue
to share it.

## Performance

`benchmark-harf` with `NotoSansDuployan-Regular.otf` and `duployan.txt`, using
the release fat-LTO profile:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| CPU time | 1.855 s | 1.607 s | -13.4% |
| Instructions | 76.24B | 63.76B | -16.4% |
| Cycles | 17.53B | 15.25B | -13.0% |

The other default `benchmark-harf` workloads remained within about 1.3% of
baseline. A separate experiment forcing `next()` out of line improved
Duployan further but regressed common workloads, so it is intentionally not
included here.

## Testing

```text
cargo fmt --all -- --check
cargo test --workspace --all-features
```

The same patch was also tested on the C API branch, including all 63 C API
tests and the 6,065 shaping cases.
