### PR TITLE
[aat] Inline in-place glyph replacement

### DIFF
--- a/harfrust/src/hb/aat/layout_common.rs
+++ b/harfrust/src/hb/aat/layout_common.rs
@@ -185,6 +185,7 @@ impl<'a> AatApplyContext<'a> {
         self.buffer.replace_glyph(DELETED_GLYPH);
     }
 
+    #[inline(always)]
     pub fn replace_glyph_inplace(&mut self, i: usize, glyph: u32) {
         self.buffer.info[i].glyph_id = glyph;
         if glyph == DELETED_GLYPH {


### PR DESCRIPTION
Noncontextual morx substitution calls `replace_glyph_inplace` for every
replacement. LLVM currently leaves the helper out of line in a fat-LTO
release build, including its buffer accesses and hot conditional paths.

Force-inlining the helper improves the Geeza Pro / Persian Little Prince
workload by about 1.8% in cycles and 1.2% in retired instructions. This PR
contains no lookup caching or custom binary-search implementation.

Tested with:

```
cargo test --workspace
```

All 6,065 shaping tests and the rest of the workspace suite pass.
